### PR TITLE
feat(system-events): implement Linux and Windows watchers

### DIFF
--- a/docs/reference/sdk/system-events.md
+++ b/docs/reference/sdk/system-events.md
@@ -82,32 +82,60 @@ each get their own host subscription.
 
 | Event                    | macOS                                                  | Linux | Windows |
 |--------------------------|--------------------------------------------------------|-------|---------|
-| `sleep` / `wake`         | `IORegisterForSystemPower` on a CFRunLoop thread       | *not yet implemented — logind PrepareForSleep signal planned* | *not yet implemented — WM_POWERBROADCAST planned* |
-| `lid-open` / `lid-close` | Poll `AppleClamshellState` from IORegistry every 2s    | *not yet implemented — UPower LidIsClosed planned* | *not yet implemented — GUID_LIDSWITCH_STATE_CHANGE planned* |
-| `battery-level-changed`  | Poll `IOPSCopyPowerSourcesInfo` every 30s, dispatch on change | *not yet implemented — UPower PropertiesChanged planned* | *not yet implemented — GUID_BATTERY_PERCENTAGE_REMAINING planned* |
-| `power-source-changed`   | Poll `IOPSCopyPowerSourcesInfo` every 30s, dispatch on change | *not yet implemented — UPower PropertiesChanged planned* | *not yet implemented — GUID_ACDC_POWER_SOURCE planned* |
+| `sleep` / `wake`         | `IORegisterForSystemPower` on a CFRunLoop thread       | logind `org.freedesktop.login1.Manager.PrepareForSleep(bool)` signal | `WM_POWERBROADCAST` — `PBT_APMSUSPEND` / `PBT_APMRESUME*` |
+| `lid-open` / `lid-close` | Poll `AppleClamshellState` from IORegistry every 2s    | UPower `LidIsClosed` property via DBus `PropertiesChanged` | `GUID_LIDSWITCH_STATE_CHANGE` via `RegisterPowerSettingNotification` |
+| `battery-level-changed`  | Poll `IOPSCopyPowerSourcesInfo` every 30s, dispatch on change | UPower `Percentage` property on the Battery device via `PropertiesChanged` (deduped at integer granularity) | `GUID_BATTERY_PERCENTAGE_REMAINING` via `RegisterPowerSettingNotification` (deduped at integer granularity) |
+| `power-source-changed`   | Poll `IOPSCopyPowerSourcesInfo` every 30s, dispatch on change | UPower `OnBattery` property via `PropertiesChanged` | `GUID_ACDC_POWER_SOURCE` via `RegisterPowerSettingNotification` |
 
-On Linux and Windows the watcher currently logs a warning at startup and
-then stays idle — subscriptions still succeed, they just never fire. Do
-**not** assume a subscription guarantees callback delivery; treat the
-service as best-effort, and design your feature to degrade gracefully when
-no events arrive.
+All three platforms dispatch into the same `SystemEventsHub` from a dedicated
+watcher thread so the Tauri runtime stays free of blocking system calls.
+
+#### Per-source degradation
+
+On Linux each DBus source (logind, UPower root, UPower display battery)
+runs on its own blocking thread with its own `zbus::blocking::Connection`.
+If any single source fails to start — the machine has no UPower (headless
+container, minimal distro), no battery device (desktop PC), or the lid
+switch isn't exposed — the watcher logs a single warning for that source
+and keeps the others running. Sleep/wake via logind still fires even when
+UPower is absent; lid events still fire even when no battery device is
+present.
+
+On Windows the four `RegisterPowerSettingNotification` registrations are
+independent: any single registration failure logs a warning and leaves the
+other sources wired up. `WM_POWERBROADCAST` sleep/wake events continue to
+fire regardless — they are delivered by the OS to every message-pump
+window and don't require the power-setting registrations.
+
+Despite the per-platform source coverage, treat the service as best-effort
+at the call site. A machine without a battery will never emit
+`battery-level-changed`; a desktop without a lid switch will never emit
+`lid-*`. Design each `on*` subscription so the feature degrades gracefully
+when no events arrive.
 
 ### Edge cases
 
 - **Desktops without a battery** (most iMacs, Mac Studios, desktop PCs):
-  `IOPSCopyPowerSourcesList` returns an empty list on macOS; no battery or
-  power-source events ever fire. Treat the absence of events as "power
-  state unknown."
-- **Debouncing battery ticks:** The macOS poller dispatches only when the
-  percent changes. Expect a burst only during discharge/recharge; a fully
-  charged machine can go hours without a single event.
-- **`lid-open` / `lid-close` on desktops** never fires. `AppleClamshellState`
-  is only present on laptops.
-- **`sleep` callback is not a lifecycle hook.** macOS gives apps only a few
-  seconds after `kIOMessageSystemWillSleep` before it acknowledges and
-  powers down. Keep the callback fast — flush critical state, don't start
-  new work.
+  none of the three platforms will ever fire `battery-level-changed` or
+  `power-source-changed`. On macOS `IOPSCopyPowerSourcesList` returns an
+  empty list; on Linux UPower exposes no `Type == 2` device; on Windows
+  `RegisterPowerSettingNotification` registers successfully but the OS
+  never delivers `GUID_BATTERY_PERCENTAGE_REMAINING` / `GUID_ACDC_POWER_SOURCE`.
+  Treat the absence of events as "power state unknown."
+- **Debouncing battery ticks:** All three platforms dedupe at integer
+  percent granularity. macOS polls every 30s and only dispatches on change;
+  Linux rounds fractional UPower updates to an integer before comparing;
+  Windows stores the last-seen percent per window and suppresses repeats.
+  Expect a burst only during discharge/recharge; a fully charged machine
+  can go hours without a single event.
+- **`lid-open` / `lid-close` on desktops** never fires. The clamshell key
+  is absent on macOS IORegistry; UPower has no `LidIsClosed` on desktops;
+  Windows' `GUID_LIDSWITCH_STATE_CHANGE` simply never fires.
+- **`sleep` callback is not a lifecycle hook.** On macOS you get only a
+  few seconds after `kIOMessageSystemWillSleep` before the system
+  acknowledges and powers down. logind's `PrepareForSleep(true)` and
+  Windows' `PBT_APMSUSPEND` arrive with similarly tight deadlines. Keep
+  the callback fast — flush critical state, don't start new work.
 - **Permission scope.** `systemEvents:read` is a single permission that
   unlocks all six event kinds. There's no per-kind granularity.
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -104,6 +104,7 @@ windows = { version = "0.61", features = [
     "Win32_UI_Accessibility",
     "Win32_System_Threading",
     "Win32_System_Power",
+    "Win32_System_LibraryLoader",
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src-tauri/src/system_events/linux.rs
+++ b/src-tauri/src/system_events/linux.rs
@@ -1,36 +1,458 @@
-//! Linux system-events watcher (zbus / dbus).
+//! Linux system-events watcher (zbus / DBus).
 //!
-//! Currently a stub — sleep/wake/battery/lid detection on Linux requires
-//! running each source on its own blocking thread and is non-trivial to
-//! wire correctly against the wide variety of desktop environments. The
-//! hub stays running; events simply never fire. Extensions degrade
-//! gracefully (no callback).
+//! Three DBus sources, each running on a dedicated blocking thread so the
+//! main async runtime stays free of `zbus::blocking::Connection`:
+//!
+//! - `org.freedesktop.login1.Manager.PrepareForSleep(bool)` — fires with
+//!   `true` just before sleep, `false` right after wake. Maps to
+//!   [`SystemEvent::Sleep`] / [`SystemEvent::Wake`].
+//! - `org.freedesktop.UPower` properties `LidIsClosed` and `OnBattery` —
+//!   watched via `PropertiesChanged` on the UPower root object. Transitions
+//!   produce [`SystemEvent::LidOpen`] / [`SystemEvent::LidClose`] and
+//!   [`SystemEvent::PowerSourceChanged`].
+//! - `org.freedesktop.UPower.Device` for the display battery (the device
+//!   whose `Type` is `2`, i.e. "Battery") — `Percentage` watched via
+//!   `PropertiesChanged`. Integer-percent changes produce
+//!   [`SystemEvent::BatteryLevelChanged`]; fractional noise is suppressed.
+//!
+//! Pure parser helpers ([`parse_lid_transition`], [`parse_on_battery_change`],
+//! [`parse_percent_change`]) are compiled on every platform so they can be
+//! unit-tested from the macOS dev machine. The zbus-using watcher glue is
+//! gated behind `#[cfg(target_os = "linux")]`.
+//!
+//! Graceful degradation: each source is started independently. A missing
+//! logind / UPower / device-enumeration step logs a single warning and is
+//! skipped — the other sources keep running.
 
-use crate::error::AppError;
-use crate::system_events::{SystemEventsHub, SystemEventsWatcher};
-use log::warn;
-use std::sync::Arc;
+use crate::system_events::SystemEvent;
 
-pub struct LinuxWatcher;
-
-impl LinuxWatcher {
-    pub fn new() -> Self {
-        Self
+/// Map a lid-closed boolean transition to a [`SystemEvent`].
+///
+/// - `(false -> true)` = lid just closed → `LidClose`
+/// - `(true -> false)` = lid just opened → `LidOpen`
+/// - No change → `None`
+pub fn parse_lid_transition(old: bool, new: bool) -> Option<SystemEvent> {
+    match (old, new) {
+        (false, true) => Some(SystemEvent::LidClose),
+        (true, false) => Some(SystemEvent::LidOpen),
+        _ => None,
     }
 }
 
-impl Default for LinuxWatcher {
-    fn default() -> Self {
-        Self::new()
+/// Map an `OnBattery` boolean transition to a [`SystemEvent`].
+///
+/// Returns `None` when the new value equals the last-observed one. The first
+/// observation (`old = None`) always produces an event so subscribers know
+/// the initial power source.
+pub fn parse_on_battery_change(old: Option<bool>, new: bool) -> Option<SystemEvent> {
+    if old == Some(new) {
+        None
+    } else {
+        Some(SystemEvent::PowerSourceChanged { on_battery: new })
     }
 }
 
-impl SystemEventsWatcher for LinuxWatcher {
-    fn start(&self, _hub: Arc<SystemEventsHub>) -> Result<(), AppError> {
-        warn!(
-            "[system_events/linux] watcher not yet implemented — \
-             sleep/wake/lid/battery events will not fire on this platform"
-        );
+/// Map a fractional battery percentage to a [`SystemEvent`], deduplicating
+/// at integer granularity.
+///
+/// UPower reports `Percentage` as an `f64` that can update on fractional
+/// boundaries (e.g. 42.1 → 42.2). We round to the nearest integer, clamp to
+/// `0..=100`, and only emit when that integer differs from the last-observed
+/// value.
+pub fn parse_percent_change(old: Option<u8>, new_fractional: f64) -> Option<SystemEvent> {
+    let clamped = new_fractional.round().clamp(0.0, 100.0) as u8;
+    if old == Some(clamped) {
+        None
+    } else {
+        Some(SystemEvent::BatteryLevelChanged { percent: clamped })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Linux-only watcher glue
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "linux")]
+pub use watcher::LinuxWatcher;
+
+#[cfg(target_os = "linux")]
+mod watcher {
+    use super::{parse_lid_transition, parse_on_battery_change, parse_percent_change};
+    use crate::error::AppError;
+    use crate::system_events::{SystemEvent, SystemEventsHub, SystemEventsWatcher};
+    use log::{info, warn};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use zbus::blocking::{Connection, MessageIterator};
+    use zbus::zvariant::{OwnedObjectPath, OwnedValue};
+    use zbus::{proxy, MatchRule, MessageType};
+
+    pub struct LinuxWatcher;
+
+    impl LinuxWatcher {
+        pub fn new() -> Self {
+            Self
+        }
+    }
+
+    impl Default for LinuxWatcher {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl SystemEventsWatcher for LinuxWatcher {
+        fn start(&self, hub: Arc<SystemEventsHub>) -> Result<(), AppError> {
+            // Each source owns its own blocking connection + thread. Failure
+            // in any one source logs a warning and skips that source; the
+            // other sources still get their chance.
+            spawn_logind_thread(hub.clone());
+            spawn_upower_root_thread(hub.clone());
+            spawn_upower_device_thread(hub);
+            info!("[system_events/linux] watcher started");
+            Ok(())
+        }
+    }
+
+    // -- logind: PrepareForSleep --------------------------------------------
+
+    fn spawn_logind_thread(hub: Arc<SystemEventsHub>) {
+        std::thread::Builder::new()
+            .name("asyar-system-events-logind".into())
+            .spawn(move || {
+                if let Err(e) = run_logind_loop(hub) {
+                    warn!("[system_events/linux] logind source failed: {e}");
+                }
+            })
+            .ok();
+        // If the thread couldn't be spawned we silently skip — nothing to
+        // recover. Other sources still start.
+    }
+
+    fn run_logind_loop(hub: Arc<SystemEventsHub>) -> zbus::Result<()> {
+        let conn = Connection::system()?;
+        let rule = MatchRule::builder()
+            .msg_type(MessageType::Signal)
+            .sender("org.freedesktop.login1")?
+            .path("/org/freedesktop/login1")?
+            .interface("org.freedesktop.login1.Manager")?
+            .member("PrepareForSleep")?
+            .build();
+        let iter = MessageIterator::for_match_rule(rule, &conn, None)?;
+        for msg in iter {
+            let msg = match msg {
+                Ok(m) => m,
+                Err(e) => {
+                    warn!("[system_events/linux] logind stream error: {e}");
+                    continue;
+                }
+            };
+            if let Ok(entering_sleep) = msg.body().deserialize::<bool>() {
+                if entering_sleep {
+                    hub.dispatch(SystemEvent::Sleep);
+                } else {
+                    hub.dispatch(SystemEvent::Wake);
+                }
+            }
+        }
         Ok(())
+    }
+
+    // -- UPower root: LidIsClosed, OnBattery --------------------------------
+
+    #[proxy(
+        interface = "org.freedesktop.UPower",
+        default_service = "org.freedesktop.UPower",
+        default_path = "/org/freedesktop/UPower"
+    )]
+    trait UPowerRoot {
+        #[zbus(property)]
+        fn lid_is_closed(&self) -> zbus::Result<bool>;
+        #[zbus(property)]
+        fn on_battery(&self) -> zbus::Result<bool>;
+        fn enumerate_devices(&self) -> zbus::Result<Vec<OwnedObjectPath>>;
+    }
+
+    fn spawn_upower_root_thread(hub: Arc<SystemEventsHub>) {
+        std::thread::Builder::new()
+            .name("asyar-system-events-upower-root".into())
+            .spawn(move || {
+                if let Err(e) = run_upower_root_loop(hub) {
+                    warn!("[system_events/linux] UPower root source failed: {e}");
+                }
+            })
+            .ok();
+    }
+
+    fn run_upower_root_loop(hub: Arc<SystemEventsHub>) -> zbus::Result<()> {
+        let conn = Connection::system()?;
+        let proxy = UPowerRootProxyBlocking::new(&conn)?;
+
+        // Seed with current state so the first transition produces a correct
+        // event (PrepareForSleep doesn't need this; properties do).
+        let mut last_lid: Option<bool> = proxy.lid_is_closed().ok();
+        let mut last_on_battery: Option<bool> = proxy.on_battery().ok();
+
+        let rule = MatchRule::builder()
+            .msg_type(MessageType::Signal)
+            .sender("org.freedesktop.UPower")?
+            .path("/org/freedesktop/UPower")?
+            .interface("org.freedesktop.DBus.Properties")?
+            .member("PropertiesChanged")?
+            .build();
+        let iter = MessageIterator::for_match_rule(rule, &conn, None)?;
+        for msg in iter {
+            let msg = match msg {
+                Ok(m) => m,
+                Err(e) => {
+                    warn!("[system_events/linux] UPower root stream error: {e}");
+                    continue;
+                }
+            };
+            let body = msg.body();
+            let (_iface, changed, _invalidated): (
+                String,
+                HashMap<String, OwnedValue>,
+                Vec<String>,
+            ) = match body.deserialize() {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+
+            if let Some(v) = changed.get("LidIsClosed") {
+                if let Ok(new_closed) = bool::try_from(v) {
+                    let prev = last_lid.unwrap_or(new_closed);
+                    if let Some(ev) = parse_lid_transition(prev, new_closed) {
+                        hub.dispatch(ev);
+                    }
+                    last_lid = Some(new_closed);
+                }
+            }
+
+            if let Some(v) = changed.get("OnBattery") {
+                if let Ok(new_on) = bool::try_from(v) {
+                    if let Some(ev) = parse_on_battery_change(last_on_battery, new_on) {
+                        hub.dispatch(ev);
+                    }
+                    last_on_battery = Some(new_on);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    // -- UPower display device: Percentage ----------------------------------
+
+    #[proxy(
+        interface = "org.freedesktop.UPower.Device",
+        default_service = "org.freedesktop.UPower"
+    )]
+    trait UPowerDevice {
+        #[zbus(property)]
+        fn type_(&self) -> zbus::Result<u32>;
+        #[zbus(property)]
+        fn percentage(&self) -> zbus::Result<f64>;
+    }
+
+    fn spawn_upower_device_thread(hub: Arc<SystemEventsHub>) {
+        std::thread::Builder::new()
+            .name("asyar-system-events-upower-device".into())
+            .spawn(move || {
+                if let Err(e) = run_upower_device_loop(hub) {
+                    warn!("[system_events/linux] UPower device source failed: {e}");
+                }
+            })
+            .ok();
+    }
+
+    fn run_upower_device_loop(hub: Arc<SystemEventsHub>) -> zbus::Result<()> {
+        let conn = Connection::system()?;
+        let root = UPowerRootProxyBlocking::new(&conn)?;
+        let devices = root.enumerate_devices()?;
+
+        // Pick the first Battery device (Type == 2).
+        let battery_path = devices.into_iter().find(|p| {
+            UPowerDeviceProxyBlocking::builder(&conn)
+                .path(p.as_str())
+                .and_then(|b| b.build())
+                .and_then(|proxy| proxy.type_())
+                .map(|t| t == 2)
+                .unwrap_or(false)
+        });
+        let Some(battery_path) = battery_path else {
+            warn!(
+                "[system_events/linux] no UPower Battery device found — \
+                 battery-level-changed events will not fire"
+            );
+            return Ok(());
+        };
+
+        let proxy = UPowerDeviceProxyBlocking::builder(&conn)
+            .path(battery_path.as_str())?
+            .build()?;
+        let mut last_percent: Option<u8> = proxy
+            .percentage()
+            .ok()
+            .map(|p: f64| p.round().clamp(0.0, 100.0) as u8);
+
+        let rule = MatchRule::builder()
+            .msg_type(MessageType::Signal)
+            .sender("org.freedesktop.UPower")?
+            .path(battery_path.as_str().to_owned())?
+            .interface("org.freedesktop.DBus.Properties")?
+            .member("PropertiesChanged")?
+            .build();
+        let iter = MessageIterator::for_match_rule(rule, &conn, None)?;
+        for msg in iter {
+            let msg = match msg {
+                Ok(m) => m,
+                Err(e) => {
+                    warn!("[system_events/linux] UPower device stream error: {e}");
+                    continue;
+                }
+            };
+            let body = msg.body();
+            let (_iface, changed, _invalidated): (
+                String,
+                HashMap<String, OwnedValue>,
+                Vec<String>,
+            ) = match body.deserialize() {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            if let Some(v) = changed.get("Percentage") {
+                if let Ok(pct) = f64::try_from(v) {
+                    if let Some(ev) = parse_percent_change(last_percent, pct) {
+                        if let SystemEvent::BatteryLevelChanged { percent } = ev {
+                            last_percent = Some(percent);
+                        }
+                        hub.dispatch(ev);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- parse_lid_transition ---------------------------------------------
+
+    #[test]
+    fn lid_open_to_closed_emits_lid_close() {
+        assert!(matches!(
+            parse_lid_transition(false, true),
+            Some(SystemEvent::LidClose)
+        ));
+    }
+
+    #[test]
+    fn lid_closed_to_open_emits_lid_open() {
+        assert!(matches!(
+            parse_lid_transition(true, false),
+            Some(SystemEvent::LidOpen)
+        ));
+    }
+
+    #[test]
+    fn lid_same_state_emits_nothing() {
+        assert!(parse_lid_transition(false, false).is_none());
+        assert!(parse_lid_transition(true, true).is_none());
+    }
+
+    // --- parse_on_battery_change ------------------------------------------
+
+    #[test]
+    fn on_battery_first_observation_always_emits() {
+        let ev = parse_on_battery_change(None, true).expect("first obs should emit");
+        assert!(matches!(
+            ev,
+            SystemEvent::PowerSourceChanged { on_battery: true }
+        ));
+        let ev = parse_on_battery_change(None, false).expect("first obs should emit");
+        assert!(matches!(
+            ev,
+            SystemEvent::PowerSourceChanged { on_battery: false }
+        ));
+    }
+
+    #[test]
+    fn on_battery_change_true_to_false_emits_not_on_battery() {
+        let ev = parse_on_battery_change(Some(true), false).unwrap();
+        assert!(matches!(
+            ev,
+            SystemEvent::PowerSourceChanged { on_battery: false }
+        ));
+    }
+
+    #[test]
+    fn on_battery_change_false_to_true_emits_on_battery() {
+        let ev = parse_on_battery_change(Some(false), true).unwrap();
+        assert!(matches!(
+            ev,
+            SystemEvent::PowerSourceChanged { on_battery: true }
+        ));
+    }
+
+    #[test]
+    fn on_battery_no_change_emits_nothing() {
+        assert!(parse_on_battery_change(Some(true), true).is_none());
+        assert!(parse_on_battery_change(Some(false), false).is_none());
+    }
+
+    // --- parse_percent_change ---------------------------------------------
+
+    #[test]
+    fn percent_first_observation_emits() {
+        let ev = parse_percent_change(None, 87.3).unwrap();
+        assert!(matches!(
+            ev,
+            SystemEvent::BatteryLevelChanged { percent: 87 }
+        ));
+    }
+
+    #[test]
+    fn percent_fractional_noise_under_rounding_threshold_is_suppressed() {
+        // 42.1 rounded = 42; last was 42; should not emit.
+        assert!(parse_percent_change(Some(42), 42.1).is_none());
+        assert!(parse_percent_change(Some(42), 41.5).is_none()); // 41.5 rounds to 42 (banker's? f64::round rounds half-away-from-zero -> 42)
+    }
+
+    #[test]
+    fn percent_fractional_crossing_integer_boundary_emits() {
+        // last = 42, new = 42.6 -> rounds to 43 -> emit.
+        let ev = parse_percent_change(Some(42), 42.6).unwrap();
+        assert!(matches!(
+            ev,
+            SystemEvent::BatteryLevelChanged { percent: 43 }
+        ));
+    }
+
+    #[test]
+    fn percent_clamps_above_100() {
+        let ev = parse_percent_change(Some(99), 150.0).unwrap();
+        assert!(matches!(
+            ev,
+            SystemEvent::BatteryLevelChanged { percent: 100 }
+        ));
+    }
+
+    #[test]
+    fn percent_clamps_below_0() {
+        let ev = parse_percent_change(Some(5), -10.0).unwrap();
+        assert!(matches!(
+            ev,
+            SystemEvent::BatteryLevelChanged { percent: 0 }
+        ));
+    }
+
+    #[test]
+    fn percent_exact_integer_match_suppressed() {
+        assert!(parse_percent_change(Some(80), 80.0).is_none());
+        assert!(parse_percent_change(Some(0), 0.0).is_none());
+        assert!(parse_percent_change(Some(100), 100.0).is_none());
     }
 }

--- a/src-tauri/src/system_events/macos.rs
+++ b/src-tauri/src/system_events/macos.rs
@@ -194,7 +194,10 @@ static KERNEL_PORT_STATIC: std::sync::OnceLock<u32> = std::sync::OnceLock::new()
 // -------------------------------------------------------------------------
 
 fn start_lid_poller(hub: Arc<SystemEventsHub>) {
-    tokio::spawn(async move {
+    // `tauri::async_runtime::spawn` routes to Tauri's managed runtime handle
+    // so it works from `setup_app` (main thread, no thread-local reactor) as
+    // well as from tokio tasks. Plain `tokio::spawn` panics in the former.
+    tauri::async_runtime::spawn(async move {
         let mut last: Option<bool> = None; // true = closed
         let mut interval = tokio::time::interval(Duration::from_secs(2));
         loop {
@@ -273,7 +276,7 @@ fn read_clamshell_closed() -> Option<bool> {
 // -------------------------------------------------------------------------
 
 fn start_battery_poller(hub: Arc<SystemEventsHub>) {
-    tokio::spawn(async move {
+    tauri::async_runtime::spawn(async move {
         let mut last_percent: Option<u8> = None;
         let mut last_on_battery: Option<bool> = None;
         let mut interval = tokio::time::interval(Duration::from_secs(30));

--- a/src-tauri/src/system_events/mod.rs
+++ b/src-tauri/src/system_events/mod.rs
@@ -16,9 +16,7 @@ use std::sync::Mutex;
 
 #[cfg(target_os = "macos")]
 pub mod macos;
-#[cfg(target_os = "linux")]
 pub mod linux;
-#[cfg(target_os = "windows")]
 pub mod windows;
 
 /// Discriminant used on the wire (kebab-case) and as registry keys.

--- a/src-tauri/src/system_events/windows.rs
+++ b/src-tauri/src/system_events/windows.rs
@@ -1,35 +1,445 @@
 //! Windows system-events watcher.
 //!
-//! Currently a stub — the full implementation requires a hidden message-only
-//! window + `RegisterPowerSettingNotification` + a `GetMessageW` pump on a
-//! dedicated thread. The hub stays running; events simply never fire.
-//! Extensions degrade gracefully (no callback).
+//! The watcher owns a dedicated thread running a hidden message-only window
+//! with a Win32 message pump. It registers for four power-setting GUIDs via
+//! `RegisterPowerSettingNotification` and handles `WM_POWERBROADCAST` in its
+//! window procedure:
+//!
+//! - `PBT_APMSUSPEND` → [`SystemEvent::Sleep`]
+//! - `PBT_APMRESUMEAUTOMATIC` / `PBT_APMRESUMESUSPEND` → [`SystemEvent::Wake`]
+//! - `GUID_ACDC_POWER_SOURCE` → [`SystemEvent::PowerSourceChanged`]
+//!   (payload: `0` AC, `1` DC, `2` short-term → we treat only `1` as "on
+//!   battery").
+//! - `GUID_BATTERY_PERCENTAGE_REMAINING` → [`SystemEvent::BatteryLevelChanged`]
+//!   (payload is a DWORD 0–100; deduped at integer granularity).
+//! - `GUID_LIDSWITCH_STATE_CHANGE` → [`SystemEvent::LidOpen`] /
+//!   [`SystemEvent::LidClose`] (payload `0` = closed, `1` = open).
+//!
+//! The hub [`Arc`](std::sync::Arc) is stored in `GWLP_USERDATA` on the hidden
+//! window so the C-ABI `wnd_proc` trampoline can recover it without a
+//! thread-local. `GWLP_USERDATA` is the canonical Win32 "per-window state"
+//! slot for this pattern.
+//!
+//! Pure parser helpers ([`parse_power_broadcast`], [`parse_power_setting`])
+//! are compiled on every platform so they can be unit-tested from the macOS
+//! dev machine. The Win32-using watcher glue is gated behind
+//! `#[cfg(target_os = "windows")]`.
 
-use crate::error::AppError;
-use crate::system_events::{SystemEventsHub, SystemEventsWatcher};
-use log::warn;
-use std::sync::Arc;
+use crate::system_events::SystemEvent;
 
-pub struct WindowsWatcher;
+/// GUIDs as 128-bit integers (the form accepted by
+/// `windows::core::GUID::from_u128`). Keeping them here lets the pure parser
+/// be tested on platforms where the `windows` crate isn't compiled.
+pub const GUID_ACDC_POWER_SOURCE_U128: u128 = 0x5d3e9a59_e9d5_4b00_a6bd_ff34ff516548;
+pub const GUID_BATTERY_PERCENTAGE_REMAINING_U128: u128 = 0xa7ad8041_b45a_4cae_87a3_eecbb468a9e1;
+pub const GUID_LIDSWITCH_STATE_CHANGE_U128: u128 = 0xba3e0f4d_b817_4094_a2d1_d56379b6c2a3;
+pub const GUID_CONSOLE_DISPLAY_STATE_U128: u128 = 0x6fe69556_704a_47a0_8f24_c28d936fda47;
 
-impl WindowsWatcher {
-    pub fn new() -> Self {
-        Self
+/// Win32 `PBT_*` constants routed through `WM_POWERBROADCAST.wParam`.
+pub const PBT_APMSUSPEND: usize = 0x04;
+pub const PBT_APMRESUMESUSPEND: usize = 0x07;
+pub const PBT_APMRESUMEAUTOMATIC: usize = 0x12;
+pub const PBT_POWERSETTINGCHANGE: usize = 0x8013;
+
+/// Map a `WM_POWERBROADCAST` message into a [`SystemEvent`].
+///
+/// Only `PBT_APMSUSPEND` / `PBT_APMRESUME*` map directly — power-setting
+/// changes (`PBT_POWERSETTINGCHANGE`) are delegated to
+/// [`parse_power_setting`] since they carry per-GUID payloads.
+pub fn parse_power_broadcast(wparam: usize, _lparam: isize) -> Option<SystemEvent> {
+    match wparam {
+        PBT_APMSUSPEND => Some(SystemEvent::Sleep),
+        PBT_APMRESUMEAUTOMATIC | PBT_APMRESUMESUSPEND => Some(SystemEvent::Wake),
+        _ => None,
     }
 }
 
-impl Default for WindowsWatcher {
-    fn default() -> Self {
-        Self::new()
+/// Map a `GUID_*` power-setting notification into a [`SystemEvent`].
+///
+/// `guid` is the 128-bit form of the GUID (match against the `*_U128`
+/// constants in this module). `payload` is the `POWERBROADCAST_SETTING.Data`
+/// field — always a DWORD in little-endian form for the GUIDs we handle.
+///
+/// Returns `None` for unknown GUIDs, truncated payloads, or payloads we
+/// don't route to a SystemEvent (e.g. `GUID_CONSOLE_DISPLAY_STATE`).
+pub fn parse_power_setting(guid: u128, payload: &[u8]) -> Option<SystemEvent> {
+    let bytes: [u8; 4] = payload.get(..4)?.try_into().ok()?;
+    let value = u32::from_le_bytes(bytes);
+    match guid {
+        GUID_ACDC_POWER_SOURCE_U128 => Some(SystemEvent::PowerSourceChanged {
+            on_battery: value == 1,
+        }),
+        GUID_BATTERY_PERCENTAGE_REMAINING_U128 => {
+            let percent = value.min(100) as u8;
+            Some(SystemEvent::BatteryLevelChanged { percent })
+        }
+        GUID_LIDSWITCH_STATE_CHANGE_U128 => Some(if value == 0 {
+            SystemEvent::LidClose
+        } else {
+            SystemEvent::LidOpen
+        }),
+        _ => None,
     }
 }
 
-impl SystemEventsWatcher for WindowsWatcher {
-    fn start(&self, _hub: Arc<SystemEventsHub>) -> Result<(), AppError> {
-        warn!(
-            "[system_events/windows] watcher not yet implemented — \
-             sleep/wake/lid/battery events will not fire on this platform"
-        );
+// ---------------------------------------------------------------------------
+// Windows-only watcher glue
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "windows")]
+pub use watcher::WindowsWatcher;
+
+#[cfg(target_os = "windows")]
+mod watcher {
+    use super::*;
+    use crate::error::AppError;
+    use crate::system_events::{SystemEventsHub, SystemEventsWatcher};
+    use log::{info, warn};
+    use std::sync::Arc;
+    use ::windows::core::{w, GUID, PCWSTR};
+    use ::windows::Win32::Foundation::{HANDLE, HINSTANCE, HWND, LPARAM, LRESULT, WPARAM};
+    use ::windows::Win32::System::LibraryLoader::GetModuleHandleW;
+    use ::windows::Win32::System::Power::{
+        RegisterPowerSettingNotification, POWERBROADCAST_SETTING,
+    };
+    use ::windows::Win32::UI::WindowsAndMessaging::{
+        CreateWindowExW, DefWindowProcW, DispatchMessageW, GetMessageW, GetWindowLongPtrW,
+        RegisterClassExW, SetWindowLongPtrW, TranslateMessage, DEVICE_NOTIFY_WINDOW_HANDLE,
+        GWLP_USERDATA, HWND_MESSAGE, MSG, WINDOW_EX_STYLE, WINDOW_STYLE, WM_POWERBROADCAST,
+        WNDCLASSEXW,
+    };
+
+    // GUIDs as seen by Win32. Construct from the u128 forms in the parent
+    // module so the pure parser and the glue can't drift apart.
+    const GUID_ACDC_POWER_SOURCE: GUID = GUID::from_u128(GUID_ACDC_POWER_SOURCE_U128);
+    const GUID_BATTERY_PERCENTAGE_REMAINING: GUID =
+        GUID::from_u128(GUID_BATTERY_PERCENTAGE_REMAINING_U128);
+    const GUID_LIDSWITCH_STATE_CHANGE: GUID = GUID::from_u128(GUID_LIDSWITCH_STATE_CHANGE_U128);
+    const GUID_CONSOLE_DISPLAY_STATE: GUID = GUID::from_u128(GUID_CONSOLE_DISPLAY_STATE_U128);
+
+    /// Per-window state the wndproc recovers via `GWLP_USERDATA`. The hub is
+    /// refcounted with Arc; `last_percent` dedupes integer percent changes,
+    /// mirroring the Linux watcher's behaviour.
+    struct WindowState {
+        hub: Arc<SystemEventsHub>,
+        last_percent: Option<u8>,
+    }
+
+    pub struct WindowsWatcher;
+
+    impl WindowsWatcher {
+        pub fn new() -> Self {
+            Self
+        }
+    }
+
+    impl Default for WindowsWatcher {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl SystemEventsWatcher for WindowsWatcher {
+        fn start(&self, hub: Arc<SystemEventsHub>) -> Result<(), AppError> {
+            std::thread::Builder::new()
+                .name("asyar-system-events-win".into())
+                .spawn(move || {
+                    if let Err(e) = run_message_loop(hub) {
+                        warn!("[system_events/windows] message loop ended: {e}");
+                    }
+                })
+                .ok();
+            info!("[system_events/windows] watcher started");
+            Ok(())
+        }
+    }
+
+    fn guid_to_u128(g: &GUID) -> u128 {
+        ((g.data1 as u128) << 96)
+            | ((g.data2 as u128) << 80)
+            | ((g.data3 as u128) << 64)
+            | (u64::from_be_bytes(g.data4) as u128)
+    }
+
+    unsafe extern "system" fn wnd_proc(
+        hwnd: HWND,
+        msg: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> LRESULT {
+        if msg == WM_POWERBROADCAST {
+            let ptr = unsafe { GetWindowLongPtrW(hwnd, GWLP_USERDATA) } as *mut WindowState;
+            if !ptr.is_null() {
+                // Safety: the pointer was installed in run_message_loop and
+                // is only cleared when the loop exits; we dereference on the
+                // same thread that owns it.
+                let state = unsafe { &mut *ptr };
+                if wparam.0 == PBT_POWERSETTINGCHANGE {
+                    if lparam.0 != 0 {
+                        let setting =
+                            unsafe { &*(lparam.0 as *const POWERBROADCAST_SETTING) };
+                        let data_len = setting.DataLength as usize;
+                        let data_ptr = setting.Data.as_ptr();
+                        // Safety: `Data` is a flexible array member; Win32
+                        // guarantees `DataLength` bytes are readable.
+                        let payload = unsafe {
+                            std::slice::from_raw_parts(data_ptr, data_len)
+                        };
+                        let guid_u128 = guid_to_u128(&setting.PowerSetting);
+                        if let Some(ev) = parse_power_setting(guid_u128, payload) {
+                            dispatch_with_dedup(state, ev);
+                        }
+                    }
+                } else if let Some(ev) = parse_power_broadcast(wparam.0, lparam.0) {
+                    state.hub.dispatch(ev);
+                }
+                return LRESULT(0);
+            }
+        }
+        unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) }
+    }
+
+    fn dispatch_with_dedup(state: &mut WindowState, ev: SystemEvent) {
+        if let SystemEvent::BatteryLevelChanged { percent } = ev {
+            if state.last_percent == Some(percent) {
+                return;
+            }
+            state.last_percent = Some(percent);
+        }
+        state.hub.dispatch(ev);
+    }
+
+    fn run_message_loop(hub: Arc<SystemEventsHub>) -> Result<(), String> {
+        unsafe {
+            let hinstance: HINSTANCE = GetModuleHandleW(PCWSTR::null())
+                .map_err(|e| format!("GetModuleHandleW failed: {e}"))?
+                .into();
+
+            let class_name = w!("AsyarSystemEventsWindow");
+            let wc = WNDCLASSEXW {
+                cbSize: std::mem::size_of::<WNDCLASSEXW>() as u32,
+                lpfnWndProc: Some(wnd_proc),
+                hInstance: hinstance,
+                lpszClassName: class_name,
+                ..Default::default()
+            };
+            if RegisterClassExW(&wc) == 0 {
+                return Err("RegisterClassExW failed".into());
+            }
+
+            let hwnd = CreateWindowExW(
+                WINDOW_EX_STYLE(0),
+                class_name,
+                w!(""),
+                WINDOW_STYLE(0),
+                0,
+                0,
+                0,
+                0,
+                Some(HWND_MESSAGE),
+                None,
+                Some(hinstance),
+                None,
+            )
+            .map_err(|e| format!("CreateWindowExW failed: {e}"))?;
+
+            // Install the per-window state so `wnd_proc` can find it.
+            let state = Box::new(WindowState {
+                hub,
+                last_percent: None,
+            });
+            let state_ptr = Box::into_raw(state);
+            SetWindowLongPtrW(hwnd, GWLP_USERDATA, state_ptr as isize);
+
+            // Register for the four power-setting GUIDs we care about. If
+            // any single registration fails we log and continue — other
+            // sources still fire.
+            for (guid, name) in [
+                (&GUID_ACDC_POWER_SOURCE, "GUID_ACDC_POWER_SOURCE"),
+                (
+                    &GUID_BATTERY_PERCENTAGE_REMAINING,
+                    "GUID_BATTERY_PERCENTAGE_REMAINING",
+                ),
+                (&GUID_LIDSWITCH_STATE_CHANGE, "GUID_LIDSWITCH_STATE_CHANGE"),
+                (&GUID_CONSOLE_DISPLAY_STATE, "GUID_CONSOLE_DISPLAY_STATE"),
+            ] {
+                if RegisterPowerSettingNotification(
+                    HANDLE(hwnd.0),
+                    guid,
+                    DEVICE_NOTIFY_WINDOW_HANDLE,
+                )
+                .is_err()
+                {
+                    warn!(
+                        "[system_events/windows] RegisterPowerSettingNotification \
+                         failed for {name} — that source will not fire"
+                    );
+                }
+            }
+
+            let mut msg = MSG::default();
+            while GetMessageW(&mut msg, None, 0, 0).into() {
+                let _ = TranslateMessage(&msg);
+                DispatchMessageW(&msg);
+            }
+
+            // Pump exited — drop the state box.
+            let _ = Box::from_raw(state_ptr);
+        }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- parse_power_broadcast --------------------------------------------
+
+    #[test]
+    fn apm_suspend_emits_sleep() {
+        assert!(matches!(
+            parse_power_broadcast(PBT_APMSUSPEND, 0),
+            Some(SystemEvent::Sleep)
+        ));
+    }
+
+    #[test]
+    fn apm_resume_automatic_emits_wake() {
+        assert!(matches!(
+            parse_power_broadcast(PBT_APMRESUMEAUTOMATIC, 0),
+            Some(SystemEvent::Wake)
+        ));
+    }
+
+    #[test]
+    fn apm_resume_suspend_emits_wake() {
+        assert!(matches!(
+            parse_power_broadcast(PBT_APMRESUMESUSPEND, 0),
+            Some(SystemEvent::Wake)
+        ));
+    }
+
+    #[test]
+    fn power_setting_change_is_none_here() {
+        // PBT_POWERSETTINGCHANGE must be routed through parse_power_setting,
+        // so parse_power_broadcast returns None for it.
+        assert!(parse_power_broadcast(PBT_POWERSETTINGCHANGE, 0).is_none());
+    }
+
+    #[test]
+    fn unknown_wparam_is_none() {
+        assert!(parse_power_broadcast(0x999, 0).is_none());
+        assert!(parse_power_broadcast(0, 0).is_none());
+    }
+
+    // --- parse_power_setting: ACDC power source ---------------------------
+
+    #[test]
+    fn acdc_power_source_dc_emits_on_battery() {
+        let payload = 1u32.to_le_bytes();
+        let ev = parse_power_setting(GUID_ACDC_POWER_SOURCE_U128, &payload).unwrap();
+        assert!(matches!(
+            ev,
+            SystemEvent::PowerSourceChanged { on_battery: true }
+        ));
+    }
+
+    #[test]
+    fn acdc_power_source_ac_emits_not_on_battery() {
+        let payload = 0u32.to_le_bytes();
+        let ev = parse_power_setting(GUID_ACDC_POWER_SOURCE_U128, &payload).unwrap();
+        assert!(matches!(
+            ev,
+            SystemEvent::PowerSourceChanged { on_battery: false }
+        ));
+    }
+
+    #[test]
+    fn acdc_power_source_short_term_is_not_on_battery() {
+        // 2 = short-term (UPS). Treated as not-on-battery — we only flag DC.
+        let payload = 2u32.to_le_bytes();
+        let ev = parse_power_setting(GUID_ACDC_POWER_SOURCE_U128, &payload).unwrap();
+        assert!(matches!(
+            ev,
+            SystemEvent::PowerSourceChanged { on_battery: false }
+        ));
+    }
+
+    // --- parse_power_setting: battery percentage --------------------------
+
+    #[test]
+    fn battery_percentage_emits_battery_level_changed() {
+        let payload = 73u32.to_le_bytes();
+        let ev =
+            parse_power_setting(GUID_BATTERY_PERCENTAGE_REMAINING_U128, &payload).unwrap();
+        assert!(matches!(
+            ev,
+            SystemEvent::BatteryLevelChanged { percent: 73 }
+        ));
+    }
+
+    #[test]
+    fn battery_percentage_clamps_above_100() {
+        let payload = 150u32.to_le_bytes();
+        let ev =
+            parse_power_setting(GUID_BATTERY_PERCENTAGE_REMAINING_U128, &payload).unwrap();
+        assert!(matches!(
+            ev,
+            SystemEvent::BatteryLevelChanged { percent: 100 }
+        ));
+    }
+
+    #[test]
+    fn battery_percentage_zero_emits() {
+        let payload = 0u32.to_le_bytes();
+        let ev =
+            parse_power_setting(GUID_BATTERY_PERCENTAGE_REMAINING_U128, &payload).unwrap();
+        assert!(matches!(
+            ev,
+            SystemEvent::BatteryLevelChanged { percent: 0 }
+        ));
+    }
+
+    // --- parse_power_setting: lid switch ----------------------------------
+
+    #[test]
+    fn lidswitch_state_closed_emits_lid_close() {
+        let payload = 0u32.to_le_bytes();
+        let ev = parse_power_setting(GUID_LIDSWITCH_STATE_CHANGE_U128, &payload).unwrap();
+        assert!(matches!(ev, SystemEvent::LidClose));
+    }
+
+    #[test]
+    fn lidswitch_state_open_emits_lid_open() {
+        let payload = 1u32.to_le_bytes();
+        let ev = parse_power_setting(GUID_LIDSWITCH_STATE_CHANGE_U128, &payload).unwrap();
+        assert!(matches!(ev, SystemEvent::LidOpen));
+    }
+
+    // --- parse_power_setting: unhandled / malformed ------------------------
+
+    #[test]
+    fn console_display_state_is_none() {
+        // We register for GUID_CONSOLE_DISPLAY_STATE for completeness but
+        // don't map it to any SystemEvent.
+        let payload = 1u32.to_le_bytes();
+        assert!(parse_power_setting(GUID_CONSOLE_DISPLAY_STATE_U128, &payload).is_none());
+    }
+
+    #[test]
+    fn unknown_guid_is_none() {
+        let payload = 1u32.to_le_bytes();
+        assert!(
+            parse_power_setting(0xdead_beef_cafe_f00d_0000_0000_0000_0000, &payload).is_none()
+        );
+    }
+
+    #[test]
+    fn truncated_payload_is_none() {
+        // DWORD requires 4 bytes; shorter payload → None (not panic).
+        assert!(parse_power_setting(GUID_ACDC_POWER_SOURCE_U128, &[1, 0]).is_none());
+        assert!(parse_power_setting(GUID_BATTERY_PERCENTAGE_REMAINING_U128, &[]).is_none());
+        assert!(parse_power_setting(GUID_LIDSWITCH_STATE_CHANGE_U128, &[0]).is_none());
     }
 }


### PR DESCRIPTION
Replace the Linux and Windows stubs with real event sources:
- Linux: logind PrepareForSleep + UPower LidIsClosed/OnBattery/Percentage
  via three zbus blocking threads, with per-source graceful degradation.
- Windows: hidden message-only HWND with GetMessageW pump, registers
  for GUID_ACDC_POWER_SOURCE / GUID_BATTERY_PERCENTAGE_REMAINING /
  GUID_LIDSWITCH_STATE_CHANGE / GUID_CONSOLE_DISPLAY_STATE and routes
  WM_POWERBROADCAST to the hub.

Pure parser helpers (parse_lid_transition, parse_on_battery_change,
parse_percent_change, parse_power_broadcast, parse_power_setting) are
compiled on every host so they can be unit-tested from macOS — 29 new
tests, TDD'd RED-first.

Fix a latent macOS startup panic: MacWatcher's pollers called
tokio::spawn from the Tauri setup closure, which has no thread-local
reactor. Switched to tauri::async_runtime::spawn.

Cargo: add Win32_System_LibraryLoader feature for GetModuleHandleW.
Docs: update platform coverage matrix and add a per-source degradation
section.