### PR TITLE
Fix/settings-window-tdz-cycle

### DIFF
--- a/src/components/layout/ActionListPopup.svelte
+++ b/src/components/layout/ActionListPopup.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { logService } from '../../services/log/logService';
   import { isIconImage, isBuiltInIcon, getBuiltInIconName } from '../../lib/iconUtils';
-  import { Icon, ListItem, Input, KeyboardHint, EmptyState } from '../../components';
+  import Icon from '../base/Icon.svelte';
+  import Input from '../base/Input.svelte';
+  import KeyboardHint from '../base/KeyboardHint.svelte';
+  import ListItem from '../list/ListItem.svelte';
+  import EmptyState from '../feedback/EmptyState.svelte';
   import { actionService } from '../../services/action/actionService.svelte';
   import type { ApplicationAction } from '../../services/action/actionService.svelte';
   import { feedbackService } from '../../services/feedback/feedbackService.svelte';

--- a/src/components/layout/SearchResultsArea.svelte
+++ b/src/components/layout/SearchResultsArea.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { ResultsList, EmptyState } from '../../components';
+  import ResultsList from '../list/ResultsList.svelte';
+  import EmptyState from '../feedback/EmptyState.svelte';
   import { logService } from '../../services/log/logService';
 
   interface Props {

--- a/src/components/settings/ExtensionDetailPanel.svelte
+++ b/src/components/settings/ExtensionDetailPanel.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { Badge, Toggle, ExtensionPreferencesForm } from '../index';
+  import Badge from '../base/Badge.svelte';
+  import Toggle from '../base/Toggle.svelte';
+  import ExtensionPreferencesForm from './ExtensionPreferencesForm.svelte';
   import type { ExtensionItem } from '../../routes/settings/settingsHandlers.svelte';
   import type { ExtensionCommand } from 'asyar-sdk';
   import { extensionPreferencesService } from '../../services/extension/extensionPreferencesService.svelte';

--- a/src/components/settings/SettingsTopBar.svelte
+++ b/src/components/settings/SettingsTopBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Icon } from '../index';
+  import Icon from '../base/Icon.svelte';
 
   let {
     tabs,

--- a/src/services/action/actionService.svelte.ts
+++ b/src/services/action/actionService.svelte.ts
@@ -33,7 +33,7 @@ export class ActionService implements IActionService {
   private allActions: Map<string, ApplicationAction> = new Map();
   private currentContext: ActionContext = ActionContext.CORE;
   private sendToExtension?: (extensionId: string, actionId: string) => void;
-  
+
   // Svelte 5 reactive state
   public filteredActions = $state<ApplicationAction[]>([]);
 

--- a/src/services/extension/extensionManager.cycle.test.ts
+++ b/src/services/extension/extensionManager.cycle.test.ts
@@ -1,0 +1,280 @@
+// Regression guard for the module-load cycle that caused a TDZ white-screen
+// crash in the Settings webview.  The cycle was:
+//   Settings +page.svelte → components barrel → ActionListPopup →
+//   actionService → searchOrchestrator → appInitializer →
+//   extensionManager → actionService  (TDZ)
+// The fix: extensionManager must NOT eagerly import actionService at module
+// body level; the wiring must be deferred to init() via a dynamic import.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+// ---------------------------------------------------------------------------
+// Test 1 – Static import-graph check
+// Asserts that extensionManager.svelte.ts does NOT contain an eager
+// (non-type) import of actionService.  This is the exact pattern that
+// triggered the TDZ crash and must never be re-introduced.
+// ---------------------------------------------------------------------------
+
+describe('extensionManager – no eager actionService import (cycle guard)', () => {
+  it('does not contain an eager import of actionService at module body level', () => {
+    const filePath = resolve(
+      __dirname,
+      'extensionManager.svelte.ts'
+    )
+    const source = readFileSync(filePath, 'utf-8')
+
+    // Match a real (non-type-only) import that pulls in actionService by name.
+    // Type-only imports (`import type { … }`) are safe and are allowed.
+    const eagerImportPattern =
+      /^import\s+\{[^}]*\bactionService\b[^}]*\}\s+from\s+['"]\.\.\/action\/actionService/m
+
+    expect(source).not.toMatch(eagerImportPattern)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Test 2 – Functional smoke test (settings-window entry order)
+// Dynamically imports actionService first, then extensionManager (the order
+// the Settings webview's module graph enters these modules), and asserts
+// both resolve without throwing.  vi.resetModules() ensures no cached
+// module state bleeds between tests.
+// ---------------------------------------------------------------------------
+
+// --- Mocks required so the modules can be loaded in Node / Vitest env ---
+
+vi.mock('../log/logService', () => ({
+  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), custom: vi.fn() }
+}))
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }))
+vi.mock('@tauri-apps/api/path', () => ({ resourceDir: vi.fn(), appDataDir: vi.fn(), join: vi.fn() }))
+vi.mock('@tauri-apps/plugin-fs', () => ({ exists: vi.fn(), readDir: vi.fn(), remove: vi.fn() }))
+vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }))
+vi.mock('asyar-sdk', () => ({
+  ExtensionBridge: {
+    getInstance: vi.fn().mockReturnValue({
+      registerManifest: vi.fn(),
+      registerExtensionImplementation: vi.fn(),
+      initializeExtensions: vi.fn().mockResolvedValue(true),
+      activateExtensions: vi.fn().mockResolvedValue(true),
+      deactivateExtensions: vi.fn().mockResolvedValue(true),
+    })
+  },
+  ActionContext: { CORE: 'CORE' },
+}))
+vi.mock('tauri-plugin-clipboard-x-api', () => ({ writeText: vi.fn() }))
+vi.mock('../settings/settingsService.svelte', () => ({
+  settingsService: {
+    isInitialized: vi.fn().mockReturnValue(true),
+    init: vi.fn(),
+    subscribe: vi.fn().mockReturnValue(() => {}),
+    isExtensionEnabled: vi.fn().mockReturnValue(true),
+    getSettings: vi.fn().mockReturnValue({ search: { enableExtensionSearch: false } }),
+    updateSettings: vi.fn(),
+    updateExtensionState: vi.fn(),
+    removeExtensionState: vi.fn(),
+  }
+}))
+vi.mock('../performance/performanceService.svelte', () => ({
+  performanceService: {
+    init: vi.fn(),
+    startTiming: vi.fn(),
+    stopTiming: vi.fn().mockReturnValue({ duration: 0 }),
+  }
+}))
+vi.mock('../extensionLoaderService', () => ({
+  extensionLoaderService: {
+    loadAllExtensions: vi.fn().mockResolvedValue(new Map()),
+    loadSingleExtension: vi.fn().mockResolvedValue(null),
+  }
+}))
+vi.mock('./extensionDiscovery', () => ({
+  discoverExtensions: vi.fn().mockResolvedValue([]),
+  isBuiltInFeature: vi.fn().mockReturnValue(false),
+}))
+vi.mock('./commandService.svelte', () => ({
+  commandService: {
+    registerCommand: vi.fn(),
+    executeCommand: vi.fn().mockResolvedValue(undefined),
+    clearCommandsForExtension: vi.fn(),
+    getCommands: vi.fn().mockReturnValue([]),
+    commands: new Map(),
+  }
+}))
+vi.mock('./viewManager.svelte', () => ({
+  viewManager: {
+    init: vi.fn(),
+    navigateToView: vi.fn(),
+    goBack: vi.fn(),
+    getActiveView: vi.fn().mockReturnValue(null),
+    isViewActive: vi.fn().mockReturnValue(false),
+    getNavigationStackSize: vi.fn().mockReturnValue(0),
+    handleViewSearch: vi.fn().mockResolvedValue(undefined),
+    handleViewSubmit: vi.fn().mockResolvedValue(undefined),
+    activeView: null,
+    activeViewSearchable: false,
+    activeViewPrimaryActionLabel: null,
+    activeViewSubtitle: null,
+  }
+}))
+vi.mock('../search/SearchService', () => ({
+  searchService: {
+    getIndexedObjectIds: vi.fn().mockResolvedValue(new Set()),
+    batchIndexItems: vi.fn().mockResolvedValue(undefined),
+    deleteItem: vi.fn().mockResolvedValue(undefined),
+    saveIndex: vi.fn().mockResolvedValue(undefined),
+  }
+}))
+vi.mock('../search/topItemsCache', () => ({ invalidateTopItemsCache: vi.fn() }))
+vi.mock('../search/searchOrchestrator.svelte', () => ({
+  searchOrchestrator: {
+    init: vi.fn(),
+    search: vi.fn().mockResolvedValue([]),
+    getResults: vi.fn().mockReturnValue([]),
+    items: [],
+  }
+}))
+vi.mock('../search/stores/search.svelte', () => ({
+  searchStores: {
+    query: '',
+    results: [],
+    isLoading: false,
+  }
+}))
+vi.mock('../statusBar/statusBarService.svelte', () => ({
+  statusBarService: { clearItemsForExtension: vi.fn(), addItem: vi.fn(), removeItem: vi.fn() }
+}))
+vi.mock('../envService', () => ({ envService: { isTauri: false } }))
+vi.mock('./extensionIframeManager.svelte', () => ({
+  extensionIframeManager: {
+    init: vi.fn(),
+    hasInputFocus: false,
+    sendViewSearchToExtension: vi.fn(),
+    handleExtensionSubmit: vi.fn(),
+    sendSearchRequestToExtension: vi.fn().mockResolvedValue([]),
+    sendActionExecuteToExtension: vi.fn(),
+    broadcastSettingsToIframes: vi.fn(),
+    forwardKeyToActiveView: vi.fn(),
+    handleSearchResponse: vi.fn(),
+    sendPreferencesToExtension: vi.fn(),
+  }
+}))
+vi.mock('../../lib/ipc/extensionOrigin', () => ({
+  getExtensionFrameOrigin: vi.fn((id: string) => `asyar-extension://${id}`)
+}))
+vi.mock('../notification/notificationService', () => ({
+  NotificationService: vi.fn().mockImplementation(function (this: any) {
+    this.notify = vi.fn()
+  })
+}))
+vi.mock('../clipboard/clipboardHistoryService', () => ({
+  ClipboardHistoryService: { getInstance: vi.fn().mockReturnValue({ getHistory: vi.fn() }) }
+}))
+vi.mock('../../lib/ipc/commands', () => ({
+  syncCommandIndex: vi.fn().mockResolvedValue({ added: 0, removed: 0, total: 0 }),
+  hideWindow: vi.fn(),
+  recordItemUsage: vi.fn().mockResolvedValue(true),
+  registerExtensionPermissions: vi.fn().mockResolvedValue(undefined),
+  setExtensionEnabled: vi.fn().mockResolvedValue(true),
+  uninstallExtension: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../ai/aiService.svelte', () => ({
+  aiExtensionService: { streamChat: vi.fn() }
+}))
+vi.mock('../auth/entitlementService.svelte', () => ({
+  entitlementService: { check: vi.fn().mockReturnValue(true), getAll: vi.fn().mockReturnValue([]) }
+}))
+vi.mock('../feedback/feedbackService.svelte', () => ({
+  feedbackService: { submit: vi.fn() }
+}))
+vi.mock('../fileManager/fileManagerService', () => ({
+  fileManagerService: { open: vi.fn() }
+}))
+vi.mock('../selection/selectionService', () => ({
+  selectionService: { getSelectedText: vi.fn().mockResolvedValue('') }
+}))
+vi.mock('../oauth/extensionOAuthService.svelte', () => ({
+  extensionOAuthService: { startFlow: vi.fn() }
+}))
+vi.mock('../shell/shellService.svelte', () => ({
+  shellService: { run: vi.fn() }
+}))
+vi.mock('../storage/extensionStorageService', () => ({
+  extensionStorageService: { get: vi.fn(), set: vi.fn(), remove: vi.fn() }
+}))
+vi.mock('../storage/extensionCacheService', () => ({
+  extensionCacheService: { get: vi.fn(), set: vi.fn(), remove: vi.fn() }
+}))
+vi.mock('../application/applicationService', () => ({
+  applicationService: { launch: vi.fn() }
+}))
+vi.mock('../windowManagement/windowManagementService', () => ({
+  windowManagementService: { open: vi.fn(), close: vi.fn() }
+}))
+vi.mock('../interop/interopService.svelte', () => ({
+  InteropService: vi.fn().mockImplementation(function (this: any) {
+    this.handle = vi.fn()
+  })
+}))
+vi.mock('./extensionSearchAggregator', () => ({
+  extensionSearchAggregator: {
+    init: vi.fn(),
+    searchAll: vi.fn().mockResolvedValue([]),
+    resolveExtensionInstance: vi.fn((m: any) => m),
+  }
+}))
+vi.mock('./extensionStateManager.svelte', () => ({
+  extensionStateManager: {
+    init: vi.fn(),
+    isExtensionEnabled: vi.fn().mockReturnValue(true),
+    toggleExtensionState: vi.fn().mockResolvedValue(true),
+    getAllExtensionsWithState: vi.fn().mockResolvedValue([]),
+    getAllExtensions: vi.fn().mockResolvedValue([]),
+    recordViewUsage: vi.fn(),
+    extensionUninstallInProgress: null,
+    extensionUsageStats: {},
+  }
+}))
+vi.mock('./ExtensionLoader', () => ({
+  ExtensionLoader: vi.fn().mockImplementation(function (this: any) {
+    this.loadExtensions = vi.fn().mockResolvedValue(undefined)
+    this.syncCommandIndex = vi.fn().mockResolvedValue(undefined)
+  })
+}))
+vi.mock('./ExtensionIpcRouter', () => ({
+  ExtensionIpcRouter: vi.fn().mockImplementation(function (this: any) {
+    this.setup = vi.fn()
+  })
+}))
+vi.mock('../context/contextModeService.svelte', () => ({
+  contextModeService: { getMode: vi.fn().mockReturnValue('default') }
+}))
+vi.mock('../theme/themeService', () => ({
+  applyTheme: vi.fn().mockResolvedValue(undefined),
+  removeTheme: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+
+describe('extensionManager – settings-window import order smoke test', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('resolves actionService then extensionManager without throwing (simulates settings-window entry)', async () => {
+    // Import actionService first — this is the order the Settings webview
+    // module graph traverses these files (barrel → ActionListPopup →
+    // actionService, then appInitializer → extensionManager).
+    // Before the fix, actionService would still be mid-execution when
+    // extensionManager's constructor tried to read it, causing a TDZ crash.
+    const actionMod = await import('../action/actionService.svelte')
+    expect(actionMod).toBeDefined()
+    expect(typeof actionMod.actionService).not.toBe('undefined')
+
+    const extMod = await import('./extensionManager.svelte')
+    expect(extMod).toBeDefined()
+    expect(typeof extMod.extensionManager).not.toBe('undefined')
+  })
+})

--- a/src/services/extension/extensionManager.cycle.test.ts
+++ b/src/services/extension/extensionManager.cycle.test.ts
@@ -3,34 +3,38 @@
 //   Settings +page.svelte → components barrel → ActionListPopup →
 //   actionService → searchOrchestrator → appInitializer →
 //   extensionManager → actionService  (TDZ)
-// The fix: extensionManager must NOT eagerly import actionService at module
-// body level; the wiring must be deferred to init() via a dynamic import.
+// Structural fix: extensionManager must NOT eagerly instantiate
+// `new ExtensionManager()` at module body.  A lazy Proxy defers construction
+// until first property access, so the ctor (which references actionService)
+// runs only after every transitive dependency has finished loading.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
 // ---------------------------------------------------------------------------
-// Test 1 – Static import-graph check
-// Asserts that extensionManager.svelte.ts does NOT contain an eager
-// (non-type) import of actionService.  This is the exact pattern that
-// triggered the TDZ crash and must never be re-introduced.
+// Test 1 – Static check: no eager instantiation at module body
+// Asserts extensionManager.svelte.ts does NOT contain a top-level
+// `new ExtensionManager(...)` statement.  Eager instantiation couples the
+// ctor to module-load order and re-opens the TDZ cycle.
 // ---------------------------------------------------------------------------
 
-describe('extensionManager – no eager actionService import (cycle guard)', () => {
-  it('does not contain an eager import of actionService at module body level', () => {
+describe('extensionManager – no eager instantiation at module body (cycle guard)', () => {
+  it('does not contain a top-level `new ExtensionManager()` statement', () => {
     const filePath = resolve(
       __dirname,
       'extensionManager.svelte.ts'
     )
     const source = readFileSync(filePath, 'utf-8')
 
-    // Match a real (non-type-only) import that pulls in actionService by name.
-    // Type-only imports (`import type { … }`) are safe and are allowed.
-    const eagerImportPattern =
-      /^import\s+\{[^}]*\bactionService\b[^}]*\}\s+from\s+['"]\.\.\/action\/actionService/m
+    // Match a top-level binding that constructs ExtensionManager. Allowed:
+    // `new ExtensionManager(...)` inside a function body (e.g. a lazy-getter).
+    // Disallowed: any top-level `const/let/var X = new ExtensionManager(...)`
+    // that runs at module load.
+    const topLevelInstantiation =
+      /^(?:export\s+(?:const|let|var)|const|let|var)\s+\w+\s*=\s*new\s+ExtensionManager\s*\(/m
 
-    expect(source).not.toMatch(eagerImportPattern)
+    expect(source).not.toMatch(topLevelInstantiation)
   })
 })
 

--- a/src/services/extension/extensionManager.svelte.ts
+++ b/src/services/extension/extensionManager.svelte.ts
@@ -23,12 +23,7 @@ import { contextModeService } from "../context/contextModeService.svelte";
 import { extensionLoaderService } from "../extensionLoaderService"; // Import the new loader service (correct path)
 import { NotificationService } from "../notification/notificationService";
 import { ClipboardHistoryService } from "../clipboard/clipboardHistoryService";
-// actionService is imported lazily in init() to break a module-load cycle:
-// actionService → searchOrchestrator → appInitializer → extensionManager →
-// actionService. Eagerly importing it here caused a TDZ crash when the
-// graph was entered from the Settings webview (via the components barrel →
-// ActionListPopup). Do not re-add the eager import.
-import type { ActionService } from "../action/actionService.svelte";
+import { actionService } from "../action/actionService.svelte";
 import { statusBarService } from "../statusBar/statusBarService.svelte";
 import { entitlementService } from '../auth/entitlementService.svelte';
 import { feedbackService } from "../feedback/feedbackService.svelte";
@@ -131,8 +126,7 @@ export class ExtensionManager implements IExtensionManager {
       'NotificationService': new NotificationService(),
       'ClipboardHistoryService': ClipboardHistoryService.getInstance(),
       'CommandService': commandService,
-      // 'ActionService' is wired up in init() via dynamic import to avoid
-      // a module-load cycle. See top of file.
+      'ActionService': actionService,
       'SettingsService': {
         get: async (section: string, key: string) => {
           const settings = settingsService.getSettings();
@@ -166,8 +160,7 @@ export class ExtensionManager implements IExtensionManager {
 
 
     extensionIframeManager.init(viewManager);
-    // actionService.setExtensionForwarder(...) is called in init() after the
-    // dynamic import of actionService resolves. See top of file for rationale.
+    actionService.setExtensionForwarder(extensionIframeManager.sendActionExecuteToExtension.bind(extensionIframeManager));
     
     // (Removed: legacy settings-broadcast path that was used exclusively by
     // the Calculator built-in to pick up refreshInterval changes. Calculator
@@ -199,16 +192,6 @@ export class ExtensionManager implements IExtensionManager {
     }
     logService.custom("🔄 Initializing extension manager...", "EXTN", "blue");
     try {
-      // Wire up actionService lazily to avoid the module-load cycle documented
-      // at the top of this file. By now actionService's module has finished
-      // loading, so we can safely import it, register it in the service
-      // registry for IPC dispatch, and hand it the iframe-action forwarder.
-      const { actionService } = await import("../action/actionService.svelte");
-      this.serviceRegistry['ActionService'] = actionService;
-      actionService.setExtensionForwarder(
-        extensionIframeManager.sendActionExecuteToExtension.bind(extensionIframeManager)
-      );
-
       await performanceService.init();
 
       if (!settingsService.isInitialized()) {
@@ -753,17 +736,66 @@ export class ExtensionManager implements IExtensionManager {
   }
 }
 
-const extensionManagerInstance = new ExtensionManager();
+// Lazy singleton. Eagerly instantiating at module body (the old pattern)
+// coupled ExtensionManager's constructor — which references actionService,
+// searchOrchestrator, etc. — to module-load order. When the Settings webview
+// entered the module graph via the components barrel, actionService was still
+// mid-loading by the time extensionManager's module ran its ctor, producing
+// a TDZ crash ("Cannot access 'component' before initialization") that rendered
+// a white screen.
+//
+// By deferring `new ExtensionManager()` to the first property access via a
+// Proxy, the module body does nothing beyond defining the class. The ctor runs
+// only after every transitive dependency has finished loading, so no cycle
+// can exist at module-load time. All 18+ consumers of `extensionManager` /
+// the default export continue to work unchanged — the Proxy transparently
+// delegates every property read, write, and method call to the real instance.
+let _instance: ExtensionManager | null = null;
+function getInstance(): ExtensionManager {
+    if (!_instance) _instance = new ExtensionManager();
+    return _instance;
+}
+
+const lazyExtensionManager = new Proxy({} as ExtensionManager, {
+    get(_target, prop) {
+        return Reflect.get(getInstance(), prop);
+    },
+    set(_target, prop, value) {
+        return Reflect.set(getInstance(), prop, value);
+    },
+    has(_target, prop) {
+        return Reflect.has(getInstance(), prop);
+    },
+    getPrototypeOf() {
+        return Reflect.getPrototypeOf(getInstance());
+    },
+    // Tools like vi.spyOn / Object.defineProperty reflect on / rewrite property
+    // descriptors. Without these traps, they would see the empty Proxy target
+    // instead of the real instance.
+    getOwnPropertyDescriptor(_target, prop) {
+        const instance = getInstance();
+        return (
+            Object.getOwnPropertyDescriptor(instance, prop) ??
+            Object.getOwnPropertyDescriptor(Object.getPrototypeOf(instance), prop)
+        );
+    },
+    defineProperty(_target, prop, descriptor) {
+        return Reflect.defineProperty(getInstance(), prop, descriptor);
+    },
+    ownKeys() {
+        return Reflect.ownKeys(getInstance());
+    },
+});
 
 // Compatibility for isReady export
 export const isReady = {
     get subscribe() {
         return (fn: (v: boolean) => void) => {
-            fn(extensionManagerInstance.isReady);
+            fn(lazyExtensionManager.isReady);
             return () => {};
         };
     }
 };
 
-export const extensionManager = extensionManagerInstance;
-export default extensionManagerInstance;
+export const extensionManager = lazyExtensionManager;
+export default lazyExtensionManager;

--- a/src/services/extension/extensionManager.svelte.ts
+++ b/src/services/extension/extensionManager.svelte.ts
@@ -23,7 +23,12 @@ import { contextModeService } from "../context/contextModeService.svelte";
 import { extensionLoaderService } from "../extensionLoaderService"; // Import the new loader service (correct path)
 import { NotificationService } from "../notification/notificationService";
 import { ClipboardHistoryService } from "../clipboard/clipboardHistoryService";
-import { actionService } from "../action/actionService.svelte";
+// actionService is imported lazily in init() to break a module-load cycle:
+// actionService → searchOrchestrator → appInitializer → extensionManager →
+// actionService. Eagerly importing it here caused a TDZ crash when the
+// graph was entered from the Settings webview (via the components barrel →
+// ActionListPopup). Do not re-add the eager import.
+import type { ActionService } from "../action/actionService.svelte";
 import { statusBarService } from "../statusBar/statusBarService.svelte";
 import { entitlementService } from '../auth/entitlementService.svelte';
 import { feedbackService } from "../feedback/feedbackService.svelte";
@@ -126,7 +131,8 @@ export class ExtensionManager implements IExtensionManager {
       'NotificationService': new NotificationService(),
       'ClipboardHistoryService': ClipboardHistoryService.getInstance(),
       'CommandService': commandService,
-      'ActionService': actionService,
+      // 'ActionService' is wired up in init() via dynamic import to avoid
+      // a module-load cycle. See top of file.
       'SettingsService': {
         get: async (section: string, key: string) => {
           const settings = settingsService.getSettings();
@@ -160,7 +166,8 @@ export class ExtensionManager implements IExtensionManager {
 
 
     extensionIframeManager.init(viewManager);
-    actionService.setExtensionForwarder(extensionIframeManager.sendActionExecuteToExtension.bind(extensionIframeManager));
+    // actionService.setExtensionForwarder(...) is called in init() after the
+    // dynamic import of actionService resolves. See top of file for rationale.
     
     // (Removed: legacy settings-broadcast path that was used exclusively by
     // the Calculator built-in to pick up refreshInterval changes. Calculator
@@ -192,6 +199,16 @@ export class ExtensionManager implements IExtensionManager {
     }
     logService.custom("🔄 Initializing extension manager...", "EXTN", "blue");
     try {
+      // Wire up actionService lazily to avoid the module-load cycle documented
+      // at the top of this file. By now actionService's module has finished
+      // loading, so we can safely import it, register it in the service
+      // registry for IPC dispatch, and hand it the iframe-action forwarder.
+      const { actionService } = await import("../action/actionService.svelte");
+      this.serviceRegistry['ActionService'] = actionService;
+      actionService.setExtensionForwarder(
+        extensionIframeManager.sendActionExecuteToExtension.bind(extensionIframeManager)
+      );
+
       await performanceService.init();
 
       if (!settingsService.isInitialized()) {

--- a/src/services/extension/extensionManager.test.ts
+++ b/src/services/extension/extensionManager.test.ts
@@ -199,7 +199,10 @@ describe('ExtensionManager Characterization Tests', () => {
       const stateMod = await import('./extensionStateManager.svelte');
       extensionManager = mod.default;
       extensionStateManager = stateMod.extensionStateManager;
-      // Capture before clearAllMocks wipes mock call history
+      // Force the lazy Proxy singleton to instantiate by touching a property,
+      // then capture the setExtensionForwarder call count the ctor produced
+      // before clearAllMocks below wipes mock history.
+      void extensionManager.initialized;
       actionForwarderCalledCount = vi.mocked(actionService.setExtensionForwarder).mock.calls.length;
     }
 
@@ -224,12 +227,12 @@ describe('ExtensionManager Characterization Tests', () => {
       expect(extensionManager).toBeDefined()
     })
 
-    it('does not call setExtensionForwarder at construction time (wired lazily in init)', () => {
-      // setExtensionForwarder is now called inside init() via a dynamic import,
-      // not in the constructor. This keeps the constructor free of the
-      // actionService eager import that caused the Settings-window TDZ cycle.
-      // The count captured before clearAllMocks reflects calls during module load only.
-      expect(actionForwarderCalledCount).toBe(0)
+    it('registers the action forwarder', () => {
+      // The ctor wires the iframe-action forwarder into actionService. With
+      // the lazy Proxy singleton, the ctor fires on first property access
+      // (see beforeEach above) — hence the count captured there must be
+      // non-zero.
+      expect(actionForwarderCalledCount).toBeGreaterThan(0)
     })
   })
 
@@ -237,13 +240,6 @@ describe('ExtensionManager Characterization Tests', () => {
     it('returns true on successful initialization', async () => {
       const result = await extensionManager.init()
       expect(result).toBe(true)
-    })
-
-    it('wires up the action forwarder via dynamic import during init()', async () => {
-      await extensionManager.init()
-      // setExtensionForwarder must be called once inside init() — this is the
-      // lazy-wiring introduced to break the actionService module-load cycle.
-      expect(actionService.setExtensionForwarder).toHaveBeenCalledTimes(1)
     })
 
     it('returns false on error', async () => {

--- a/src/services/extension/extensionManager.test.ts
+++ b/src/services/extension/extensionManager.test.ts
@@ -224,9 +224,12 @@ describe('ExtensionManager Characterization Tests', () => {
       expect(extensionManager).toBeDefined()
     })
 
-    it('registers the action forwarder', () => {
-      // It should have been called at least once during module load
-      expect(actionForwarderCalledCount).toBeGreaterThan(0)
+    it('does not call setExtensionForwarder at construction time (wired lazily in init)', () => {
+      // setExtensionForwarder is now called inside init() via a dynamic import,
+      // not in the constructor. This keeps the constructor free of the
+      // actionService eager import that caused the Settings-window TDZ cycle.
+      // The count captured before clearAllMocks reflects calls during module load only.
+      expect(actionForwarderCalledCount).toBe(0)
     })
   })
 
@@ -234,6 +237,13 @@ describe('ExtensionManager Characterization Tests', () => {
     it('returns true on successful initialization', async () => {
       const result = await extensionManager.init()
       expect(result).toBe(true)
+    })
+
+    it('wires up the action forwarder via dynamic import during init()', async () => {
+      await extensionManager.init()
+      // setExtensionForwarder must be called once inside init() — this is the
+      // lazy-wiring introduced to break the actionService module-load cycle.
+      expect(actionService.setExtensionForwarder).toHaveBeenCalledTimes(1)
     })
 
     it('returns false on error', async () => {


### PR DESCRIPTION
Eager `const extensionManagerInstance = new ExtensionManager()` at module
body coupled the ctor — which references actionService, searchOrchestrator,
and others — to module-load order. When the Settings webview entered the
module graph via the components barrel (→ ActionListPopup → actionService →
searchOrchestrator → appInitializer → extensionManager), the ctor ran
while actionService was still mid-loading, producing a TDZ crash with a
white screen.

Structural fix: replace the eager instantiation with a lazy Proxy singleton.
Module load is now side-effect-free; the ctor fires only on first property
access, by which point every transitive dependency has fully loaded. No
cycle edge needs to be broken — the cycle is structurally impossible at
module-load time.

Also converts four self-referential barrel imports (ExtensionDetailPanel,
SettingsTopBar, ActionListPopup, SearchResultsArea) to direct imports —
same TDZ-bomb pattern, caught preventively during diagnosis.

Regression test guards the structural invariant: no top-level
`new ExtensionManager()` in extensionManager.svelte.ts.