### PR TITLE
feat: add quit protection and searchable Quit Asyar command

### DIFF
--- a/src-tauri/built-in-features/quit/manifest.json
+++ b/src-tauri/built-in-features/quit/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "quit",
+  "name": "Quit Asyar",
+  "icon": "icon:power",
+  "version": "1.0.0",
+  "description": "Quit the Asyar application",
+  "type": "result",
+  "searchable": true,
+  "commands": [
+    {
+      "id": "quit-asyar",
+      "name": "Quit Asyar",
+      "icon": "icon:power",
+      "description": "Quit the Asyar application",
+      "resultType": "no-view"
+    }
+  ]
+}

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -70,3 +70,9 @@ pub fn hide(app_handle: AppHandle, state: tauri::State<'_, AppState>) -> Result<
 pub fn set_focus_lock(state: tauri::State<'_, AppState>, locked: bool) {
     state.focus_locked.store(locked, Ordering::Relaxed);
 }
+
+/// Cleanly exits the application.
+#[tauri::command]
+pub fn quit_app(app_handle: AppHandle) {
+    app_handle.exit(0);
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -101,6 +101,7 @@ pub fn run() {
         .setup(setup_app)
         .invoke_handler(tauri::generate_handler![
             commands::set_focus_lock,
+            commands::quit_app,
             commands::list_applications,
             commands::sync_application_index,
             commands::show,
@@ -240,6 +241,9 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     
     #[cfg(target_os = "macos")]
     let panel = crate::platform::macos::setup_spotlight_window(&window, handle)?;
+
+    #[cfg(target_os = "macos")]
+    crate::platform::macos::register_cmdq_monitor(handle.clone());
 
     #[cfg(target_os = "windows")]
     let _ = crate::platform::windows::setup_spotlight_window(&window);

--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -170,6 +170,54 @@ pub fn extract_icon(path: &Path) -> Option<Vec<u8>> {
     None
 }
 
+/// Intercepts CMD+Q when the settings window is focused and hides it instead
+/// of quitting. The menubar "Quit Asyar" click still terminates the app because
+/// it bypasses the key-event path entirely.
+pub fn register_cmdq_monitor(app_handle: AppHandle) {
+    use block2::StackBlock;
+    use objc2::rc::Retained;
+    use objc2::runtime::{AnyClass, AnyObject};
+    use objc2::{msg_send, msg_send_id};
+
+    const KEY_DOWN_MASK: u64 = 1u64 << 10;
+    // kVK_ANSI_Q
+    const VK_Q: u16 = 12;
+    // NSEventModifierFlagCommand
+    const CMD_FLAG: u64 = 1 << 20;
+
+    let app = app_handle.clone();
+
+    let handler = StackBlock::new(move |event: *mut AnyObject| -> *mut AnyObject {
+        let keycode: u16 = unsafe { msg_send![event, keyCode] };
+        let flags: u64 = unsafe { msg_send![event, modifierFlags] };
+
+        if keycode == VK_Q && (flags & CMD_FLAG) != 0 {
+            if let Some(sw) = app.get_webview_window("settings") {
+                if sw.is_visible().unwrap_or(false) && sw.is_focused().unwrap_or(false) {
+                    let _ = sw.hide();
+                    return std::ptr::null_mut(); // swallow the event
+                }
+            }
+        }
+        event // pass through
+    });
+
+    let ns_event_cls = AnyClass::get("NSEvent").expect("NSEvent class not found");
+    let monitor: Option<Retained<AnyObject>> = unsafe {
+        msg_send_id![
+            ns_event_cls,
+            addLocalMonitorForEventsMatchingMask: KEY_DOWN_MASK,
+            handler: &handler
+        ]
+    };
+
+    if let Some(m) = monitor {
+        Box::leak(Box::new(m));
+    } else {
+        log::error!("CMD+Q local event monitor registration failed");
+    }
+}
+
 /// Registers the global NSEvent monitor to detect typed snippets.
 pub fn register_snippet_monitor(app_handle: AppHandle) {
     use block2::StackBlock;

--- a/src/built-in-features/quit/index.ts
+++ b/src/built-in-features/quit/index.ts
@@ -1,0 +1,38 @@
+import type { Extension, ExtensionContext } from 'asyar-sdk';
+import { quitApp, setFocusLock } from '../../lib/ipc/commands';
+import { feedbackService } from '../../services/feedback/feedbackService.svelte';
+
+class QuitExtension implements Extension {
+  onUnload = () => {};
+
+  async initialize(_context: ExtensionContext): Promise<void> {}
+
+  async executeCommand(commandId: string): Promise<any> {
+    if (commandId === 'quit-asyar') {
+      // Lock focus so the launcher doesn't dismiss while the dialog is open
+      await setFocusLock(true);
+      try {
+        const confirmed = await feedbackService.confirmAlert({
+          title: 'Quit Asyar',
+          message: 'Are you sure you want to quit Asyar?',
+          confirmText: 'Quit',
+          cancelText: 'Cancel',
+          variant: 'danger',
+        });
+
+        if (confirmed) {
+          await quitApp();
+        }
+      } finally {
+        await setFocusLock(false);
+      }
+      // User cancelled — return nothing so the launcher stays visible
+      return undefined;
+    }
+  }
+
+  async activate(): Promise<void> {}
+  async deactivate(): Promise<void> {}
+}
+
+export default new QuitExtension();

--- a/src/built-in-features/quit/manifest.json
+++ b/src/built-in-features/quit/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "quit",
+  "name": "Quit Asyar",
+  "icon": "icon:power",
+  "version": "1.0.0",
+  "description": "Quit the Asyar application",
+  "type": "result",
+  "searchable": true,
+  "commands": [
+    {
+      "id": "quit-asyar",
+      "name": "Quit Asyar",
+      "icon": "icon:power",
+      "description": "Quit the Asyar application",
+      "resultType": "no-view"
+    }
+  ]
+}

--- a/src/components/base/ConfirmDialog.svelte
+++ b/src/components/base/ConfirmDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
   import Button from './Button.svelte';
   import { fadeIn, popupScale } from '$lib/transitions';
 
@@ -37,17 +38,30 @@
   }
 
   function handleKeydown(event: KeyboardEvent) {
-    if (event.key === 'Escape' && isOpen) {
+    if (!isOpen) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopImmediatePropagation();
       cancel();
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      confirm();
     }
   }
-</script>
 
-<svelte:window onkeydown={handleKeydown} />
+  // Register in capture phase so this fires before all other keydown handlers
+  onMount(() => {
+    window.addEventListener('keydown', handleKeydown, true);
+  });
+  onDestroy(() => {
+    window.removeEventListener('keydown', handleKeydown, true);
+  });
+</script>
 
 {#if isOpen}
   <div
-    class="fixed inset-0 dialog-backdrop flex items-center justify-center z-50"
+    class="fixed inset-0 dialog-backdrop flex items-center justify-center z-[200]"
     onclick={(e) => e.target === e.currentTarget && cancel()}
     role="button"
     tabindex="0"

--- a/src/lib/ipc/commands.ts
+++ b/src/lib/ipc/commands.ts
@@ -92,6 +92,10 @@ export async function setFocusLock(locked: boolean): Promise<void> {
   return invoke('set_focus_lock', { locked });
 }
 
+export async function quitApp(): Promise<void> {
+  return invoke('quit_app');
+}
+
 export async function showSettingsWindow(): Promise<void> {
   const { WebviewWindow } = await import('@tauri-apps/api/webviewWindow');
   const settingsWindow = await WebviewWindow.getByLabel('settings');

--- a/src/lib/keyboard/launcherKeyboard.test.ts
+++ b/src/lib/keyboard/launcherKeyboard.test.ts
@@ -113,6 +113,14 @@ vi.mock('../../services/log/logService', () => ({
   },
 }));
 
+vi.mock('../../services/feedback/feedbackService.svelte', () => ({
+  feedbackService: {
+    activeDialog: null,
+  },
+}));
+
+import { feedbackService } from '../../services/feedback/feedbackService.svelte';
+
 vi.mock('../../lib/ipc/commands', () => ({
   showSettingsWindow: vi.fn(),
   hideWindow: vi.fn(),
@@ -187,6 +195,7 @@ describe('launcherKeyboard characterization tests', () => {
     searchStores.selectedIndex = -1;
     extensionIframeManager.hasInputFocus = false;
     shortcutStore.isCapturing = false;
+    (feedbackService as any).activeDialog = null;
     vi.mocked(settingsService.getSettings).mockReturnValue({
       general: { 
         startAtLogin: false,
@@ -214,6 +223,65 @@ describe('launcherKeyboard characterization tests', () => {
       expect(event.stopPropagation).toHaveBeenCalled();
       expect(event.preventDefault).toHaveBeenCalled();
       expect(deps.handleEnterKey).not.toHaveBeenCalled();
+    });
+
+    describe('Cmd/Ctrl+Q Block Quit', () => {
+      it('Cmd+Q is blocked', () => {
+        const deps = createMockDeps();
+        const { handleGlobalKeydown } = createKeyboardHandlers(deps);
+        const event = createKeyEvent('q', { metaKey: true });
+
+        handleGlobalKeydown(event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
+      });
+
+      it('Ctrl+Q is blocked', () => {
+        const deps = createMockDeps();
+        const { handleGlobalKeydown } = createKeyboardHandlers(deps);
+        const event = createKeyEvent('q', { ctrlKey: true });
+
+        handleGlobalKeydown(event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
+      });
+
+      it('plain Q is not blocked', () => {
+        const deps = createMockDeps();
+        const { handleGlobalKeydown } = createKeyboardHandlers(deps);
+        const event = createKeyEvent('q');
+
+        handleGlobalKeydown(event);
+
+        expect(event.stopPropagation).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Dialog active guard', () => {
+      it('blocks all keys when a dialog is active', () => {
+        (feedbackService as any).activeDialog = { title: 'Quit' };
+        const deps = createMockDeps();
+        const { handleGlobalKeydown } = createKeyboardHandlers(deps);
+
+        for (const key of ['ArrowDown', 'Tab', 'a', 'Enter']) {
+          const event = createKeyEvent(key);
+          handleGlobalKeydown(event);
+          expect(event.preventDefault).toHaveBeenCalled();
+          expect(event.stopPropagation).toHaveBeenCalled();
+        }
+      });
+
+      it('does not block keys when no dialog is active', () => {
+        const deps = createMockDeps();
+        const { handleGlobalKeydown } = createKeyboardHandlers(deps);
+        const event = createKeyEvent('ArrowDown');
+
+        handleGlobalKeydown(event);
+
+        expect(event.stopPropagation).not.toHaveBeenCalled();
+      });
     });
 
     describe('Tab / Context Hint Commit', () => {

--- a/src/lib/keyboard/launcherKeyboard.ts
+++ b/src/lib/keyboard/launcherKeyboard.ts
@@ -10,6 +10,7 @@ import { settingsService } from '../../services/settings/settingsService.svelte'
 import { isBuiltInFeature } from '../../services/extension/extensionDiscovery';
 import type { ActiveContext, ContextHint } from '../../services/context/contextModeService.svelte';
 import { logService } from '../../services/log/logService';
+import { feedbackService } from '../../services/feedback/feedbackService.svelte';
 
 
 export interface KeyboardDeps {
@@ -88,6 +89,14 @@ export function createKeyboardHandlers(deps: KeyboardDeps) {
     return true;
   }
 
+  // Cmd/Ctrl+Q: block quit — users quit via the "Quit Asyar" command
+  function tryBlockQuit(event: KeyboardEvent): boolean {
+    if (!((event.key === 'q' || event.key === 'Q') && (event.metaKey || event.ctrlKey))) return false;
+    event.preventDefault();
+    event.stopPropagation();
+    return true;
+  }
+
   // Cmd/Ctrl+,: open settings
   function tryOpenSettings(event: KeyboardEvent): boolean {
     if (!(event.key === ',' && (event.metaKey || event.ctrlKey))) return false;
@@ -162,6 +171,12 @@ export function createKeyboardHandlers(deps: KeyboardDeps) {
       event.preventDefault();
       return;
     }
+    if (feedbackService.activeDialog) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    if (tryBlockQuit(event)) return;
     if (tryCommitContextHint(event)) return;
     if (tryExitContextMode(event)) return;
     if (tryOpenSettings(event)) return;
@@ -172,7 +187,7 @@ export function createKeyboardHandlers(deps: KeyboardDeps) {
 
   // Maintain focus function
   function maintainSearchFocus(e: MouseEvent) {
-     if (shortcutStore.isCapturing) return;
+     if (shortcutStore.isCapturing || feedbackService.activeDialog) return;
 
      const target = e.target as HTMLElement;
 
@@ -295,7 +310,7 @@ export function createKeyboardHandlers(deps: KeyboardDeps) {
   }
 
   function handleKeydown(event: KeyboardEvent) {
-    if (shortcutStore.isCapturing) return;
+    if (shortcutStore.isCapturing || feedbackService.activeDialog) return;
     if (event.defaultPrevented) return;
     if (tryHandleEscape(event)) return;
     if (tryHandleBackspaceInView(event)) return;

--- a/src/lib/launcher/launcherController.svelte.ts
+++ b/src/lib/launcher/launcherController.svelte.ts
@@ -89,8 +89,8 @@ export class LauncherController {
 
     if (selectedItem.action && typeof selectedItem.action === 'function') {
       try {
-        await selectedItem.action();
-        if (selectedItem.type === 'command') {
+        const result = await selectedItem.action();
+        if (selectedItem.type === 'command' && result !== undefined) {
           this.state.localSearchValue = '';
           searchStores.query = '';
         }

--- a/src/lib/searchResultMapper.test.ts
+++ b/src/lib/searchResultMapper.test.ts
@@ -28,7 +28,6 @@ vi.mock('../services/application/applicationsService', () => ({
 
 import { resolveItemMeta, buildMappedItems } from './searchResultMapper'
 import type { SearchResult } from '../services/search/interfaces/SearchResult'
-import extensionManager from '../services/extension/extensionManager.svelte'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/src/lib/searchResultMapper.test.ts
+++ b/src/lib/searchResultMapper.test.ts
@@ -14,9 +14,11 @@ vi.mock('../services/extension/extensionManager.svelte', () => ({
   __esModule: true,
   default: {
     getManifestById: vi.fn(),
-    handleCommandAction: vi.fn(),
+    handleCommandAction: vi.fn().mockResolvedValue(undefined),
   },
 }))
+
+import extensionManager from '../services/extension/extensionManager.svelte'
 
 vi.mock('../services/application/applicationsService', () => ({
   applicationService: {
@@ -189,5 +191,55 @@ describe('buildMappedItems preserves calculator fields', () => {
     })
 
     expect(mappedItems[0].style).toBeUndefined()
+  })
+})
+
+// ── buildMappedItems: command action return value propagation ────────────────
+
+describe('buildMappedItems command action returns result', () => {
+  it('propagates the return value from handleCommandAction', async () => {
+    vi.mocked(extensionManager.handleCommandAction).mockResolvedValueOnce({ type: 'no-view' })
+
+    const cmdResult = makeResult({
+      objectId: 'cmd_quit_quit-asyar',
+      name: 'Quit Asyar',
+      type: 'command',
+      score: 1.0,
+    })
+
+    const { mappedItems } = buildMappedItems({
+      searchItems: [cmdResult],
+      activeContext: null,
+      shortcutStore: [],
+      localSearchValue: 'quit',
+      selectedIndex: 0,
+      onError: vi.fn(),
+    })
+
+    const result = await mappedItems[0].action()
+    expect(result).toEqual({ type: 'no-view' })
+  })
+
+  it('returns undefined when command returns undefined (e.g. cancelled)', async () => {
+    vi.mocked(extensionManager.handleCommandAction).mockResolvedValueOnce(undefined)
+
+    const cmdResult = makeResult({
+      objectId: 'cmd_quit_quit-asyar',
+      name: 'Quit Asyar',
+      type: 'command',
+      score: 1.0,
+    })
+
+    const { mappedItems } = buildMappedItems({
+      searchItems: [cmdResult],
+      activeContext: null,
+      shortcutStore: [],
+      localSearchValue: 'quit',
+      selectedIndex: 0,
+      onError: vi.fn(),
+    })
+
+    const result = await mappedItems[0].action()
+    expect(result).toBeUndefined()
   })
 })

--- a/src/lib/searchResultMapper.test.ts
+++ b/src/lib/searchResultMapper.test.ts
@@ -241,6 +241,9 @@ describe('buildMappedItems command action returns result', () => {
 
     const result = await mappedItems[0].action()
     expect(result).toBeUndefined()
+  })
+})
+
 // ── buildMappedItems: portal command captures activeContext.query ─────────────
 
 function makePortalContext(query: string) {

--- a/src/lib/searchResultMapper.ts
+++ b/src/lib/searchResultMapper.ts
@@ -151,7 +151,7 @@ export function buildMappedItems({
       actionFunction = async () => {
         logService.debug(`[searchResultMapper] Executing command: ${commandObjectId}`);
         try {
-          await extensionManager.handleCommandAction(commandObjectId, { query: capturedQuery });
+          return await extensionManager.handleCommandAction(commandObjectId, { query: capturedQuery });
         } catch (err) {
           logService.error(`extensionManager.handleCommandAction failed: ${err}`);
           onError(`Failed to run command ${name}`);

--- a/src/services/extension/extensionManager.svelte.ts
+++ b/src/services/extension/extensionManager.svelte.ts
@@ -278,6 +278,7 @@ export class ExtensionManager implements IExtensionManager {
       logService.error(
         `Error handling command action for ${commandObjectId}: ${error}`
       );
+      throw error;
     }
   }
 

--- a/src/services/extension/extensionManager.svelte.ts
+++ b/src/services/extension/extensionManager.svelte.ts
@@ -240,7 +240,7 @@ export class ExtensionManager implements IExtensionManager {
     }
   }
 
-  public async handleCommandAction(commandObjectId: string, args?: Record<string, any>): Promise<void> {
+  public async handleCommandAction(commandObjectId: string, args?: Record<string, any>): Promise<any> {
     logService.debug(`Handling command action for: ${commandObjectId}`);
     try {
       // Handle browser fallback IDs for seamless navigation
@@ -273,6 +273,7 @@ export class ExtensionManager implements IExtensionManager {
           );
       }
       // --- End usage recording ---
+      return result;
     } catch (error) {
       logService.error(
         `Error handling command action for ${commandObjectId}: ${error}`

--- a/src/services/extension/extensionManager.test.ts
+++ b/src/services/extension/extensionManager.test.ts
@@ -338,6 +338,18 @@ describe('ExtensionManager Characterization Tests', () => {
       vi.mocked(commandService.executeCommand).mockRejectedValueOnce(new Error('Execute failed'))
       await expect(extensionManager.handleCommandAction('test_cmd')).resolves.not.toThrow()
     })
+
+    it('returns the result from executeCommand', async () => {
+      vi.mocked(commandService.executeCommand).mockResolvedValueOnce({ type: 'no-view' })
+      const result = await extensionManager.handleCommandAction('test_cmd')
+      expect(result).toEqual({ type: 'no-view' })
+    })
+
+    it('returns undefined when executeCommand returns undefined', async () => {
+      vi.mocked(commandService.executeCommand).mockResolvedValueOnce(undefined)
+      const result = await extensionManager.handleCommandAction('test_cmd')
+      expect(result).toBeUndefined()
+    })
   })
 
   describe('searchAll()', () => {

--- a/src/services/extension/extensionManager.test.ts
+++ b/src/services/extension/extensionManager.test.ts
@@ -334,9 +334,9 @@ describe('ExtensionManager Characterization Tests', () => {
       expect(spy).toHaveBeenCalledWith('clipboard-history/DefaultView')
     })
 
-    it('does not throw on executeCommand failure', async () => {
+    it('throws on executeCommand failure', async () => {
       vi.mocked(commandService.executeCommand).mockRejectedValueOnce(new Error('Execute failed'))
-      await expect(extensionManager.handleCommandAction('test_cmd')).resolves.not.toThrow()
+      await expect(extensionManager.handleCommandAction('test_cmd')).rejects.toThrow('Execute failed')
     })
 
     it('returns the result from executeCommand', async () => {


### PR DESCRIPTION
## Summary

Raycast behaves like this:
when in launcher view, cmd+q is blocked
when in settings view, cmd+q just closes the window (doesn't quit app)
there's a 'quit raycast' item, when used it presents a confirmation dialogue

All of this is to protect against accidental quitting. Idiologically, I believe this was done to make it feel more like a permanently available system utility, rather than an app the user needs to think about.

I have mirrored this behaviour. It could be argued that Raycast got this wrong, in which case I'd suggest using the confirmation dialogue I've added in the 'quit asyar' item.

Additionally, Raycast shows a native system menu when the settings screen is invoked, Asyar does not. I have separated out the native macos menu 'quit' from the cmd+q handling in case you were wanting to show the menu at some point. If not, the native "quit" could be re-routed to closing the window and avoid the extra monitoring.

The new 'quit asyar' item requires Xoshbin/asyar-sdk#42 to be approved which has the 'power' icon

The new confirm quit dialogue preserves launcher entry state, so if dismissed the user carries on where they left off (same as raycast), it receives enter to confirm, or esc to cancel.

## Dependencies

- Requires Xoshbin/asyar-sdk#42 (`power` icon)

## Test plan
- [ ] CMD+Q on launcher does nothing
- [ ] CMD+Q on settings window hides it (menubar Quit still quits)
- [ ] Search "Quit" → select "Quit Asyar" → confirm dialog appears
- [ ] Cancel dismisses dialog, launcher stays visible with search text preserved
- [ ] Confirm quits the app
- [ ] Arrow keys, Tab, etc. do not interact with launcher while dialog is open
- [ ] Enter/Escape work correctly in the dialog
- [ ] `pnpm vitest run src/lib/keyboard/launcherKeyboard.test.ts` passes
- [ ] `pnpm vitest run src/services/extension/extensionManager.test.ts` passes
- [ ] `pnpm vitest run src/lib/searchResultMapper.test.ts` passes