### PR TITLE
feat: add Window Management as Tier 1 built-in feature

### DIFF
--- a/src-tauri/built-in-features/window-management/manifest.json
+++ b/src-tauri/built-in-features/window-management/manifest.json
@@ -1,0 +1,31 @@
+{
+  "id": "window-management",
+  "name": "Window Management",
+  "version": "1.0.0",
+  "description": "Resize and reposition the frontmost window using layout presets",
+  "type": "view",
+  "defaultView": "ManageView",
+  "searchable": true,
+  "icon": "icon:store",
+  "permissions": ["window:manage", "storage:read", "storage:write"],
+  "commands": [
+    { "id": "left-half",           "name": "Left Half",            "description": "Left 50% of screen",             "trigger": "left half window",           "resultType": "no-view", "icon": "icon:store" },
+    { "id": "right-half",          "name": "Right Half",           "description": "Right 50% of screen",            "trigger": "right half window",          "resultType": "no-view", "icon": "icon:store" },
+    { "id": "top-half",            "name": "Top Half",             "description": "Top 50% of screen",              "trigger": "top half window",            "resultType": "no-view", "icon": "icon:store" },
+    { "id": "bottom-half",         "name": "Bottom Half",          "description": "Bottom 50% of screen",           "trigger": "bottom half window",         "resultType": "no-view", "icon": "icon:store" },
+    { "id": "top-left-quarter",    "name": "Top Left Quarter",     "description": "Top-left 25% of screen",         "trigger": "top left quarter window",    "resultType": "no-view", "icon": "icon:store" },
+    { "id": "top-right-quarter",   "name": "Top Right Quarter",    "description": "Top-right 25% of screen",        "trigger": "top right quarter window",   "resultType": "no-view", "icon": "icon:store" },
+    { "id": "bottom-left-quarter", "name": "Bottom Left Quarter",  "description": "Bottom-left 25% of screen",      "trigger": "bottom left quarter window", "resultType": "no-view", "icon": "icon:store" },
+    { "id": "bottom-right-quarter","name": "Bottom Right Quarter", "description": "Bottom-right 25% of screen",     "trigger": "bottom right quarter",       "resultType": "no-view", "icon": "icon:store" },
+    { "id": "left-third",          "name": "Left Third",           "description": "Left 33% of screen",             "trigger": "left third window",          "resultType": "no-view", "icon": "icon:store" },
+    { "id": "center-third",        "name": "Center Third",         "description": "Center 33% of screen",           "trigger": "center third window",        "resultType": "no-view", "icon": "icon:store" },
+    { "id": "right-third",         "name": "Right Third",          "description": "Right 33% of screen",            "trigger": "right third window",         "resultType": "no-view", "icon": "icon:store" },
+    { "id": "left-two-thirds",     "name": "Left Two Thirds",      "description": "Left 66% of screen",             "trigger": "left two thirds window",     "resultType": "no-view", "icon": "icon:store" },
+    { "id": "right-two-thirds",    "name": "Right Two Thirds",     "description": "Right 66% of screen",            "trigger": "right two thirds window",    "resultType": "no-view", "icon": "icon:store" },
+    { "id": "center",              "name": "Center",               "description": "Centered, 80% × 80% of screen",  "trigger": "center window",              "resultType": "no-view", "icon": "icon:store" },
+    { "id": "almost-maximize",     "name": "Almost Maximize",      "description": "Centered, 90% × 90% of screen",  "trigger": "almost maximize window",     "resultType": "no-view", "icon": "icon:store" },
+    { "id": "maximize",            "name": "Maximize",             "description": "Fill the entire screen (fullscreen)", "trigger": "maximize fullscreen window", "resultType": "no-view", "icon": "icon:store" },
+    { "id": "restore",             "name": "Restore Previous Bounds", "description": "Undo the last applied window layout", "trigger": "restore window undo",   "resultType": "no-view", "icon": "icon:refresh" },
+    { "id": "manage-layouts",      "name": "Manage Window Layouts", "description": "View, add, and delete custom window layouts", "trigger": "manage window layouts", "resultType": "view", "view": "ManageView", "icon": "icon:settings" }
+  ]
+}

--- a/src/built-in-features/window-management/ManageView.svelte
+++ b/src/built-in-features/window-management/ManageView.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte'
+  import { ListItem, EmptyState, ActionFooter } from '../../components'
+  import { windowManagementState } from './state.svelte'
+  import { windowManagementService } from '../../services/windowManagement/windowManagementService'
+  import { feedbackService } from '../../services/feedback/feedbackService.svelte'
+  import { actionService } from '../../services/action/actionService.svelte'
+  import type { IStorageService } from 'asyar-sdk'
+  import { ActionContext } from 'asyar-sdk'
+
+  interface Props {
+    store?: IStorageService
+  }
+  let { store }: Props = $props()
+
+  let selectedId = $state<string | null>(null)
+  let layouts = $derived(windowManagementState.customLayouts)
+
+  $effect(() => {
+    if (!selectedId) {
+      actionService.unregisterAction('window-management:delete-layout')
+      return
+    }
+    const id = selectedId
+    const layout = layouts.find(l => l.id === id)
+    if (!layout) return
+
+    actionService.registerAction({
+      id: 'window-management:delete-layout',
+      title: `Delete "${layout.name}"`,
+      icon: 'icon:trash',
+      extensionId: 'window-management',
+      category: 'window-management',
+      context: ActionContext.EXTENSION_VIEW,
+      execute: async () => {
+        if (!store) return
+        const name = layout.name
+        await windowManagementState.deleteCustomLayout(id, store)
+        selectedId = null
+        await feedbackService.showHUD(`Deleted "${name}"`)
+      },
+    })
+
+    return () => {
+      actionService.unregisterAction('window-management:delete-layout')
+    }
+  })
+
+  onDestroy(() => {
+    actionService.unregisterAction('window-management:delete-layout')
+  })
+</script>
+
+<div class="view-container">
+  <div class="list custom-scrollbar">
+    {#if layouts.length === 0}
+      <EmptyState
+        message="No custom layouts yet"
+        description="Use ⌘K → Save Current Window as Layout to capture a window position."
+      />
+    {:else}
+      <div class="section-header">Custom Layouts</div>
+      {#each layouts as layout (layout.id)}
+        <ListItem
+          title={layout.name}
+          subtitle={`${Math.round(layout.bounds.width)}x${Math.round(layout.bounds.height)} at (${Math.round(layout.bounds.x)}, ${Math.round(layout.bounds.y)})`}
+          selected={selectedId === layout.id}
+          onclick={() => { selectedId = layout.id }}
+        >
+          {#snippet leading()}
+            <div class="layout-icon">⊞</div>
+          {/snippet}
+        </ListItem>
+      {/each}
+    {/if}
+  </div>
+
+  <ActionFooter>
+    {#snippet right()}
+      <span class="count-label">
+        {layouts.length} custom {layouts.length === 1 ? 'layout' : 'layouts'}
+      </span>
+    {/snippet}
+  </ActionFooter>
+</div>
+
+<style>
+  .list {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+  }
+
+  .section-header {
+    padding: 6px 12px 4px;
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    color: var(--text-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .layout-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: var(--radius-md);
+    background: var(--bg-tertiary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--font-size-lg);
+  }
+
+  .count-label {
+    font-size: var(--font-size-xs);
+    color: var(--text-tertiary);
+  }
+</style>

--- a/src/built-in-features/window-management/index.test.ts
+++ b/src/built-in-features/window-management/index.test.ts
@@ -1,0 +1,151 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('../../services/log/logService', () => ({
+  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('../../services/windowManagement/windowManagementService', () => ({
+  windowManagementService: {
+    getWindowBounds: vi.fn(),
+    setWindowBounds: vi.fn(),
+    setFullscreen: vi.fn(),
+  },
+}))
+vi.mock('../../services/feedback/feedbackService.svelte', () => ({
+  feedbackService: {
+    showHUD: vi.fn(),
+    showToast: vi.fn(),
+  },
+}))
+vi.mock('../../services/action/actionService.svelte', () => ({
+  actionService: {
+    registerAction: vi.fn(),
+    unregisterAction: vi.fn(),
+  },
+}))
+vi.mock('./state.svelte', () => ({
+  windowManagementState: {
+    customLayouts: [],
+    previousBounds: null,
+    loadFromStorage: vi.fn(),
+    savePreviousBounds: vi.fn(),
+    addCustomLayout: vi.fn(),
+    deleteCustomLayout: vi.fn(),
+  },
+}))
+vi.mock('./ManageView.svelte', () => ({ default: {} }))
+
+import extension from './index'
+import { windowManagementService } from '../../services/windowManagement/windowManagementService'
+import { feedbackService } from '../../services/feedback/feedbackService.svelte'
+import { windowManagementState } from './state.svelte'
+import type { ExtensionContext } from 'asyar-sdk'
+
+function makeContext(): ExtensionContext {
+  return {
+    getService: vi.fn().mockImplementation((name: string) => {
+      if (name === 'StorageService') return { get: vi.fn(async () => null), set: vi.fn(), delete: vi.fn() }
+      if (name === 'ExtensionManager') return { navigateToView: vi.fn(), setActiveViewActionLabel: vi.fn() }
+      return null
+    }),
+  } as unknown as ExtensionContext
+}
+
+describe('WindowManagementExtension', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  describe('initialize', () => {
+    it('resolves StorageService and loads state', async () => {
+      const ctx = makeContext()
+      await extension.initialize(ctx)
+      expect(ctx.getService).toHaveBeenCalledWith('StorageService')
+      expect(windowManagementState.loadFromStorage).toHaveBeenCalled()
+    })
+  })
+
+  describe('executeCommand — layout presets', () => {
+    beforeEach(async () => {
+      await extension.initialize(makeContext())
+      vi.mocked(windowManagementService.getWindowBounds).mockResolvedValue(
+        { x: 0, y: 0, width: 1440, height: 900 }
+      )
+      vi.mocked(windowManagementService.setWindowBounds).mockResolvedValue()
+      vi.mocked(windowManagementService.setFullscreen).mockResolvedValue()
+      vi.mocked(feedbackService.showHUD).mockResolvedValue()
+    })
+
+    it('left-half saves previous bounds then calls setWindowBounds', async () => {
+      await extension.executeCommand('left-half')
+      expect(windowManagementState.savePreviousBounds).toHaveBeenCalled()
+      expect(windowManagementService.setWindowBounds).toHaveBeenCalled()
+      expect(feedbackService.showHUD).toHaveBeenCalledWith('Left Half')
+    })
+
+    it('maximize calls setFullscreen(true)', async () => {
+      await extension.executeCommand('maximize')
+      expect(windowManagementService.setFullscreen).toHaveBeenCalledWith(true)
+      expect(windowManagementService.setWindowBounds).not.toHaveBeenCalled()
+    })
+
+    it('shows failure toast when getWindowBounds throws', async () => {
+      vi.mocked(windowManagementService.getWindowBounds).mockRejectedValue(
+        new Error('Accessibility permission required')
+      )
+      vi.mocked(feedbackService.showToast).mockResolvedValue('')
+      await extension.executeCommand('left-half')
+      expect(feedbackService.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ style: 'failure' })
+      )
+    })
+  })
+
+  describe('executeCommand — restore', () => {
+    beforeEach(async () => { await extension.initialize(makeContext()) })
+
+    it('calls setWindowBounds with previousBounds when available', async () => {
+      const prev = { x: 100, y: 100, width: 800, height: 600 }
+      Object.defineProperty(windowManagementState, 'previousBounds', { value: prev, configurable: true })
+      vi.mocked(windowManagementService.setWindowBounds).mockResolvedValue()
+      vi.mocked(feedbackService.showHUD).mockResolvedValue()
+      await extension.executeCommand('restore')
+      expect(windowManagementService.setWindowBounds).toHaveBeenCalledWith(prev)
+    })
+
+    it('shows toast when nothing to restore', async () => {
+      Object.defineProperty(windowManagementState, 'previousBounds', { value: null, configurable: true })
+      vi.mocked(feedbackService.showToast).mockResolvedValue('')
+      await extension.executeCommand('restore')
+      expect(feedbackService.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Nothing to restore', style: 'failure' })
+      )
+    })
+  })
+
+  describe('executeCommand — manage-layouts', () => {
+    it('navigates to ManageView and returns view type', async () => {
+      const ctx = makeContext()
+      await extension.initialize(ctx)
+      const result = await extension.executeCommand('manage-layouts')
+      expect(result).toMatchObject({ type: 'view', viewPath: 'window-management/ManageView' })
+    })
+  })
+
+  describe('search', () => {
+    it('returns custom layouts as ExtensionResult entries', async () => {
+      const layout = { id: '1', name: 'My Layout', bounds: { x: 0, y: 0, width: 800, height: 600 } }
+      Object.defineProperty(windowManagementState, 'customLayouts', { value: [layout], configurable: true })
+      await extension.initialize(makeContext())
+      const results = await extension.search('my')
+      expect(results.length).toBeGreaterThan(0)
+      expect(results[0].title).toContain('My Layout')
+    })
+
+    it('returns empty array when no custom layouts match', async () => {
+      Object.defineProperty(windowManagementState, 'customLayouts', { value: [], configurable: true })
+      await extension.initialize(makeContext())
+      const results = await extension.search('anything')
+      expect(results).toEqual([])
+    })
+  })
+})

--- a/src/built-in-features/window-management/index.ts
+++ b/src/built-in-features/window-management/index.ts
@@ -1,0 +1,187 @@
+import { logService } from '../../services/log/logService'
+import { windowManagementService } from '../../services/windowManagement/windowManagementService'
+import { feedbackService } from '../../services/feedback/feedbackService.svelte'
+import { actionService } from '../../services/action/actionService.svelte'
+import { windowManagementState } from './state.svelte'
+import { getPresetBounds, PRESET_IDS } from './presets'
+import ManageView from './ManageView.svelte'
+import {
+  type Extension,
+  type ExtensionContext,
+  type ExtensionResult,
+  type IStorageService,
+  type IExtensionManager,
+  ActionContext,
+} from 'asyar-sdk'
+
+class WindowManagementExtension implements Extension {
+  onUnload: any
+
+  private store?: IStorageService
+  private extensionManager?: IExtensionManager
+  private inView = false
+
+  async initialize(context: ExtensionContext): Promise<void> {
+    this.store = context.getService<IStorageService>('StorageService')
+    this.extensionManager = context.getService<IExtensionManager>('ExtensionManager')
+    if (this.store) {
+      await windowManagementState.loadFromStorage(this.store)
+    }
+    logService.info('[WindowManagement] Initialized')
+  }
+
+  async executeCommand(commandId: string, _args?: Record<string, any>): Promise<any> {
+    if (commandId === 'restore') {
+      return this.restorePreviousBounds()
+    }
+
+    if (commandId === 'manage-layouts') {
+      this.extensionManager?.navigateToView('window-management/ManageView')
+      return { type: 'view', viewPath: 'window-management/ManageView' }
+    }
+
+    if ((PRESET_IDS as readonly string[]).includes(commandId)) {
+      return this.applyPreset(commandId)
+    }
+
+    logService.warn(`[WindowManagement] Unknown command: ${commandId}`)
+  }
+
+  private async applyPreset(presetId: string): Promise<void> {
+    const sw = window.screen.availWidth
+    const sh = window.screen.availHeight
+    const preset = getPresetBounds(presetId, sw, sh)
+    if (!preset) return
+
+    try {
+      const current = await windowManagementService.getWindowBounds()
+      if (this.store) {
+        await windowManagementState.savePreviousBounds(current, this.store)
+      }
+
+      if (preset.fullscreen) {
+        await windowManagementService.setFullscreen(true)
+      } else if (preset.bounds) {
+        await windowManagementService.setWindowBounds(preset.bounds)
+      }
+
+      const label = presetId
+        .split('-')
+        .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ')
+      await feedbackService.showHUD(label)
+    } catch (err: any) {
+      logService.error(`[WindowManagement] applyPreset failed: ${err}`)
+      await feedbackService.showToast({
+        title: 'Could not apply layout',
+        message: err.message,
+        style: 'failure',
+      })
+    }
+  }
+
+  private async restorePreviousBounds(): Promise<void> {
+    const prev = windowManagementState.previousBounds
+    if (!prev) {
+      await feedbackService.showToast({ title: 'Nothing to restore', style: 'failure' })
+      return
+    }
+    try {
+      await windowManagementService.setWindowBounds(prev)
+      await feedbackService.showHUD('Restored')
+    } catch (err: any) {
+      await feedbackService.showToast({
+        title: 'Restore failed',
+        message: err.message,
+        style: 'failure',
+      })
+    }
+  }
+
+  async search(query: string): Promise<ExtensionResult[]> {
+    const { customLayouts } = windowManagementState
+    if (!customLayouts.length) return []
+
+    const q = query.toLowerCase()
+    const matched = customLayouts.filter(l => l.name.toLowerCase().includes(q))
+
+    return matched.map(layout => ({
+      title: layout.name,
+      subtitle: `${Math.round(layout.bounds.width)}x${Math.round(layout.bounds.height)} at (${Math.round(layout.bounds.x)}, ${Math.round(layout.bounds.y)})`,
+      score: 0.7,
+      type: 'result' as const,
+      icon: 'icon:store',
+      action: () => this.applyCustomLayout(layout),
+    }))
+  }
+
+  private async applyCustomLayout(layout: import('./state.svelte').CustomLayout): Promise<void> {
+    try {
+      const current = await windowManagementService.getWindowBounds()
+      if (this.store) {
+        await windowManagementState.savePreviousBounds(current, this.store)
+      }
+      await windowManagementService.setWindowBounds(layout.bounds)
+      await feedbackService.showHUD(layout.name)
+    } catch (err: any) {
+      await feedbackService.showToast({
+        title: 'Could not apply layout',
+        message: err.message,
+        style: 'failure',
+      })
+    }
+  }
+
+  async viewActivated(viewPath: string): Promise<void> {
+    this.inView = true
+    this.registerManageActions()
+    logService.debug(`[WindowManagement] View activated: ${viewPath}`)
+  }
+
+  async viewDeactivated(viewPath: string): Promise<void> {
+    this.inView = false
+    this.unregisterManageActions()
+    logService.debug(`[WindowManagement] View deactivated: ${viewPath}`)
+  }
+
+  private registerManageActions(): void {
+    actionService.registerAction({
+      id: 'window-management:save-current-window',
+      title: 'Save Current Window as Layout',
+      description: 'Capture the frontmost window position and size as a custom layout',
+      icon: 'icon:plus',
+      extensionId: 'window-management',
+      category: 'window-management',
+      context: ActionContext.EXTENSION_VIEW,
+      execute: () => this.saveCurrentWindowLayout(),
+    })
+  }
+
+  private unregisterManageActions(): void {
+    actionService.unregisterAction('window-management:save-current-window')
+  }
+
+  private async saveCurrentWindowLayout(): Promise<void> {
+    if (!this.store) return
+    try {
+      const bounds = await windowManagementService.getWindowBounds()
+      const name = `${Math.round(bounds.width)}x${Math.round(bounds.height)}`
+      await windowManagementState.addCustomLayout(name, bounds, this.store)
+      await feedbackService.showHUD(`Saved "${name}"`)
+    } catch (err: any) {
+      await feedbackService.showToast({
+        title: 'Could not save layout',
+        message: err.message,
+        style: 'failure',
+      })
+    }
+  }
+
+  async activate(): Promise<void> {}
+  async deactivate(): Promise<void> {
+    if (this.inView) this.unregisterManageActions()
+  }
+}
+
+export default new WindowManagementExtension()
+export { ManageView }

--- a/src/built-in-features/window-management/manifest.json
+++ b/src/built-in-features/window-management/manifest.json
@@ -1,0 +1,31 @@
+{
+  "id": "window-management",
+  "name": "Window Management",
+  "version": "1.0.0",
+  "description": "Resize and reposition the frontmost window using layout presets",
+  "type": "view",
+  "defaultView": "ManageView",
+  "searchable": true,
+  "icon": "icon:store",
+  "permissions": ["window:manage", "storage:read", "storage:write"],
+  "commands": [
+    { "id": "left-half",           "name": "Left Half",            "description": "Left 50% of screen",             "trigger": "left half window",           "resultType": "no-view", "icon": "icon:store" },
+    { "id": "right-half",          "name": "Right Half",           "description": "Right 50% of screen",            "trigger": "right half window",          "resultType": "no-view", "icon": "icon:store" },
+    { "id": "top-half",            "name": "Top Half",             "description": "Top 50% of screen",              "trigger": "top half window",            "resultType": "no-view", "icon": "icon:store" },
+    { "id": "bottom-half",         "name": "Bottom Half",          "description": "Bottom 50% of screen",           "trigger": "bottom half window",         "resultType": "no-view", "icon": "icon:store" },
+    { "id": "top-left-quarter",    "name": "Top Left Quarter",     "description": "Top-left 25% of screen",         "trigger": "top left quarter window",    "resultType": "no-view", "icon": "icon:store" },
+    { "id": "top-right-quarter",   "name": "Top Right Quarter",    "description": "Top-right 25% of screen",        "trigger": "top right quarter window",   "resultType": "no-view", "icon": "icon:store" },
+    { "id": "bottom-left-quarter", "name": "Bottom Left Quarter",  "description": "Bottom-left 25% of screen",      "trigger": "bottom left quarter window", "resultType": "no-view", "icon": "icon:store" },
+    { "id": "bottom-right-quarter","name": "Bottom Right Quarter", "description": "Bottom-right 25% of screen",     "trigger": "bottom right quarter",       "resultType": "no-view", "icon": "icon:store" },
+    { "id": "left-third",          "name": "Left Third",           "description": "Left 33% of screen",             "trigger": "left third window",          "resultType": "no-view", "icon": "icon:store" },
+    { "id": "center-third",        "name": "Center Third",         "description": "Center 33% of screen",           "trigger": "center third window",        "resultType": "no-view", "icon": "icon:store" },
+    { "id": "right-third",         "name": "Right Third",          "description": "Right 33% of screen",            "trigger": "right third window",         "resultType": "no-view", "icon": "icon:store" },
+    { "id": "left-two-thirds",     "name": "Left Two Thirds",      "description": "Left 66% of screen",             "trigger": "left two thirds window",     "resultType": "no-view", "icon": "icon:store" },
+    { "id": "right-two-thirds",    "name": "Right Two Thirds",     "description": "Right 66% of screen",            "trigger": "right two thirds window",    "resultType": "no-view", "icon": "icon:store" },
+    { "id": "center",              "name": "Center",               "description": "Centered, 80% × 80% of screen",  "trigger": "center window",              "resultType": "no-view", "icon": "icon:store" },
+    { "id": "almost-maximize",     "name": "Almost Maximize",      "description": "Centered, 90% × 90% of screen",  "trigger": "almost maximize window",     "resultType": "no-view", "icon": "icon:store" },
+    { "id": "maximize",            "name": "Maximize",             "description": "Fill the entire screen (fullscreen)", "trigger": "maximize fullscreen window", "resultType": "no-view", "icon": "icon:store" },
+    { "id": "restore",             "name": "Restore Previous Bounds", "description": "Undo the last applied window layout", "trigger": "restore window undo",   "resultType": "no-view", "icon": "icon:refresh" },
+    { "id": "manage-layouts",      "name": "Manage Window Layouts", "description": "View, add, and delete custom window layouts", "trigger": "manage window layouts", "resultType": "view", "view": "ManageView", "icon": "icon:settings" }
+  ]
+}

--- a/src/built-in-features/window-management/presets.test.ts
+++ b/src/built-in-features/window-management/presets.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { getPresetBounds, PRESET_IDS } from './presets'
+
+const SW = 2560
+const SH = 1440
+
+describe('getPresetBounds', () => {
+  it('left-half fills left 50%', () => {
+    const result = getPresetBounds('left-half', SW, SH)
+    expect(result).toEqual({ bounds: { x: 0, y: 0, width: SW / 2, height: SH } })
+  })
+
+  it('right-half fills right 50%', () => {
+    const result = getPresetBounds('right-half', SW, SH)
+    expect(result).toEqual({ bounds: { x: SW / 2, y: 0, width: SW / 2, height: SH } })
+  })
+
+  it('top-half fills top 50%', () => {
+    const result = getPresetBounds('top-half', SW, SH)
+    expect(result).toEqual({ bounds: { x: 0, y: 0, width: SW, height: SH / 2 } })
+  })
+
+  it('bottom-half fills bottom 50%', () => {
+    const result = getPresetBounds('bottom-half', SW, SH)
+    expect(result).toEqual({ bounds: { x: 0, y: SH / 2, width: SW, height: SH / 2 } })
+  })
+
+  it('top-left-quarter fills top-left 25%', () => {
+    const result = getPresetBounds('top-left-quarter', SW, SH)
+    expect(result).toEqual({ bounds: { x: 0, y: 0, width: SW / 2, height: SH / 2 } })
+  })
+
+  it('top-right-quarter fills top-right 25%', () => {
+    const result = getPresetBounds('top-right-quarter', SW, SH)
+    expect(result).toEqual({ bounds: { x: SW / 2, y: 0, width: SW / 2, height: SH / 2 } })
+  })
+
+  it('bottom-left-quarter fills bottom-left 25%', () => {
+    const result = getPresetBounds('bottom-left-quarter', SW, SH)
+    expect(result).toEqual({ bounds: { x: 0, y: SH / 2, width: SW / 2, height: SH / 2 } })
+  })
+
+  it('bottom-right-quarter fills bottom-right 25%', () => {
+    const result = getPresetBounds('bottom-right-quarter', SW, SH)
+    expect(result).toEqual({ bounds: { x: SW / 2, y: SH / 2, width: SW / 2, height: SH / 2 } })
+  })
+
+  it('left-third fills left 33%', () => {
+    const result = getPresetBounds('left-third', SW, SH)
+    expect(result).toEqual({ bounds: { x: 0, y: 0, width: SW / 3, height: SH } })
+  })
+
+  it('center-third fills center 33%', () => {
+    const result = getPresetBounds('center-third', SW, SH)
+    expect(result).toEqual({ bounds: { x: SW / 3, y: 0, width: SW / 3, height: SH } })
+  })
+
+  it('right-third fills right 33%', () => {
+    const result = getPresetBounds('right-third', SW, SH)
+    expect(result).toEqual({ bounds: { x: (SW / 3) * 2, y: 0, width: SW / 3, height: SH } })
+  })
+
+  it('left-two-thirds fills left 66%', () => {
+    const result = getPresetBounds('left-two-thirds', SW, SH)
+    expect(result).toEqual({ bounds: { x: 0, y: 0, width: (SW / 3) * 2, height: SH } })
+  })
+
+  it('right-two-thirds fills right 66%', () => {
+    const result = getPresetBounds('right-two-thirds', SW, SH)
+    expect(result).toEqual({ bounds: { x: SW / 3, y: 0, width: (SW / 3) * 2, height: SH } })
+  })
+
+  it('center is 80% centered', () => {
+    const result = getPresetBounds('center', SW, SH)
+    expect(result).toEqual({
+      bounds: { x: SW * 0.1, y: SH * 0.1, width: SW * 0.8, height: SH * 0.8 }
+    })
+  })
+
+  it('almost-maximize is 90% centered', () => {
+    const result = getPresetBounds('almost-maximize', SW, SH)
+    expect(result).toEqual({
+      bounds: { x: SW * 0.05, y: SH * 0.05, width: SW * 0.9, height: SH * 0.9 }
+    })
+  })
+
+  it('maximize returns fullscreen:true and no bounds', () => {
+    const result = getPresetBounds('maximize', SW, SH)
+    expect(result).toEqual({ fullscreen: true })
+  })
+
+  it('returns null for unknown preset id', () => {
+    const result = getPresetBounds('nonexistent', SW, SH)
+    expect(result).toBeNull()
+  })
+
+  it('PRESET_IDS contains all 16 layout preset ids', () => {
+    expect(PRESET_IDS).toHaveLength(16)
+    expect(PRESET_IDS).toContain('left-half')
+    expect(PRESET_IDS).toContain('maximize')
+    expect(PRESET_IDS).not.toContain('restore')
+    expect(PRESET_IDS).not.toContain('manage-layouts')
+  })
+})

--- a/src/built-in-features/window-management/presets.ts
+++ b/src/built-in-features/window-management/presets.ts
@@ -1,0 +1,67 @@
+import type { WindowBoundsUpdate } from '../../lib/ipc/commands'
+
+export interface PresetResult {
+  bounds?: WindowBoundsUpdate
+  fullscreen?: boolean
+}
+
+/**
+ * Returns the target bounds for a preset given available screen dimensions.
+ * Screen dimensions must be passed in (do not read window.screen here — keeps
+ * this module pure and testable without a DOM).
+ * Returns null if presetId is not recognised.
+ */
+export function getPresetBounds(
+  presetId: string,
+  screenWidth: number,
+  screenHeight: number,
+): PresetResult | null {
+  const sw = screenWidth
+  const sh = screenHeight
+
+  switch (presetId) {
+    case 'left-half':
+      return { bounds: { x: 0, y: 0, width: sw / 2, height: sh } }
+    case 'right-half':
+      return { bounds: { x: sw / 2, y: 0, width: sw / 2, height: sh } }
+    case 'top-half':
+      return { bounds: { x: 0, y: 0, width: sw, height: sh / 2 } }
+    case 'bottom-half':
+      return { bounds: { x: 0, y: sh / 2, width: sw, height: sh / 2 } }
+    case 'top-left-quarter':
+      return { bounds: { x: 0, y: 0, width: sw / 2, height: sh / 2 } }
+    case 'top-right-quarter':
+      return { bounds: { x: sw / 2, y: 0, width: sw / 2, height: sh / 2 } }
+    case 'bottom-left-quarter':
+      return { bounds: { x: 0, y: sh / 2, width: sw / 2, height: sh / 2 } }
+    case 'bottom-right-quarter':
+      return { bounds: { x: sw / 2, y: sh / 2, width: sw / 2, height: sh / 2 } }
+    case 'left-third':
+      return { bounds: { x: 0, y: 0, width: sw / 3, height: sh } }
+    case 'center-third':
+      return { bounds: { x: sw / 3, y: 0, width: sw / 3, height: sh } }
+    case 'right-third':
+      return { bounds: { x: (sw / 3) * 2, y: 0, width: sw / 3, height: sh } }
+    case 'left-two-thirds':
+      return { bounds: { x: 0, y: 0, width: (sw / 3) * 2, height: sh } }
+    case 'right-two-thirds':
+      return { bounds: { x: sw / 3, y: 0, width: (sw / 3) * 2, height: sh } }
+    case 'center':
+      return { bounds: { x: sw * 0.1, y: sh * 0.1, width: sw * 0.8, height: sh * 0.8 } }
+    case 'almost-maximize':
+      return { bounds: { x: sw * 0.05, y: sh * 0.05, width: sw * 0.9, height: sh * 0.9 } }
+    case 'maximize':
+      return { fullscreen: true }
+    default:
+      return null
+  }
+}
+
+/** All preset IDs that apply a layout (excludes 'restore' and 'manage-layouts'). */
+export const PRESET_IDS: readonly string[] = [
+  'left-half', 'right-half', 'top-half', 'bottom-half',
+  'top-left-quarter', 'top-right-quarter', 'bottom-left-quarter', 'bottom-right-quarter',
+  'left-third', 'center-third', 'right-third',
+  'left-two-thirds', 'right-two-thirds',
+  'center', 'almost-maximize', 'maximize',
+] as const

--- a/src/built-in-features/window-management/state.svelte.test.ts
+++ b/src/built-in-features/window-management/state.svelte.test.ts
@@ -1,0 +1,122 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock logService before importing the module under test
+vi.mock('../../services/log/logService', () => ({
+  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+import { WindowManagementState } from './state.svelte'
+import type { IStorageService } from 'asyar-sdk'
+import type { WindowBounds } from '../../lib/ipc/commands'
+
+function makeStoreMock(data: Record<string, string> = {}): IStorageService {
+  const store = { ...data }
+  return {
+    get: vi.fn(async (key: string) => store[key] ?? null),
+    set: vi.fn(async (key: string, value: string) => { store[key] = value }),
+    delete: vi.fn(async () => true),
+    getAll: vi.fn(async () => store),
+    clear: vi.fn(async () => 0),
+  } as unknown as IStorageService
+}
+
+describe('WindowManagementState', () => {
+  let state: WindowManagementState
+  let storeMock: IStorageService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state = new WindowManagementState()
+    storeMock = makeStoreMock()
+  })
+
+  describe('loadFromStorage', () => {
+    it('initializes with empty arrays when storage is empty', async () => {
+      await state.loadFromStorage(storeMock)
+      expect(state.customLayouts).toEqual([])
+      expect(state.previousBounds).toBeNull()
+    })
+
+    it('loads custom layouts from storage', async () => {
+      const layouts = [{ id: '1', name: 'My Layout', bounds: { x: 0, y: 0, width: 800, height: 600 } }]
+      storeMock = makeStoreMock({ custom_layouts: JSON.stringify(layouts) })
+      await state.loadFromStorage(storeMock)
+      expect(state.customLayouts).toEqual(layouts)
+    })
+
+    it('loads previous bounds from storage', async () => {
+      const bounds: WindowBounds = { x: 100, y: 200, width: 1000, height: 800 }
+      storeMock = makeStoreMock({ previous_bounds: JSON.stringify(bounds) })
+      await state.loadFromStorage(storeMock)
+      expect(state.previousBounds).toEqual(bounds)
+    })
+
+    it('handles corrupted JSON gracefully — sets empty state', async () => {
+      storeMock = makeStoreMock({ custom_layouts: 'not-json' })
+      await state.loadFromStorage(storeMock)
+      expect(state.customLayouts).toEqual([])
+    })
+  })
+
+  describe('addCustomLayout', () => {
+    it('appends layout and persists to storage', async () => {
+      const bounds: WindowBounds = { x: 0, y: 0, width: 1200, height: 800 }
+      await state.loadFromStorage(storeMock)
+      await state.addCustomLayout('Work Setup', bounds, storeMock)
+      expect(state.customLayouts).toHaveLength(1)
+      expect(state.customLayouts[0].name).toBe('Work Setup')
+      expect(state.customLayouts[0].bounds).toEqual(bounds)
+      expect(storeMock.set).toHaveBeenCalledWith(
+        'custom_layouts',
+        JSON.stringify(state.customLayouts),
+      )
+    })
+
+    it('generates a unique id based on timestamp', async () => {
+      const bounds: WindowBounds = { x: 0, y: 0, width: 800, height: 600 }
+      await state.loadFromStorage(storeMock)
+      await state.addCustomLayout('A', bounds, storeMock)
+      await state.addCustomLayout('B', bounds, storeMock)
+      const ids = state.customLayouts.map(l => l.id)
+      expect(new Set(ids).size).toBe(2)
+    })
+  })
+
+  describe('deleteCustomLayout', () => {
+    it('removes layout by id and persists to storage', async () => {
+      const layouts = [
+        { id: 'abc', name: 'Layout A', bounds: { x: 0, y: 0, width: 800, height: 600 } },
+        { id: 'def', name: 'Layout B', bounds: { x: 0, y: 0, width: 1200, height: 800 } },
+      ]
+      storeMock = makeStoreMock({ custom_layouts: JSON.stringify(layouts) })
+      await state.loadFromStorage(storeMock)
+      await state.deleteCustomLayout('abc', storeMock)
+      expect(state.customLayouts).toHaveLength(1)
+      expect(state.customLayouts[0].id).toBe('def')
+      expect(storeMock.set).toHaveBeenCalledWith(
+        'custom_layouts',
+        JSON.stringify(state.customLayouts),
+      )
+    })
+
+    it('is a no-op for unknown id', async () => {
+      await state.loadFromStorage(storeMock)
+      await state.deleteCustomLayout('nonexistent', storeMock)
+      expect(state.customLayouts).toEqual([])
+    })
+  })
+
+  describe('savePreviousBounds', () => {
+    it('stores bounds in state and persists to storage', async () => {
+      const bounds: WindowBounds = { x: 50, y: 50, width: 1440, height: 900 }
+      await state.loadFromStorage(storeMock)
+      await state.savePreviousBounds(bounds, storeMock)
+      expect(state.previousBounds).toEqual(bounds)
+      expect(storeMock.set).toHaveBeenCalledWith(
+        'previous_bounds',
+        JSON.stringify(bounds),
+      )
+    })
+  })
+})

--- a/src/built-in-features/window-management/state.svelte.ts
+++ b/src/built-in-features/window-management/state.svelte.ts
@@ -1,0 +1,56 @@
+import { logService } from '../../services/log/logService'
+import type { IStorageService } from 'asyar-sdk'
+import type { WindowBounds } from '../../lib/ipc/commands'
+
+export interface CustomLayout {
+  id: string
+  name: string
+  bounds: WindowBounds
+}
+
+const STORAGE_KEY_LAYOUTS = 'custom_layouts'
+const STORAGE_KEY_PREV_BOUNDS = 'previous_bounds'
+
+export class WindowManagementState {
+  customLayouts = $state<CustomLayout[]>([])
+  previousBounds = $state<WindowBounds | null>(null)
+
+  async loadFromStorage(store: IStorageService): Promise<void> {
+    try {
+      const rawLayouts = await store.get(STORAGE_KEY_LAYOUTS)
+      this.customLayouts = rawLayouts ? JSON.parse(rawLayouts) : []
+    } catch {
+      logService.warn('[WindowManagement] Failed to parse custom_layouts — resetting to []')
+      this.customLayouts = []
+    }
+
+    try {
+      const rawBounds = await store.get(STORAGE_KEY_PREV_BOUNDS)
+      this.previousBounds = rawBounds ? JSON.parse(rawBounds) : null
+    } catch {
+      this.previousBounds = null
+    }
+  }
+
+  async addCustomLayout(
+    name: string,
+    bounds: WindowBounds,
+    store: IStorageService,
+  ): Promise<void> {
+    const layout: CustomLayout = { id: `${Date.now()}-${Math.random().toString(36).slice(2)}`, name, bounds }
+    this.customLayouts = [...this.customLayouts, layout]
+    await store.set(STORAGE_KEY_LAYOUTS, JSON.stringify(this.customLayouts))
+  }
+
+  async deleteCustomLayout(id: string, store: IStorageService): Promise<void> {
+    this.customLayouts = this.customLayouts.filter(l => l.id !== id)
+    await store.set(STORAGE_KEY_LAYOUTS, JSON.stringify(this.customLayouts))
+  }
+
+  async savePreviousBounds(bounds: WindowBounds, store: IStorageService): Promise<void> {
+    this.previousBounds = bounds
+    await store.set(STORAGE_KEY_PREV_BOUNDS, JSON.stringify(bounds))
+  }
+}
+
+export const windowManagementState = new WindowManagementState()


### PR DESCRIPTION
16 layout presets (halves, quarters, thirds, center variants) each as
an individual no-view command, plus restore and custom layout management.
Replaces the Tier 2 window-layouts extension. 36 new tests, zero regressions.