### PR TITLE
feat: add deeplink extension triggering (open-by-default)

### DIFF
--- a/docs/reference/deeplink-triggering.md
+++ b/docs/reference/deeplink-triggering.md
@@ -1,0 +1,243 @@
+---
+order: 8
+---
+# Deeplink Triggering
+
+**No permission or manifest flag required.** Every command in an enabled extension is automatically reachable via deep links.
+
+Any external source — browser, terminal, automation tool, another app — can invoke an extension command by opening an `asyar://extensions/{extensionId}/{commandId}` URL. The only requirement is that the extension is installed and enabled.
+
+---
+
+## Quick start
+
+Trigger a command from a terminal:
+
+```bash
+open "asyar://extensions/com.example.currency/convert?from=USD&to=EUR&amount=100"
+```
+
+Generate a deeplink from inside your extension:
+
+```typescript
+const url = context.createDeeplink('convert', { from: 'USD', to: 'EUR', amount: '100' });
+// → "asyar://extensions/com.example.currency/convert?from=USD&to=EUR&amount=100"
+```
+
+---
+
+## URL format
+
+```
+asyar://extensions/{extensionId}/{commandId}?key=value&key2=value2
+```
+
+| Segment | Description |
+|---|---|
+| `extensionId` | The extension's `id` as declared in `manifest.json`. |
+| `commandId` | The command's `id` as declared in `manifest.json`. |
+| Query params | Passed to `executeCommand` as `args`. All values are strings. URL-encoding is handled automatically. |
+
+### Character constraints
+
+- `extensionId` — alphanumeric characters, dots, hyphens, and underscores only (e.g. `com.example.my-ext`).
+- `commandId` — alphanumeric characters, hyphens, and underscores only.
+- URLs that fail these rules are silently dropped in Rust before reaching the frontend.
+
+---
+
+## Receiving deeplink calls
+
+When a deeplink fires, Asyar calls your extension's `executeCommand` method:
+
+```typescript
+class MyCurrencyExtension implements Extension {
+  async executeCommand(commandId: string, args?: Record<string, any>): Promise<any> {
+    if (commandId === 'convert') {
+      const isDeeplink = args?.deeplinkTrigger === true;
+      const from   = args?.from   ?? 'USD';
+      const to     = args?.to     ?? 'EUR';
+      const amount = Number(args?.amount ?? 1);
+      await this.convert(from, to, amount);
+    }
+  }
+}
+```
+
+The `args` object includes `{ deeplinkTrigger: true }` alongside any query params, so you can distinguish a deeplink invocation from a manual user selection if needed.
+
+### Args are always strings
+
+All query parameter values arrive as strings. Parse them explicitly:
+
+```typescript
+const amount = Number(args?.amount);   // "100" → 100
+const enabled = args?.enabled === 'true';  // "true" → true
+```
+
+---
+
+## `context.createDeeplink()` — SDK utility
+
+Extensions can generate deeplink URLs for their own commands using `createDeeplink()` on the `ExtensionContext`:
+
+```typescript
+createDeeplink(commandId: string, args?: Record<string, string>): string
+```
+
+This is a pure string utility — no IPC, no async, no permissions. Use it to embed deeplinks in:
+
+- Notification bodies
+- Clipboard output (e.g. "copied link to clipboard")
+- Generated documents or Markdown
+- Inter-app communication
+
+```typescript
+class TaskManager implements Extension {
+  private context!: ExtensionContext;
+
+  async initialize(context: ExtensionContext): Promise<void> {
+    this.context = context;
+  }
+
+  async createTask(title: string): Promise<void> {
+    const taskId = await this.saveTask(title);
+    const link = this.context.createDeeplink('open-task', { id: taskId });
+    // link = "asyar://extensions/com.example.tasks/open-task?id=abc123"
+
+    await this.context.proxies.NotificationService.notify({
+      title: 'Task created',
+      body: `Click to open: ${link}`,
+    });
+  }
+}
+```
+
+---
+
+## Window behavior
+
+| Command `resultType` | Window behavior |
+|---|---|
+| `"no-view"` | Launcher stays hidden. Command executes silently in the background. |
+| `"view"` | Launcher opens and navigates to the extension's view. |
+
+For `"view"` type extensions (manifest `type: "view"`), the window always opens regardless of the command's `resultType`.
+
+---
+
+## Required preferences
+
+Deeplink invocations bypass the required-preferences prompt — there is no user present to fill in a form. If your command has `required: true` preferences that are unset, the command will still execute and receive `undefined` for those preference values. Design your handler to handle missing preferences gracefully, or guide users to configure the extension first via Settings → Extensions.
+
+---
+
+## Use case examples
+
+### Browser → Asyar ("Save this page")
+
+A bookmarklet or browser extension passes the current page URL:
+
+```javascript
+window.open(`asyar://extensions/com.example.bookmarks/save?url=${encodeURIComponent(location.href)}&title=${encodeURIComponent(document.title)}`);
+```
+
+### Terminal shortcut
+
+A shell alias triggers a command silently:
+
+```bash
+alias weather='open "asyar://extensions/com.example.weather/check?city=Berlin"'
+```
+
+### macOS Shortcuts / Automations
+
+A Shortcuts workflow opens an `asyar://` URL as its action. Any extension command becomes a callable automation step — no app scripting or AppleScript required.
+
+### Webhook → local action
+
+A local webhook receiver (e.g. a small HTTP server) opens a deeplink in response to an external event:
+
+```python
+import subprocess
+subprocess.run(["open", "asyar://extensions/com.example.deploy/notify?env=staging&status=success"])
+```
+
+### Sharing runnable commands
+
+Share a deeplink in a team doc or Slack message. Anyone with the extension installed can click it to run the command:
+
+```
+Run our staging health check: asyar://extensions/com.example.devtools/health-check?env=staging
+```
+
+### Extension-generated links
+
+An extension creates a deeplink and copies it to the clipboard for the user to share:
+
+```typescript
+const link = context.createDeeplink('view-report', { date: '2025-01-15' });
+await navigator.clipboard.writeText(link);
+```
+
+---
+
+## Validation and error handling
+
+All validation happens before `executeCommand` is called. Invalid deep links are silently dropped with a log entry — they never reach your extension code.
+
+| Condition | Behavior |
+|---|---|
+| Malformed URL or invalid characters | Dropped in Rust. Logged as warning. |
+| Extension not installed | Dropped in TS. Logged as error. |
+| Extension disabled | Dropped in TS. Logged as error. |
+| Command not found in manifest | Dropped in TS. Logged as error. |
+| Command handler throws | Error logged. Usage not recorded. |
+
+---
+
+## How it works under the hood
+
+```
+External source opens asyar://extensions/com.example.ext/cmd?arg=val
+
+Rust (tauri-plugin-deep-link)         TS host                    Extension (iframe)
+───────────────────────────────────────────────────────────────────────────────────
+on_open_url fires
+URL starts with "asyar://extensions/"
+  → parse_extension_deeplink()
+    validates extensionId + commandId
+    collects query params
+  → emit "asyar:deeplink:extension"
+    { extensionId, commandId, args }
+                                      DeeplinkService listens
+                                      handleExtensionDeeplink():
+                                        guard: extension exists?
+                                        guard: extension enabled?
+                                        guard: command in manifest?
+                                        guard: command registered?
+                                        if view: showWindow() + navigateToView()
+                                        commandService.executeCommand(
+                                          "cmd_{extensionId}_{commandId}",
+                                          { ...args, deeplinkTrigger: true }
+                                        )
+                                        ──────────────────────────────────────►
+                                        for Tier 2 (iframe) extensions:
+                                          postMessage to iframe:
+                                          { type: 'asyar:command:execute',
+                                            payload: { commandId, args } }
+                                                                           ExtensionBridge
+                                                                           calls extension
+                                                                           .executeCommand()
+                                        recordItemUsage(objectId)
+```
+
+The URL is parsed entirely in Rust (`src-tauri/src/deeplink.rs`). The TS `DeeplinkService` (`src/services/deeplink/deeplinkService.svelte.ts`) owns all validation and dispatch logic. Neither layer requires a new Tauri command — Rust only emits an event, and TS listens.
+
+---
+
+## Interaction with the compatibility system
+
+Deeplinks only execute for extensions whose compatibility status is `Compatible`. If an extension is incompatible (wrong SDK version, wrong app version, wrong platform), its commands cannot be triggered via deeplink.
+
+---

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -49,6 +49,8 @@ order: 1
 | `schedule` | `{ intervalSeconds: number }` | ❌ | Declares a recurring background timer. The command is called every `intervalSeconds` seconds. Requires `resultType: "no-view"`. Range: 60–86400 seconds. See [Background scheduling](./background-scheduling.md). |
 | `preferences` | `PreferenceDeclaration[]` | ❌ | Command-scoped preferences (as opposed to the extension-level ones on the root). At runtime, a command sees the union of extension-level and command-level preferences, with command-level shadowing extension-level on name collision. Reached via `context.preferences.commands[commandId][name]`. See [Preferences reference](./sdk/preferences.md). |
 
+> **Deeplink triggering:** Every command in an enabled extension is automatically reachable via `asyar://extensions/{id}/{commandId}?args` URLs. No manifest declaration needed. See [Deeplink triggering](./deeplink-triggering.md).
+
 ### Complete manifest example
 
 ```json

--- a/src-tauri/.svelte-kit/ambient.d.ts
+++ b/src-tauri/.svelte-kit/ambient.d.ts
@@ -1,0 +1,310 @@
+
+// this file is generated — do not edit it
+
+
+/// <reference types="@sveltejs/kit" />
+
+/**
+ * This module provides access to environment variables that are injected _statically_ into your bundle at build time and are limited to _private_ access.
+ * 
+ * |         | Runtime                                                                    | Build time                                                               |
+ * | ------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+ * | Private | [`$env/dynamic/private`](https://svelte.dev/docs/kit/$env-dynamic-private) | [`$env/static/private`](https://svelte.dev/docs/kit/$env-static-private) |
+ * | Public  | [`$env/dynamic/public`](https://svelte.dev/docs/kit/$env-dynamic-public)   | [`$env/static/public`](https://svelte.dev/docs/kit/$env-static-public)   |
+ * 
+ * Static environment variables are [loaded by Vite](https://vitejs.dev/guide/env-and-mode.html#env-files) from `.env` files and `process.env` at build time and then statically injected into your bundle at build time, enabling optimisations like dead code elimination.
+ * 
+ * **_Private_ access:**
+ * 
+ * - This module cannot be imported into client-side code
+ * - This module only includes variables that _do not_ begin with [`config.kit.env.publicPrefix`](https://svelte.dev/docs/kit/configuration#env) _and do_ start with [`config.kit.env.privatePrefix`](https://svelte.dev/docs/kit/configuration#env) (if configured)
+ * 
+ * For example, given the following build time environment:
+ * 
+ * ```env
+ * ENVIRONMENT=production
+ * PUBLIC_BASE_URL=http://site.com
+ * ```
+ * 
+ * With the default `publicPrefix` and `privatePrefix`:
+ * 
+ * ```ts
+ * import { ENVIRONMENT, PUBLIC_BASE_URL } from '$env/static/private';
+ * 
+ * console.log(ENVIRONMENT); // => "production"
+ * console.log(PUBLIC_BASE_URL); // => throws error during build
+ * ```
+ * 
+ * The above values will be the same _even if_ different values for `ENVIRONMENT` or `PUBLIC_BASE_URL` are set at runtime, as they are statically replaced in your code with their build time values.
+ */
+declare module '$env/static/private' {
+	export const NoDefaultCurrentDirectoryInExePath: string;
+	export const CLAUDE_CODE_ENTRYPOINT: string;
+	export const VSCODE_CRASH_REPORTER_PROCESS_TYPE: string;
+	export const NVM_CD_FLAGS: string;
+	export const SHELL: string;
+	export const TMPDIR: string;
+	export const APPLE_ID: string;
+	export const CLAUDE_AGENT_SDK_VERSION: string;
+	export const MallocNanoZone: string;
+	export const ZSH: string;
+	export const GIT_EDITOR: string;
+	export const APPLE_PASSWORD: string;
+	export const USER: string;
+	export const NVM_DIR: string;
+	export const LS_COLORS: string;
+	export const COMMAND_MODE: string;
+	export const SSH_AUTH_SOCK: string;
+	export const __CF_USER_TEXT_ENCODING: string;
+	export const HERD_PHP_82_INI_SCAN_DIR: string;
+	export const VIRTUAL_ENV: string;
+	export const PAGER: string;
+	export const ELECTRON_RUN_AS_NODE: string;
+	export const npm_config_verify_deps_before_run: string;
+	export const LSCOLORS: string;
+	export const APPLE_TEAM_ID: string;
+	export const PATH: string;
+	export const HERD_PHP_84_INI_SCAN_DIR: string;
+	export const __CFBundleIdentifier: string;
+	export const npm_command: string;
+	export const PWD: string;
+	export const VSCODE_HANDLES_UNCAUGHT_ERRORS: string;
+	export const OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: string;
+	export const VSCODE_ESM_ENTRYPOINT: string;
+	export const P9K_SSH: string;
+	export const LANG: string;
+	export const CODE_ASSIST_ENDPOINT: string;
+	export const NODE_PATH: string;
+	export const XPC_FLAGS: string;
+	export const pnpm_config_verify_deps_before_run: string;
+	export const XPC_SERVICE_NAME: string;
+	export const CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING: string;
+	export const SHLVL: string;
+	export const HOME: string;
+	export const CLAUDE_CODE_EXECPATH: string;
+	export const VSCODE_NLS_CONFIG: string;
+	export const LOGNAME: string;
+	export const LESS: string;
+	export const VSCODE_IPC_HOOK: string;
+	export const VSCODE_CODE_CACHE_PATH: string;
+	export const COREPACK_ENABLE_AUTO_PIN: string;
+	export const npm_config_user_agent: string;
+	export const VSCODE_PID: string;
+	export const OSLogRateLimit: string;
+	export const CLAUDECODE: string;
+	export const VSCODE_L10N_BUNDLE_LOCATION: string;
+	export const VSCODE_CWD: string;
+	export const TEST: string;
+	export const VITEST: string;
+	export const NODE_ENV: string;
+	export const PROD: string;
+	export const DEV: string;
+	export const BASE_URL: string;
+	export const MODE: string;
+}
+
+/**
+ * This module provides access to environment variables that are injected _statically_ into your bundle at build time and are _publicly_ accessible.
+ * 
+ * |         | Runtime                                                                    | Build time                                                               |
+ * | ------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+ * | Private | [`$env/dynamic/private`](https://svelte.dev/docs/kit/$env-dynamic-private) | [`$env/static/private`](https://svelte.dev/docs/kit/$env-static-private) |
+ * | Public  | [`$env/dynamic/public`](https://svelte.dev/docs/kit/$env-dynamic-public)   | [`$env/static/public`](https://svelte.dev/docs/kit/$env-static-public)   |
+ * 
+ * Static environment variables are [loaded by Vite](https://vitejs.dev/guide/env-and-mode.html#env-files) from `.env` files and `process.env` at build time and then statically injected into your bundle at build time, enabling optimisations like dead code elimination.
+ * 
+ * **_Public_ access:**
+ * 
+ * - This module _can_ be imported into client-side code
+ * - **Only** variables that begin with [`config.kit.env.publicPrefix`](https://svelte.dev/docs/kit/configuration#env) (which defaults to `PUBLIC_`) are included
+ * 
+ * For example, given the following build time environment:
+ * 
+ * ```env
+ * ENVIRONMENT=production
+ * PUBLIC_BASE_URL=http://site.com
+ * ```
+ * 
+ * With the default `publicPrefix` and `privatePrefix`:
+ * 
+ * ```ts
+ * import { ENVIRONMENT, PUBLIC_BASE_URL } from '$env/static/public';
+ * 
+ * console.log(ENVIRONMENT); // => throws error during build
+ * console.log(PUBLIC_BASE_URL); // => "http://site.com"
+ * ```
+ * 
+ * The above values will be the same _even if_ different values for `ENVIRONMENT` or `PUBLIC_BASE_URL` are set at runtime, as they are statically replaced in your code with their build time values.
+ */
+declare module '$env/static/public' {
+	
+}
+
+/**
+ * This module provides access to environment variables set _dynamically_ at runtime and that are limited to _private_ access.
+ * 
+ * |         | Runtime                                                                    | Build time                                                               |
+ * | ------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+ * | Private | [`$env/dynamic/private`](https://svelte.dev/docs/kit/$env-dynamic-private) | [`$env/static/private`](https://svelte.dev/docs/kit/$env-static-private) |
+ * | Public  | [`$env/dynamic/public`](https://svelte.dev/docs/kit/$env-dynamic-public)   | [`$env/static/public`](https://svelte.dev/docs/kit/$env-static-public)   |
+ * 
+ * Dynamic environment variables are defined by the platform you're running on. For example if you're using [`adapter-node`](https://github.com/sveltejs/kit/tree/main/packages/adapter-node) (or running [`vite preview`](https://svelte.dev/docs/kit/cli)), this is equivalent to `process.env`.
+ * 
+ * **_Private_ access:**
+ * 
+ * - This module cannot be imported into client-side code
+ * - This module includes variables that _do not_ begin with [`config.kit.env.publicPrefix`](https://svelte.dev/docs/kit/configuration#env) _and do_ start with [`config.kit.env.privatePrefix`](https://svelte.dev/docs/kit/configuration#env) (if configured)
+ * 
+ * > [!NOTE] In `dev`, `$env/dynamic` includes environment variables from `.env`. In `prod`, this behavior will depend on your adapter.
+ * 
+ * > [!NOTE] To get correct types, environment variables referenced in your code should be declared (for example in an `.env` file), even if they don't have a value until the app is deployed:
+ * >
+ * > ```env
+ * > MY_FEATURE_FLAG=
+ * > ```
+ * >
+ * > You can override `.env` values from the command line like so:
+ * >
+ * > ```sh
+ * > MY_FEATURE_FLAG="enabled" npm run dev
+ * > ```
+ * 
+ * For example, given the following runtime environment:
+ * 
+ * ```env
+ * ENVIRONMENT=production
+ * PUBLIC_BASE_URL=http://site.com
+ * ```
+ * 
+ * With the default `publicPrefix` and `privatePrefix`:
+ * 
+ * ```ts
+ * import { env } from '$env/dynamic/private';
+ * 
+ * console.log(env.ENVIRONMENT); // => "production"
+ * console.log(env.PUBLIC_BASE_URL); // => undefined
+ * ```
+ */
+declare module '$env/dynamic/private' {
+	export const env: {
+		NoDefaultCurrentDirectoryInExePath: string;
+		CLAUDE_CODE_ENTRYPOINT: string;
+		VSCODE_CRASH_REPORTER_PROCESS_TYPE: string;
+		NVM_CD_FLAGS: string;
+		SHELL: string;
+		TMPDIR: string;
+		APPLE_ID: string;
+		CLAUDE_AGENT_SDK_VERSION: string;
+		MallocNanoZone: string;
+		ZSH: string;
+		GIT_EDITOR: string;
+		APPLE_PASSWORD: string;
+		USER: string;
+		NVM_DIR: string;
+		LS_COLORS: string;
+		COMMAND_MODE: string;
+		SSH_AUTH_SOCK: string;
+		__CF_USER_TEXT_ENCODING: string;
+		HERD_PHP_82_INI_SCAN_DIR: string;
+		VIRTUAL_ENV: string;
+		PAGER: string;
+		ELECTRON_RUN_AS_NODE: string;
+		npm_config_verify_deps_before_run: string;
+		LSCOLORS: string;
+		APPLE_TEAM_ID: string;
+		PATH: string;
+		HERD_PHP_84_INI_SCAN_DIR: string;
+		__CFBundleIdentifier: string;
+		npm_command: string;
+		PWD: string;
+		VSCODE_HANDLES_UNCAUGHT_ERRORS: string;
+		OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: string;
+		VSCODE_ESM_ENTRYPOINT: string;
+		P9K_SSH: string;
+		LANG: string;
+		CODE_ASSIST_ENDPOINT: string;
+		NODE_PATH: string;
+		XPC_FLAGS: string;
+		pnpm_config_verify_deps_before_run: string;
+		XPC_SERVICE_NAME: string;
+		CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING: string;
+		SHLVL: string;
+		HOME: string;
+		CLAUDE_CODE_EXECPATH: string;
+		VSCODE_NLS_CONFIG: string;
+		LOGNAME: string;
+		LESS: string;
+		VSCODE_IPC_HOOK: string;
+		VSCODE_CODE_CACHE_PATH: string;
+		COREPACK_ENABLE_AUTO_PIN: string;
+		npm_config_user_agent: string;
+		VSCODE_PID: string;
+		OSLogRateLimit: string;
+		CLAUDECODE: string;
+		VSCODE_L10N_BUNDLE_LOCATION: string;
+		VSCODE_CWD: string;
+		TEST: string;
+		VITEST: string;
+		NODE_ENV: string;
+		PROD: string;
+		DEV: string;
+		BASE_URL: string;
+		MODE: string;
+		[key: `PUBLIC_${string}`]: undefined;
+		[key: `${string}`]: string | undefined;
+	}
+}
+
+/**
+ * This module provides access to environment variables set _dynamically_ at runtime and that are _publicly_ accessible.
+ * 
+ * |         | Runtime                                                                    | Build time                                                               |
+ * | ------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+ * | Private | [`$env/dynamic/private`](https://svelte.dev/docs/kit/$env-dynamic-private) | [`$env/static/private`](https://svelte.dev/docs/kit/$env-static-private) |
+ * | Public  | [`$env/dynamic/public`](https://svelte.dev/docs/kit/$env-dynamic-public)   | [`$env/static/public`](https://svelte.dev/docs/kit/$env-static-public)   |
+ * 
+ * Dynamic environment variables are defined by the platform you're running on. For example if you're using [`adapter-node`](https://github.com/sveltejs/kit/tree/main/packages/adapter-node) (or running [`vite preview`](https://svelte.dev/docs/kit/cli)), this is equivalent to `process.env`.
+ * 
+ * **_Public_ access:**
+ * 
+ * - This module _can_ be imported into client-side code
+ * - **Only** variables that begin with [`config.kit.env.publicPrefix`](https://svelte.dev/docs/kit/configuration#env) (which defaults to `PUBLIC_`) are included
+ * 
+ * > [!NOTE] In `dev`, `$env/dynamic` includes environment variables from `.env`. In `prod`, this behavior will depend on your adapter.
+ * 
+ * > [!NOTE] To get correct types, environment variables referenced in your code should be declared (for example in an `.env` file), even if they don't have a value until the app is deployed:
+ * >
+ * > ```env
+ * > MY_FEATURE_FLAG=
+ * > ```
+ * >
+ * > You can override `.env` values from the command line like so:
+ * >
+ * > ```sh
+ * > MY_FEATURE_FLAG="enabled" npm run dev
+ * > ```
+ * 
+ * For example, given the following runtime environment:
+ * 
+ * ```env
+ * ENVIRONMENT=production
+ * PUBLIC_BASE_URL=http://example.com
+ * ```
+ * 
+ * With the default `publicPrefix` and `privatePrefix`:
+ * 
+ * ```ts
+ * import { env } from '$env/dynamic/public';
+ * console.log(env.ENVIRONMENT); // => undefined, not public
+ * console.log(env.PUBLIC_BASE_URL); // => "http://example.com"
+ * ```
+ * 
+ * ```
+ * 
+ * ```
+ */
+declare module '$env/dynamic/public' {
+	export const env: {
+		[key: `PUBLIC_${string}`]: string | undefined;
+	}
+}

--- a/src-tauri/.svelte-kit/generated/client/app.js
+++ b/src-tauri/.svelte-kit/generated/client/app.js
@@ -1,0 +1,28 @@
+export { matchers } from './matchers.js';
+
+export const nodes = [
+	() => import('./nodes/0'),
+	() => import('./nodes/1')
+];
+
+export const server_loads = [];
+
+export const dictionary = {
+		
+	};
+
+export const hooks = {
+	handleError: (({ error }) => { console.error(error) }),
+	
+	reroute: (() => {}),
+	transport: {}
+};
+
+export const decoders = Object.fromEntries(Object.entries(hooks.transport).map(([k, v]) => [k, v.decode]));
+export const encoders = Object.fromEntries(Object.entries(hooks.transport).map(([k, v]) => [k, v.encode]));
+
+export const hash = false;
+
+export const decode = (type, value) => decoders[type](value);
+
+export { default as root } from '../root.js';

--- a/src-tauri/.svelte-kit/generated/client/matchers.js
+++ b/src-tauri/.svelte-kit/generated/client/matchers.js
@@ -1,0 +1,1 @@
+export const matchers = {};

--- a/src-tauri/.svelte-kit/generated/client/nodes/0.js
+++ b/src-tauri/.svelte-kit/generated/client/nodes/0.js
@@ -1,0 +1,1 @@
+export { default as component } from "../../../../../../node_modules/.pnpm/@sveltejs+kit@2.55.0_@sveltejs+vite-plugin-svelte@5.1.1_svelte@5.54.1_vite@6.2.2_@types_ce20823bfecf677d5057023026cadbbd/node_modules/@sveltejs/kit/src/runtime/components/svelte-5/layout.svelte";

--- a/src-tauri/.svelte-kit/generated/client/nodes/1.js
+++ b/src-tauri/.svelte-kit/generated/client/nodes/1.js
@@ -1,0 +1,1 @@
+export { default as component } from "../../../../../../node_modules/.pnpm/@sveltejs+kit@2.55.0_@sveltejs+vite-plugin-svelte@5.1.1_svelte@5.54.1_vite@6.2.2_@types_ce20823bfecf677d5057023026cadbbd/node_modules/@sveltejs/kit/src/runtime/components/svelte-5/error.svelte";

--- a/src-tauri/.svelte-kit/tsconfig.json
+++ b/src-tauri/.svelte-kit/tsconfig.json
@@ -1,0 +1,49 @@
+{
+	"compilerOptions": {
+		"paths": {
+			"$app/types": [
+				"./types/index.d.ts"
+			]
+		},
+		"rootDirs": [
+			"..",
+			"./types"
+		],
+		"verbatimModuleSyntax": true,
+		"isolatedModules": true,
+		"lib": [
+			"esnext",
+			"DOM",
+			"DOM.Iterable"
+		],
+		"moduleResolution": "bundler",
+		"module": "esnext",
+		"noEmit": true,
+		"target": "esnext"
+	},
+	"include": [
+		"ambient.d.ts",
+		"non-ambient.d.ts",
+		"./types/**/$types.d.ts",
+		"../vite.config.js",
+		"../vite.config.ts",
+		"../src/**/*.js",
+		"../src/**/*.ts",
+		"../src/**/*.svelte",
+		"../test/**/*.js",
+		"../test/**/*.ts",
+		"../test/**/*.svelte",
+		"../tests/**/*.js",
+		"../tests/**/*.ts",
+		"../tests/**/*.svelte"
+	],
+	"exclude": [
+		"../node_modules/**",
+		"../src/service-worker.js",
+		"../src/service-worker/**/*.js",
+		"../src/service-worker.ts",
+		"../src/service-worker/**/*.ts",
+		"../src/service-worker.d.ts",
+		"../src/service-worker/**/*.d.ts"
+	]
+}

--- a/src-tauri/src/deeplink.rs
+++ b/src-tauri/src/deeplink.rs
@@ -1,0 +1,173 @@
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// Typed payload emitted as `asyar:deeplink:extension` when a deep link
+/// targets an extension command: `asyar://extensions/{extensionId}/{commandId}?args`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExtensionDeeplinkPayload {
+    pub extension_id: String,
+    pub command_id: String,
+    pub args: HashMap<String, String>,
+}
+
+/// Attempts to parse an `asyar://extensions/{extensionId}/{commandId}?args` URL.
+///
+/// Returns `None` (and logs a warning) if the URL is not an extension deep link,
+/// has missing/empty segments, or contains unsafe characters in the extension ID.
+pub fn parse_extension_deeplink(raw: &str) -> Option<ExtensionDeeplinkPayload> {
+    let parsed = url::Url::parse(raw).ok()?;
+
+    // Must be the asyar scheme
+    if parsed.scheme() != "asyar" {
+        return None;
+    }
+
+    // Host is "extensions" (URL parses asyar://extensions/... as host = "extensions")
+    if parsed.host_str() != Some("extensions") {
+        return None;
+    }
+
+    // Path segments after host: /{extensionId}/{commandId}
+    let segments: Vec<&str> = parsed
+        .path_segments()?
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if segments.len() < 2 {
+        log::warn!("Deep link missing extensionId or commandId: {}", raw);
+        return None;
+    }
+
+    let extension_id = segments[0];
+    let command_id = segments[1];
+
+    // Validate extensionId format: alphanumeric, dots, hyphens, underscores only.
+    // Prevents path traversal (e.g. "../etc/passwd") and other injection.
+    if !extension_id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
+    {
+        log::warn!(
+            "Deep link extensionId contains invalid characters: {}",
+            extension_id
+        );
+        return None;
+    }
+
+    // Validate commandId is non-empty and safe
+    if !command_id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        log::warn!(
+            "Deep link commandId contains invalid characters: {}",
+            command_id
+        );
+        return None;
+    }
+
+    // Collect query params with URL decoding (handled by url::Url)
+    let args: HashMap<String, String> = parsed
+        .query_pairs()
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect();
+
+    Some(ExtensionDeeplinkPayload {
+        extension_id: extension_id.to_string(),
+        command_id: command_id.to_string(),
+        args,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_valid_deeplink_with_args() {
+        let result = parse_extension_deeplink(
+            "asyar://extensions/com.example.weather/check?city=Berlin&units=metric",
+        );
+        let payload = result.expect("should parse successfully");
+        assert_eq!(payload.extension_id, "com.example.weather");
+        assert_eq!(payload.command_id, "check");
+        assert_eq!(payload.args.get("city"), Some(&"Berlin".to_string()));
+        assert_eq!(payload.args.get("units"), Some(&"metric".to_string()));
+    }
+
+    #[test]
+    fn parses_valid_deeplink_without_args() {
+        let result = parse_extension_deeplink("asyar://extensions/com.example.calc/run");
+        let payload = result.expect("should parse successfully");
+        assert_eq!(payload.extension_id, "com.example.calc");
+        assert_eq!(payload.command_id, "run");
+        assert!(payload.args.is_empty());
+    }
+
+    #[test]
+    fn rejects_missing_command_id() {
+        assert!(parse_extension_deeplink("asyar://extensions/com.example.calc").is_none());
+    }
+
+    #[test]
+    fn rejects_empty_extension_id() {
+        assert!(parse_extension_deeplink("asyar://extensions//run").is_none());
+    }
+
+    #[test]
+    fn rejects_path_traversal_in_extension_id() {
+        // Dots in isolation are fine (e.g. "com.example"), but characters like
+        // slashes or percent-encoded slashes would be caught by the URL parser
+        // or the character allowlist. Test that special chars are rejected:
+        assert!(
+            parse_extension_deeplink("asyar://extensions/ext%2F..%2Fetc/run").is_none()
+        );
+        assert!(
+            parse_extension_deeplink("asyar://extensions/ext%00id/run").is_none()
+        );
+    }
+
+    #[test]
+    fn rejects_non_extension_deeplinks() {
+        assert!(parse_extension_deeplink("asyar://auth/callback?code=abc").is_none());
+    }
+
+    #[test]
+    fn handles_url_encoded_args() {
+        let result =
+            parse_extension_deeplink("asyar://extensions/ext/cmd?q=hello%20world&n=42");
+        let payload = result.expect("should parse successfully");
+        assert_eq!(payload.args.get("q"), Some(&"hello world".to_string()));
+        assert_eq!(payload.args.get("n"), Some(&"42".to_string()));
+    }
+
+    #[test]
+    fn rejects_non_asyar_scheme() {
+        assert!(
+            parse_extension_deeplink("https://extensions/com.example/cmd").is_none()
+        );
+    }
+
+    #[test]
+    fn accepts_hyphenated_and_underscored_ids() {
+        let result =
+            parse_extension_deeplink("asyar://extensions/my-ext_v2/do-thing_now");
+        let payload = result.expect("should parse successfully");
+        assert_eq!(payload.extension_id, "my-ext_v2");
+        assert_eq!(payload.command_id, "do-thing_now");
+    }
+
+    #[test]
+    fn serializes_payload_as_camel_case() {
+        let payload = ExtensionDeeplinkPayload {
+            extension_id: "test".to_string(),
+            command_id: "cmd".to_string(),
+            args: HashMap::new(),
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("extensionId"));
+        assert!(json.contains("commandId"));
+        assert!(!json.contains("extension_id"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -50,6 +50,7 @@ pub mod oauth;
 pub mod shell;
 pub mod application;
 pub mod window_management;
+pub mod deeplink;
 
 pub const SPOTLIGHT_LABEL: &str = "main";
 
@@ -258,19 +259,31 @@ pub fn run() {
 fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     tray::setup_tray(app)?;
     
-    // Deep link handler — receives asyar://auth/callback?session_code=X
-    // and emits an event for the frontend to complete the login flow.
+    // Deep link handler — routes incoming asyar:// URLs.
+    // Extension deep links (asyar://extensions/{extId}/{cmdId}?args) are parsed
+    // in Rust and emitted as a typed "asyar:deeplink:extension" event.
+    // All other URLs (auth, OAuth) are emitted as raw "asyar:deep-link" strings.
     {
         use tauri_plugin_deep_link::DeepLinkExt;
         let handle = app.handle().clone();
         app.deep_link().on_open_url(move |event| {
-            // The frontend listens for "asyar:deep-link" and handles the URL
-            // (extracting session_code and completing the poll).
             let urls: Vec<String> = event.urls().iter()
                 .map(|u| u.to_string())
                 .collect();
             for url in urls {
-                let _ = handle.emit("asyar:deep-link", url);
+                if url.starts_with("asyar://extensions/") {
+                    match deeplink::parse_extension_deeplink(&url) {
+                        Some(payload) => {
+                            log::info!("[Deeplink] Extension trigger: {}/{}", payload.extension_id, payload.command_id);
+                            let _ = handle.emit("asyar:deeplink:extension", payload);
+                        }
+                        None => {
+                            log::warn!("[Deeplink] Failed to parse extension URL: {}", url);
+                        }
+                    }
+                } else {
+                    let _ = handle.emit("asyar:deep-link", url);
+                }
             }
         });
     }

--- a/src/services/appInitializer.ts
+++ b/src/services/appInitializer.ts
@@ -126,6 +126,22 @@ export const appInitializer = {
       extensionUpdateService.startPeriodicCheck(); // hourly re-check
       commandService.initialize(extensionManager); // Initialize CommandService with ExtensionManager instance
 
+      // Initialize extension deeplink service (asyar://extensions/{extId}/{cmdId})
+      if (envService.isTauri) {
+        const { createDeeplinkService } = await import('./deeplink/deeplinkService.svelte');
+        const deeplinkService = createDeeplinkService({
+          getManifestById: (id) => extensionManager.getManifestById(id),
+          isExtensionEnabled: (id) => extensionManager.isExtensionEnabled(id),
+          hasCommand: (id) => commandService.commands.has(id),
+          executeCommand: (id, args) => commandService.executeCommand(id, args),
+          navigateToView: (path) => extensionManager.navigateToView(path),
+          showWindow: () => commands.showWindow(),
+          recordItemUsage: (id) => commands.recordItemUsage(id),
+        });
+        await deeplinkService.init();
+        logService.info('Extension deeplink service initialized.');
+      }
+
       if (envService.isTauri) {
         await shortcutService.init();
         await snippetService.init();

--- a/src/services/deeplink/deeplinkService.svelte.ts
+++ b/src/services/deeplink/deeplinkService.svelte.ts
@@ -1,0 +1,88 @@
+import { listen } from '@tauri-apps/api/event';
+import { logService } from '../log/logService';
+import type { ExtensionManifest, ExtensionCommand } from 'asyar-sdk';
+
+export interface DeeplinkDeps {
+  getManifestById: (id: string) => ExtensionManifest | undefined;
+  isExtensionEnabled: (id: string) => boolean;
+  hasCommand: (objectId: string) => boolean;
+  executeCommand: (objectId: string, args?: Record<string, any>) => Promise<any>;
+  navigateToView: (viewPath: string) => void;
+  showWindow: () => Promise<void>;
+  recordItemUsage: (objectId: string) => Promise<void>;
+}
+
+interface ExtensionDeeplinkPayload {
+  extensionId: string;
+  commandId: string;
+  args: Record<string, string>;
+}
+
+export class DeeplinkService {
+  constructor(private deps: DeeplinkDeps) {}
+
+  /** Register the permanent Tauri event listener. Call once at app init. */
+  async init(): Promise<void> {
+    await listen<ExtensionDeeplinkPayload>('asyar:deeplink:extension', (event) => {
+      this.handleExtensionDeeplink(event.payload);
+    });
+  }
+
+  /** Validate and dispatch an extension deep link. Errors are logged, never thrown. */
+  async handleExtensionDeeplink(payload: ExtensionDeeplinkPayload): Promise<void> {
+    const { extensionId, commandId, args } = payload;
+    const objectId = `cmd_${extensionId}_${commandId}`;
+
+    try {
+      // 1. Extension must exist
+      const manifest = this.deps.getManifestById(extensionId);
+      if (!manifest) {
+        logService.error(`[Deeplink] Extension not found: ${extensionId}`);
+        return;
+      }
+
+      // 2. Extension must be enabled
+      if (!this.deps.isExtensionEnabled(extensionId)) {
+        logService.error(`[Deeplink] Extension is disabled: ${extensionId}`);
+        return;
+      }
+
+      // 3. Command must exist in manifest
+      const command = manifest.commands.find((c: ExtensionCommand) => c.id === commandId);
+      if (!command) {
+        logService.error(`[Deeplink] Command '${commandId}' not found in extension '${extensionId}'`);
+        return;
+      }
+
+      // 4. Command must be registered in commandService
+      if (!this.deps.hasCommand(objectId)) {
+        logService.error(`[Deeplink] Command '${objectId}' not registered`);
+        return;
+      }
+
+      // 6. Determine execution mode based on resultType
+      const isView = command.resultType === 'view' || manifest.type === 'view';
+
+      if (isView) {
+        await this.deps.showWindow();
+        const viewPath = `${extensionId}/${manifest.defaultView || commandId}`;
+        this.deps.navigateToView(viewPath);
+      }
+
+      // 7. Execute with deeplinkTrigger flag (bypasses preference gate)
+      await this.deps.executeCommand(objectId, { ...args, deeplinkTrigger: true });
+
+      // 8. Record usage
+      this.deps.recordItemUsage(objectId).catch((err) =>
+        logService.error(`[Deeplink] Failed to record usage for ${objectId}: ${err}`)
+      );
+
+    } catch (error) {
+      logService.error(`[Deeplink] Failed to execute ${objectId}: ${error}`);
+    }
+  }
+}
+
+export function createDeeplinkService(deps: DeeplinkDeps): DeeplinkService {
+  return new DeeplinkService(deps);
+}

--- a/src/services/deeplink/deeplinkService.test.ts
+++ b/src/services/deeplink/deeplinkService.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../log/logService', () => ({
+  logService: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { DeeplinkService, type DeeplinkDeps } from './deeplinkService.svelte'
+import { logService } from '../log/logService'
+
+function makeDeps(overrides?: Partial<DeeplinkDeps>): DeeplinkDeps {
+  return {
+    getManifestById: vi.fn().mockReturnValue(undefined),
+    isExtensionEnabled: vi.fn().mockReturnValue(false),
+    hasCommand: vi.fn().mockReturnValue(false),
+    executeCommand: vi.fn().mockResolvedValue(undefined),
+    navigateToView: vi.fn(),
+    showWindow: vi.fn().mockResolvedValue(undefined),
+    recordItemUsage: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+/** A minimal manifest with one no-view command. */
+function makeManifest(overrides?: {
+  commandId?: string
+  resultType?: string
+  defaultView?: string
+  extensionType?: string
+}) {
+  const commandId = overrides?.commandId ?? 'run'
+  const resultType = overrides?.resultType ?? 'no-view'
+  return {
+    id: 'com.example.ext',
+    name: 'Test Extension',
+    version: '1.0.0',
+    description: '',
+    type: overrides?.extensionType ?? 'result',
+    defaultView: overrides?.defaultView,
+    commands: [
+      {
+        id: commandId,
+        name: 'Run',
+        description: '',
+        trigger: 'run',
+        resultType,
+      },
+    ],
+  }
+}
+
+describe('DeeplinkService.handleExtensionDeeplink', () => {
+  let service: DeeplinkService
+  let deps: DeeplinkDeps
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    deps = makeDeps()
+    service = new DeeplinkService(deps)
+  })
+
+  // ── Happy path: no-view ──────────────────────────────────────────────
+
+  it('executes no-view command with correct objectId and args', async () => {
+    const manifest = makeManifest()
+    vi.mocked(deps.getManifestById).mockReturnValue(manifest)
+    vi.mocked(deps.isExtensionEnabled).mockReturnValue(true)
+    vi.mocked(deps.hasCommand).mockReturnValue(true)
+    vi.mocked(deps.executeCommand).mockResolvedValue({ type: 'no-view' })
+
+    await service.handleExtensionDeeplink({
+      extensionId: 'com.example.ext',
+      commandId: 'run',
+      args: { city: 'Berlin' },
+    })
+
+    expect(deps.executeCommand).toHaveBeenCalledWith(
+      'cmd_com.example.ext_run',
+      expect.objectContaining({ city: 'Berlin', deeplinkTrigger: true }),
+    )
+  })
+
+  it('does not show window for no-view commands', async () => {
+    const manifest = makeManifest()
+    vi.mocked(deps.getManifestById).mockReturnValue(manifest)
+    vi.mocked(deps.isExtensionEnabled).mockReturnValue(true)
+    vi.mocked(deps.hasCommand).mockReturnValue(true)
+    vi.mocked(deps.executeCommand).mockResolvedValue({ type: 'no-view' })
+
+    await service.handleExtensionDeeplink({
+      extensionId: 'com.example.ext',
+      commandId: 'run',
+      args: {},
+    })
+
+    expect(deps.showWindow).not.toHaveBeenCalled()
+  })
+
+  // ── Happy path: view ─────────────────────────────────────────────────
+
+  it('shows window and navigates for view commands', async () => {
+    const manifest = makeManifest({
+      resultType: 'view',
+      defaultView: 'DefaultView',
+    })
+    vi.mocked(deps.getManifestById).mockReturnValue(manifest)
+    vi.mocked(deps.isExtensionEnabled).mockReturnValue(true)
+    vi.mocked(deps.hasCommand).mockReturnValue(true)
+    vi.mocked(deps.executeCommand).mockResolvedValue({ type: 'view' })
+
+    await service.handleExtensionDeeplink({
+      extensionId: 'com.example.ext',
+      commandId: 'run',
+      args: {},
+    })
+
+    expect(deps.showWindow).toHaveBeenCalled()
+    expect(deps.navigateToView).toHaveBeenCalledWith('com.example.ext/DefaultView')
+  })
+
+  it('shows window for view-type extension even when command resultType is no-view', async () => {
+    const manifest = makeManifest({
+      extensionType: 'view',
+      resultType: 'no-view',
+      defaultView: 'MainView',
+    })
+    vi.mocked(deps.getManifestById).mockReturnValue(manifest)
+    vi.mocked(deps.isExtensionEnabled).mockReturnValue(true)
+    vi.mocked(deps.hasCommand).mockReturnValue(true)
+    vi.mocked(deps.executeCommand).mockResolvedValue({ type: 'no-view' })
+
+    await service.handleExtensionDeeplink({
+      extensionId: 'com.example.ext',
+      commandId: 'run',
+      args: {},
+    })
+
+    expect(deps.showWindow).toHaveBeenCalled()
+    expect(deps.navigateToView).toHaveBeenCalledWith('com.example.ext/MainView')
+  })
+
+  // ── Validation: extension not found ──────────────────────────────────
+
+  it('rejects unknown extensionId gracefully', async () => {
+    vi.mocked(deps.getManifestById).mockReturnValue(undefined)
+
+    await service.handleExtensionDeeplink({
+      extensionId: 'unknown.ext',
+      commandId: 'run',
+      args: {},
+    })
+
+    expect(deps.executeCommand).not.toHaveBeenCalled()
+    expect(logService.error).toHaveBeenCalled()
+  })
+
+  // ── Validation: extension disabled ───────────────────────────────────
+
+  it('rejects disabled extension gracefully', async () => {
+    const manifest = makeManifest()
+    vi.mocked(deps.getManifestById).mockReturnValue(manifest)
+    vi.mocked(deps.isExtensionEnabled).mockReturnValue(false)
+
+    await service.handleExtensionDeeplink({
+      extensionId: 'com.example.ext',
+      commandId: 'run',
+      args: {},
+    })
+
+    expect(deps.executeCommand).not.toHaveBeenCalled()
+    expect(logService.error).toHaveBeenCalled()
+  })
+
+  // ── Validation: command not in manifest ──────────────────────────────
+
+  it('rejects command that does not exist in manifest', async () => {
+    const manifest = makeManifest()
+    vi.mocked(deps.getManifestById).mockReturnValue(manifest)
+    vi.mocked(deps.isExtensionEnabled).mockReturnValue(true)
+
+    await service.handleExtensionDeeplink({
+      extensionId: 'com.example.ext',
+      commandId: 'nonexistent',
+      args: {},
+    })
+
+    expect(deps.executeCommand).not.toHaveBeenCalled()
+    expect(logService.error).toHaveBeenCalled()
+  })
+
+  // ── Validation: command not registered ───────────────────────────────
+
+  it('rejects command not registered in commandService', async () => {
+    const manifest = makeManifest()
+    vi.mocked(deps.getManifestById).mockReturnValue(manifest)
+    vi.mocked(deps.isExtensionEnabled).mockReturnValue(true)
+    vi.mocked(deps.hasCommand).mockReturnValue(false)
+
+    await service.handleExtensionDeeplink({
+      extensionId: 'com.example.ext',
+      commandId: 'run',
+      args: {},
+    })
+
+    expect(deps.executeCommand).not.toHaveBeenCalled()
+    expect(logService.error).toHaveBeenCalled()
+  })
+
+  // ── deeplinkTrigger flag ─────────────────────────────────────────────
+
+  it('passes deeplinkTrigger: true in args to executeCommand', async () => {
+    const manifest = makeManifest()
+    vi.mocked(deps.getManifestById).mockReturnValue(manifest)
+    vi.mocked(deps.isExtensionEnabled).mockReturnValue(true)
+    vi.mocked(deps.hasCommand).mockReturnValue(true)
+    vi.mocked(deps.executeCommand).mockResolvedValue({ type: 'no-view' })
+
+    await service.handleExtensionDeeplink({
+      extensionId: 'com.example.ext',
+      commandId: 'run',
+      args: { key: 'val' },
+    })
+
+    const callArgs = vi.mocked(deps.executeCommand).mock.calls[0][1]
+    expect(callArgs).toHaveProperty('deeplinkTrigger', true)
+  })
+
+  // ── Usage recording ──────────────────────────────────────────────────
+
+  it('records usage after successful execution', async () => {
+    const manifest = makeManifest()
+    vi.mocked(deps.getManifestById).mockReturnValue(manifest)
+    vi.mocked(deps.isExtensionEnabled).mockReturnValue(true)
+    vi.mocked(deps.hasCommand).mockReturnValue(true)
+    vi.mocked(deps.executeCommand).mockResolvedValue({ type: 'no-view' })
+
+    await service.handleExtensionDeeplink({
+      extensionId: 'com.example.ext',
+      commandId: 'run',
+      args: {},
+    })
+
+    expect(deps.recordItemUsage).toHaveBeenCalledWith('cmd_com.example.ext_run')
+  })
+
+  it('does not record usage after failed execution', async () => {
+    const manifest = makeManifest()
+    vi.mocked(deps.getManifestById).mockReturnValue(manifest)
+    vi.mocked(deps.isExtensionEnabled).mockReturnValue(true)
+    vi.mocked(deps.hasCommand).mockReturnValue(true)
+    vi.mocked(deps.executeCommand).mockRejectedValue(new Error('boom'))
+
+    await service.handleExtensionDeeplink({
+      extensionId: 'com.example.ext',
+      commandId: 'run',
+      args: {},
+    })
+
+    expect(deps.recordItemUsage).not.toHaveBeenCalled()
+  })
+
+  // ── Empty args ───────────────────────────────────────────────────────
+
+  it('handles empty args map correctly', async () => {
+    const manifest = makeManifest()
+    vi.mocked(deps.getManifestById).mockReturnValue(manifest)
+    vi.mocked(deps.isExtensionEnabled).mockReturnValue(true)
+    vi.mocked(deps.hasCommand).mockReturnValue(true)
+    vi.mocked(deps.executeCommand).mockResolvedValue({ type: 'no-view' })
+
+    await service.handleExtensionDeeplink({
+      extensionId: 'com.example.ext',
+      commandId: 'run',
+      args: {},
+    })
+
+    expect(deps.executeCommand).toHaveBeenCalledWith(
+      'cmd_com.example.ext_run',
+      { deeplinkTrigger: true },
+    )
+  })
+})

--- a/src/services/extension/commandService.svelte.ts
+++ b/src/services/extension/commandService.svelte.ts
@@ -98,8 +98,9 @@ export class CommandService implements ICommandService {
    * this call throws. The host's PreferencesPromptHost handles the user's
    * input and re-invokes this method after persisting values.
    *
-   * Scheduled tick invocations (signalled via `args.scheduledTick === true`)
-   * bypass the gate — there's no user to prompt from a background timer.
+   * Scheduled tick invocations (`args.scheduledTick === true`) and deep link
+   * invocations (`args.deeplinkTrigger === true`) bypass the gate — there's
+   * no user to prompt from a background timer or external trigger.
    */
   async executeCommand(
     commandObjectId: string,
@@ -111,9 +112,9 @@ export class CommandService implements ICommandService {
       throw new Error(`Command not found: ${commandObjectId}`);
     }
 
-    const isScheduledTick = args?.scheduledTick === true;
+    const bypassPreferenceGate = args?.scheduledTick === true || args?.deeplinkTrigger === true;
     const shortCommandId = this.shortCommandIds.get(commandObjectId);
-    if (!isScheduledTick && shortCommandId) {
+    if (!bypassPreferenceGate && shortCommandId) {
       const missing = await extensionPreferencesService.getMissingRequired(
         command.extensionId,
         shortCommandId

--- a/src/services/extension/commandService.test.ts
+++ b/src/services/extension/commandService.test.ts
@@ -9,6 +9,18 @@ vi.mock('../log/logService', () => ({
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
 import { invoke } from '@tauri-apps/api/core'
 
+vi.mock('./extensionPreferencesService.svelte', () => ({
+  extensionPreferencesService: {
+    getMissingRequired: vi.fn().mockResolvedValue([]),
+  },
+}))
+import { extensionPreferencesService } from './extensionPreferencesService.svelte'
+
+vi.mock('./preferencesPromptStore.svelte', () => ({
+  preferencesPromptStore: { open: vi.fn() },
+}))
+import { preferencesPromptStore } from './preferencesPromptStore.svelte'
+
 function freshService(): CommandService {
   return new CommandService()
 }
@@ -95,6 +107,62 @@ describe('executeCommand', () => {
     const handler = { execute: vi.fn().mockRejectedValue(new Error('handler error')) }
     svc.registerCommand('faulty', handler, 'ext-a')
     await expect(svc.executeCommand('faulty')).rejects.toThrow('handler error')
+  })
+})
+
+// ── preference gate bypass ───────────────────────────────────────────────────
+
+describe('preference gate bypass', () => {
+  it('bypasses preference gate when deeplinkTrigger is true', async () => {
+    const svc = freshService()
+    const handler = makeHandler('ok')
+    svc.registerCommand('cmd_ext_run', handler, 'ext')
+    svc.setShortCommandId('cmd_ext_run', 'run')
+
+    // If the gate were NOT bypassed, getMissingRequired would be called
+    vi.mocked(extensionPreferencesService.getMissingRequired).mockResolvedValue([
+      { name: 'apiKey', type: 'password', title: 'API Key', required: true },
+    ])
+
+    await svc.executeCommand('cmd_ext_run', { deeplinkTrigger: true })
+
+    expect(extensionPreferencesService.getMissingRequired).not.toHaveBeenCalled()
+    expect(handler.execute).toHaveBeenCalledOnce()
+  })
+
+  it('bypasses preference gate when scheduledTick is true', async () => {
+    const svc = freshService()
+    const handler = makeHandler('ok')
+    svc.registerCommand('cmd_ext_tick', handler, 'ext')
+    svc.setShortCommandId('cmd_ext_tick', 'tick')
+
+    vi.mocked(extensionPreferencesService.getMissingRequired).mockResolvedValue([
+      { name: 'apiKey', type: 'password', title: 'API Key', required: true },
+    ])
+
+    await svc.executeCommand('cmd_ext_tick', { scheduledTick: true })
+
+    expect(extensionPreferencesService.getMissingRequired).not.toHaveBeenCalled()
+    expect(handler.execute).toHaveBeenCalledOnce()
+  })
+
+  it('enforces preference gate when no bypass flag is set', async () => {
+    const svc = freshService()
+    const handler = makeHandler('ok')
+    svc.registerCommand('cmd_ext_normal', handler, 'ext')
+    svc.setShortCommandId('cmd_ext_normal', 'normal')
+
+    vi.mocked(extensionPreferencesService.getMissingRequired).mockResolvedValue([
+      { name: 'apiKey', type: 'password', title: 'API Key', required: true },
+    ])
+
+    await expect(svc.executeCommand('cmd_ext_normal')).rejects.toThrow(
+      "requires preferences"
+    )
+
+    expect(extensionPreferencesService.getMissingRequired).toHaveBeenCalledWith('ext', 'normal')
+    expect(preferencesPromptStore.open).toHaveBeenCalled()
+    expect(handler.execute).not.toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
Every enabled extension command is reachable via
asyar://extensions/{extensionId}/{commandId}?key=val — no manifest
declaration required. Rust parses and validates the URL, emits
asyar:deeplink:extension, and DeeplinkService dispatches to the
command handler with deeplinkTrigger:true (bypasses preference gate).

Wired into appInitializer. commandService bypassPreferenceGate now
covers both scheduledTick and deeplinkTrigger.