### PR TITLE
feat: add user toggle to gate extension actions on main launcher

### DIFF
--- a/src/routes/settings/settingsHandlers.svelte.ts
+++ b/src/routes/settings/settingsHandlers.svelte.ts
@@ -39,6 +39,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
     searchSystemPreferences: true,
     fuzzySearch: true,
     enableExtensionSearch: false,
+    allowExtensionActions: false,
     additionalScanPaths: [],
   },
   shortcut: {
@@ -382,6 +383,20 @@ export class SettingsHandler {
         this.saveMessage = '';
         this.saveError = false;
       }, 5000);
+    }
+  }
+
+  async handleExtensionActionsToggle() {
+    try {
+      const success = await settingsService.updateSettings('search', {
+        allowExtensionActions: !this.settings.search.allowExtensionActions,
+      });
+      if (!success) throw new Error('Failed to update extension actions setting');
+    } catch (error) {
+      logService.error(`Failed to update extension actions setting: ${error}`);
+      this.saveError = true;
+      this.saveMessage = 'Failed to update extension actions setting';
+      setTimeout(() => { this.saveMessage = ''; this.saveError = false; }, 3000);
     }
   }
 

--- a/src/routes/settings/tabs/AdvancedTab.svelte
+++ b/src/routes/settings/tabs/AdvancedTab.svelte
@@ -67,6 +67,17 @@
   </SettingsFormRow>
 
   <SettingsFormRow
+    label="Extension Actions"
+    separator
+    description="Allow extensions to contribute actions to the main launcher's action panel (⌘K). When off, only Asyar's built-in actions appear."
+  >
+    <Toggle
+      checked={handler.settings.search.allowExtensionActions}
+      onchange={() => handler.handleExtensionActionsToggle()}
+    />
+  </SettingsFormRow>
+
+  <SettingsFormRow
     label="Escape Key"
     separator
     description="What happens when you press Escape while a view is open"

--- a/src/services/extension/ExtensionLoader.test.ts
+++ b/src/services/extension/ExtensionLoader.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ExtensionLoader } from './ExtensionLoader'
+import { ActionContext } from 'asyar-sdk'
+
+// ---------- hoisted mocks ----------
+
+const mockSearchOrchestrator = vi.hoisted(() => ({ items: [] as any[] }))
+vi.mock('../search/searchOrchestrator.svelte', () => ({
+  searchOrchestrator: mockSearchOrchestrator,
+}))
+
+const mockSearchStores = vi.hoisted(() => ({ selectedIndex: -1 }))
+vi.mock('../search/stores/search.svelte', () => ({
+  searchStores: mockSearchStores,
+}))
+
+const mockSettingsGetSettings = vi.hoisted(() =>
+  vi.fn().mockReturnValue({ search: { enableExtensionSearch: false, allowExtensionActions: true } })
+)
+vi.mock('../settings/settingsService.svelte', () => ({
+  settingsService: {
+    getSettings: mockSettingsGetSettings,
+    isInitialized: vi.fn().mockReturnValue(true),
+    init: vi.fn(),
+    subscribe: vi.fn().mockReturnValue(() => {}),
+    isExtensionEnabled: vi.fn().mockReturnValue(true),
+    updateSettings: vi.fn(),
+    updateExtensionState: vi.fn(),
+    removeExtensionState: vi.fn(),
+  },
+}))
+
+// Capture calls to registerAction so we can inspect visible() callbacks
+const registeredActions: any[] = []
+vi.mock('../action/actionService.svelte', () => ({
+  actionService: {
+    registerAction: vi.fn((action: any) => { registeredActions.push(action) }),
+    getAllActions: vi.fn().mockReturnValue([]),
+    unregisterAction: vi.fn(),
+    clearActionsForExtension: vi.fn(),
+    setContext: vi.fn(),
+    setActionExecutor: vi.fn(),
+    refreshFiltered: vi.fn(),
+    filteredActions: [],
+  },
+}))
+
+vi.mock('../log/logService', () => ({
+  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('../extensionLoaderService', () => ({
+  extensionLoaderService: {
+    loadAllExtensions: vi.fn().mockResolvedValue(new Map()),
+    loadSingleExtension: vi.fn().mockResolvedValue(null),
+  },
+}))
+vi.mock('../performance/performanceService.svelte', () => ({
+  performanceService: {
+    init: vi.fn(),
+    startTiming: vi.fn(),
+    stopTiming: vi.fn().mockReturnValue({ duration: 0 }),
+    trackExtensionLoadStart: vi.fn(),
+    trackExtensionLoadEnd: vi.fn(),
+  },
+}))
+vi.mock('../envService', () => ({ envService: { isDev: vi.fn().mockReturnValue(false) } }))
+vi.mock('../../lib/ipc/commands', () => ({
+  syncSearchIndex: vi.fn().mockResolvedValue(undefined),
+  syncCommandIndex: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('./commandService.svelte', () => ({
+  commandService: {
+    setShortCommandId: vi.fn(),
+    registerCommandObjectId: vi.fn(),
+    getLiveSubtitle: vi.fn(),
+    liveSubtitles: {},
+  },
+}))
+vi.mock('./extensionIframeManager.svelte', () => ({
+  extensionIframeManager: { getIframeRef: vi.fn() },
+}))
+vi.mock('./extensionPreferencesService.svelte', () => ({
+  extensionPreferencesService: {
+    preLoadPreferences: vi.fn().mockResolvedValue(undefined),
+    getCurrentPreferences: vi.fn().mockReturnValue({}),
+  },
+}))
+
+// ---------- helpers ----------
+
+function makeManifest(extensionId: string, actions: any[] = [], commands: any[] = []) {
+  return {
+    id: extensionId,
+    name: extensionId,
+    version: '1.0.0',
+    description: '',
+    type: 'view' as const,
+    permissions: [],
+    actions,
+    commands,
+  }
+}
+
+function makeCommand(cmdId: string, actions: any[] = []) {
+  return { id: cmdId, name: cmdId, description: '', trigger: cmdId, actions }
+}
+
+function makeLoader(loadedCommands: { cmd: any; manifest: any; isBuiltIn: boolean }[]) {
+  const loader = new ExtensionLoader({} as any, {} as any)
+  ;(loader as any).allLoadedCommands = loadedCommands
+  return loader
+}
+
+// ---------- tests ----------
+
+describe('ExtensionLoader.registerManifestActions', () => {
+  beforeEach(() => {
+    registeredActions.length = 0
+    vi.clearAllMocks()
+    // Reset getSettings to default (allowExtensionActions = true)
+    mockSettingsGetSettings.mockReturnValue({
+      search: { enableExtensionSearch: false, allowExtensionActions: true },
+    })
+  })
+
+  describe('when allowExtensionActions = true', () => {
+    it('registers extension-level actions with a visible() that returns true when the correct extension command is selected', () => {
+      const manifest = makeManifest('test-ext', [{ id: 'open', title: 'Open', category: 'Test' }])
+      const cmd = makeCommand('do-thing')
+      const loader = makeLoader([{ cmd, manifest, isBuiltIn: true }])
+
+      loader.registerManifestActions()
+
+      const action = registeredActions.find(a => a.id === 'act_test-ext_open')
+      expect(action).toBeDefined()
+      expect(action.extensionId).toBe('test-ext')
+      expect(action.context).toBe(ActionContext.CORE)
+
+      // Simulate item selected = command from this extension
+      mockSearchStores.selectedIndex = 0
+      mockSearchOrchestrator.items = [{ type: 'command', extensionId: 'test-ext', objectId: 'cmd_test-ext_do-thing' }]
+      expect(action.visible()).toBe(true)
+    })
+
+    it('extension-level visible() returns false when a different extension is selected', () => {
+      const manifest = makeManifest('test-ext', [{ id: 'open', title: 'Open' }])
+      const loader = makeLoader([{ cmd: makeCommand('do-thing'), manifest, isBuiltIn: true }])
+
+      loader.registerManifestActions()
+
+      const action = registeredActions.find(a => a.id === 'act_test-ext_open')
+      mockSearchStores.selectedIndex = 0
+      mockSearchOrchestrator.items = [{ type: 'command', extensionId: 'other-ext', objectId: 'cmd_other-ext_cmd' }]
+      expect(action.visible()).toBe(false)
+    })
+
+    it('registers command-level actions with a visible() that returns true only for that command', () => {
+      const cmdActions = [{ id: 'copy', title: 'Copy Result' }]
+      const manifest = makeManifest('test-ext', [], [])
+      const cmd = makeCommand('search-cmd', cmdActions)
+      const loader = makeLoader([{ cmd, manifest, isBuiltIn: true }])
+
+      loader.registerManifestActions()
+
+      const action = registeredActions.find(a => a.id === 'act_test-ext_copy')
+      expect(action).toBeDefined()
+
+      // Exact command selected
+      mockSearchStores.selectedIndex = 0
+      mockSearchOrchestrator.items = [{ objectId: 'cmd_test-ext_search-cmd' }]
+      expect(action.visible()).toBe(true)
+
+      // Different command selected
+      mockSearchOrchestrator.items = [{ objectId: 'cmd_test-ext_other-cmd' }]
+      expect(action.visible()).toBe(false)
+    })
+
+    it('registers extension-level actions once per extension even with multiple commands', () => {
+      const manifest = makeManifest('multi-ext', [{ id: 'settings', title: 'Settings' }])
+      const cmd1 = makeCommand('cmd-a')
+      const cmd2 = makeCommand('cmd-b')
+      const loader = makeLoader([
+        { cmd: cmd1, manifest, isBuiltIn: true },
+        { cmd: cmd2, manifest, isBuiltIn: true },
+      ])
+
+      loader.registerManifestActions()
+
+      const settingsActions = registeredActions.filter(a => a.id === 'act_multi-ext_settings')
+      expect(settingsActions).toHaveLength(1)
+    })
+  })
+
+  describe('when allowExtensionActions = false', () => {
+    beforeEach(() => {
+      mockSettingsGetSettings.mockReturnValue({
+        search: { enableExtensionSearch: false, allowExtensionActions: false },
+      })
+    })
+
+    it('extension-level action visible() returns false even when the correct command is selected', () => {
+      const manifest = makeManifest('test-ext', [{ id: 'open', title: 'Open' }])
+      const loader = makeLoader([{ cmd: makeCommand('do-thing'), manifest, isBuiltIn: true }])
+
+      loader.registerManifestActions()
+
+      const action = registeredActions.find(a => a.id === 'act_test-ext_open')
+      expect(action).toBeDefined()
+
+      mockSearchStores.selectedIndex = 0
+      mockSearchOrchestrator.items = [{ type: 'command', extensionId: 'test-ext', objectId: 'cmd_test-ext_do-thing' }]
+      // Setting is OFF → must return false regardless of selection
+      expect(action.visible()).toBe(false)
+    })
+
+    it('command-level action visible() returns false even when the exact command is selected', () => {
+      const cmdActions = [{ id: 'copy', title: 'Copy Result' }]
+      const loader = makeLoader([
+        { cmd: makeCommand('search-cmd', cmdActions), manifest: makeManifest('test-ext'), isBuiltIn: true },
+      ])
+
+      loader.registerManifestActions()
+
+      const action = registeredActions.find(a => a.id === 'act_test-ext_copy')
+      expect(action).toBeDefined()
+
+      mockSearchStores.selectedIndex = 0
+      mockSearchOrchestrator.items = [{ objectId: 'cmd_test-ext_search-cmd' }]
+      // Setting is OFF → must return false
+      expect(action.visible()).toBe(false)
+    })
+  })
+
+  describe('when allowExtensionActions is undefined (older settings.dat)', () => {
+    beforeEach(() => {
+      // Simulate missing key (undefined) — should be treated as ON
+      mockSettingsGetSettings.mockReturnValue({
+        search: { enableExtensionSearch: false },
+      })
+    })
+
+    it('extension-level action visible() returns true (undefined treated as ON via !== false)', () => {
+      const manifest = makeManifest('test-ext', [{ id: 'open', title: 'Open' }])
+      const loader = makeLoader([{ cmd: makeCommand('do-thing'), manifest, isBuiltIn: true }])
+
+      loader.registerManifestActions()
+
+      const action = registeredActions.find(a => a.id === 'act_test-ext_open')
+      mockSearchStores.selectedIndex = 0
+      mockSearchOrchestrator.items = [{ type: 'command', extensionId: 'test-ext', objectId: 'cmd_test-ext_do-thing' }]
+      expect(action.visible()).toBe(true)
+    })
+  })
+})

--- a/src/services/extension/ExtensionLoader.ts
+++ b/src/services/extension/ExtensionLoader.ts
@@ -318,6 +318,7 @@ export class ExtensionLoader {
             extensionId,
             context: ActionContext.CORE,
             visible: () => {
+              if (settingsService.getSettings().search.allowExtensionActions === false) return false;
               const idx = searchStores.selectedIndex;
               if (idx < 0) return false;
               const item = searchOrchestrator.items[idx];
@@ -344,6 +345,7 @@ export class ExtensionLoader {
             extensionId,
             context: ActionContext.CORE,
             visible: () => {
+              if (settingsService.getSettings().search.allowExtensionActions === false) return false;
               const idx = searchStores.selectedIndex;
               if (idx < 0) return false;
               const item = searchOrchestrator.items[idx];

--- a/src/services/extension/extensionManager.cycle.test.ts
+++ b/src/services/extension/extensionManager.cycle.test.ts
@@ -75,7 +75,7 @@ vi.mock('../settings/settingsService.svelte', () => ({
     init: vi.fn(),
     subscribe: vi.fn().mockReturnValue(() => {}),
     isExtensionEnabled: vi.fn().mockReturnValue(true),
-    getSettings: vi.fn().mockReturnValue({ search: { enableExtensionSearch: false } }),
+    getSettings: vi.fn().mockReturnValue({ search: { enableExtensionSearch: false, allowExtensionActions: true } }),
     updateSettings: vi.fn(),
     updateExtensionState: vi.fn(),
     removeExtensionState: vi.fn(),

--- a/src/services/extension/extensionManager.test.ts
+++ b/src/services/extension/extensionManager.test.ts
@@ -61,7 +61,7 @@ vi.mock('../settings/settingsService.svelte', () => ({
     subscribe: vi.fn().mockReturnValue(() => {}),
     isExtensionEnabled: vi.fn().mockReturnValue(true),
     getSettings: vi.fn().mockReturnValue({
-      search: { enableExtensionSearch: false }
+      search: { enableExtensionSearch: false, allowExtensionActions: true }
     }),
     updateSettings: vi.fn(),
     updateExtensionState: vi.fn(),

--- a/src/services/settings/settingsService.svelte.ts
+++ b/src/services/settings/settingsService.svelte.ts
@@ -19,6 +19,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     searchSystemPreferences: true,
     fuzzySearch: true,
     enableExtensionSearch: false, // Off by default
+    allowExtensionActions: false,
     additionalScanPaths: [],
   },
   shortcut: {

--- a/src/services/settings/settingsService.test.ts
+++ b/src/services/settings/settingsService.test.ts
@@ -30,6 +30,7 @@ const DEFAULT: AppSettings = {
     searchSystemPreferences: true,
     fuzzySearch: true,
     enableExtensionSearch: false,
+    allowExtensionActions: false,
     additionalScanPaths: [],
   },
   shortcut: { modifier: 'Alt', key: 'Space' },

--- a/src/services/settings/types/AppSettingsType.ts
+++ b/src/services/settings/types/AppSettingsType.ts
@@ -15,6 +15,7 @@ export interface AppSettings {
     searchSystemPreferences: boolean;
     fuzzySearch: boolean;
     enableExtensionSearch: boolean;
+    allowExtensionActions: boolean;
     additionalScanPaths: string[];
   };
   shortcut: {


### PR DESCRIPTION
Extensions can now contribute manifest-declared actions to the main
launcher's ⌘K panel when one of their commands is selected. A new
"Extension Actions" toggle in Settings → Advanced lets users disable
this and keep the panel clean with only Asyar's built-in actions.
Disabled by default.