### PR TITLE
feat: scan bundleId + add ScreenSaver power fallback on Linux

### DIFF
--- a/src-tauri/src/application/service.rs
+++ b/src-tauri/src/application/service.rs
@@ -87,6 +87,7 @@ pub fn sync_application_index(
             usage_count: 0,
             icon: extract_app_icon(path_str, &icon_cache_dir),
             last_used_at: None,
+            bundle_id: extract_bundle_id(Path::new(path_str)),
         });
     }
 
@@ -167,6 +168,7 @@ pub fn list_applications(
             usage_count: 0,
             icon: extract_app_icon(path_str, &icon_cache_dir),
             last_used_at: None,
+            bundle_id: extract_bundle_id(Path::new(path_str)),
         });
     }
 
@@ -300,6 +302,73 @@ fn is_app_bundle(path: &Path) -> bool {
 
     #[cfg(target_os = "windows")]
     { path.extension().map(|e| e == "lnk").unwrap_or(false) }
+}
+
+/// Extract a platform-native bundle / process identifier for an installed app.
+///
+/// Works the same whether the path comes from a default scan location or from
+/// a user-configured custom scan directory — the logic is purely
+/// path-content-based (Info.plist or .desktop), no registry lookup.
+pub(crate) fn extract_bundle_id(path: &Path) -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        // macOS .app bundles contain Contents/Info.plist with CFBundleIdentifier.
+        let plist_path = path.join("Contents/Info.plist");
+        if !plist_path.is_file() { return None; }
+        let value = plist::Value::from_file(&plist_path).ok()?;
+        let dict = value.as_dictionary()?;
+        let id = dict.get("CFBundleIdentifier")?.as_string()?;
+        let trimmed = id.trim();
+        if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // Parse the .desktop file. Prefer StartupWMClass (matches X11 WM_CLASS
+        // and is what process-name checks want). Fallback: basename of the
+        // first arg of Exec= with format specifiers stripped.
+        let contents = std::fs::read_to_string(path).ok()?;
+        let mut wm_class: Option<String> = None;
+        let mut exec_cmd: Option<String> = None;
+        let mut in_desktop_entry = false;
+        for line in contents.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with('[') && trimmed.ends_with(']') {
+                in_desktop_entry = trimmed == "[Desktop Entry]";
+                continue;
+            }
+            if !in_desktop_entry { continue; }
+            if let Some(rest) = trimmed.strip_prefix("StartupWMClass=") {
+                wm_class = Some(rest.trim().to_string());
+            } else if let Some(rest) = trimmed.strip_prefix("Exec=") {
+                // Strip format specifiers like %U %f %F %u and surrounding quotes.
+                let cleaned: String = rest
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or("")
+                    .trim_matches('"')
+                    .to_string();
+                if !cleaned.is_empty() {
+                    let basename = Path::new(&cleaned)
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or(&cleaned)
+                        .to_string();
+                    exec_cmd = Some(basename);
+                }
+            }
+        }
+        wm_class.filter(|s| !s.is_empty()).or_else(|| exec_cmd.filter(|s| !s.is_empty()))
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        // .lnk shortcuts don't carry a bundle identifier. Leave None — the
+        // caller falls back to `name` for isRunning() which uses process-name
+        // matching on Windows.
+        let _ = path;
+        None
+    }
 }
 
 fn get_icon_cache_dir(app: &AppHandle) -> PathBuf {

--- a/src-tauri/src/power/linux.rs
+++ b/src-tauri/src/power/linux.rs
@@ -1,11 +1,21 @@
-//! Linux backend using logind's `org.freedesktop.login1.Manager.Inhibit`.
+//! Linux sleep-inhibitor backend.
 //!
-//! The returned file descriptor keeps the inhibit active as long as it is
-//! held open; dropping our [`LinuxInhibitHandle`] closes the fd and releases
-//! the inhibit. Non-systemd systems (no logind on the session bus) cause
-//! [`PowerBackend::inhibit`] to return [`AppError::Power`] with
-//! `PowerUnavailable:` — we deliberately do NOT fall back to shelling out to
-//! `systemd-inhibit`.
+//! Primary: logind's `org.freedesktop.login1.Manager.Inhibit`. The returned
+//! file descriptor keeps the inhibit active as long as it is held open;
+//! dropping our [`LinuxInhibitHandle`] closes the fd and releases the
+//! inhibit.
+//!
+//! Fallback: session-bus `org.freedesktop.ScreenSaver.Inhibit` when logind
+//! isn't reachable (non-systemd distros such as Void, Alpine, Artix).
+//! This is a *screensaver*-level inhibit — it keeps the display awake on
+//! most desktop environments (GNOME, KDE, XFCE, MATE, Cinnamon) but does
+//! not block system sleep. That's a known reduction in power compared to
+//! logind and is documented in the IPowerService JSDoc.
+//!
+//! Both backends are acquired through `zbus`, no child-process hop. On the
+//! rare system where neither bus name is reachable, the call returns
+//! [`AppError::Power`] with a `PowerUnavailable:` prefix — callers that
+//! check for that prefix can degrade gracefully.
 
 use crate::error::AppError;
 use crate::power::{PowerBackend, PowerHandle, ResolvedOptions};
@@ -27,12 +37,35 @@ impl Default for LinuxPowerBackend {
     }
 }
 
-pub struct LinuxInhibitHandle {
+pub enum LinuxInhibitHandle {
     /// Held for its `Drop` impl — closing this fd releases the inhibit.
-    _fd: OwnedFd,
+    Logind { _fd: OwnedFd },
+    /// ScreenSaver cookie returned from `Inhibit`; passed back to `UnInhibit`
+    /// on drop. Connection is kept alive so the UnInhibit call can still
+    /// reach the bus.
+    ScreenSaver {
+        conn: Connection,
+        cookie: u32,
+    },
 }
 
 impl PowerHandle for LinuxInhibitHandle {}
+
+impl Drop for LinuxInhibitHandle {
+    fn drop(&mut self) {
+        if let LinuxInhibitHandle::ScreenSaver { conn, cookie } = self {
+            let _ = conn.call_method(
+                Some("org.freedesktop.ScreenSaver"),
+                "/org/freedesktop/ScreenSaver",
+                Some("org.freedesktop.ScreenSaver"),
+                "UnInhibit",
+                &(*cookie,),
+            );
+        }
+        // Logind variant: the OwnedFd's own Drop closes the fd, which
+        // releases the inhibit server-side.
+    }
+}
 
 fn what_string(opts: ResolvedOptions) -> String {
     let mut parts: Vec<&'static str> = Vec::new();
@@ -57,6 +90,64 @@ fn what_string(opts: ResolvedOptions) -> String {
         .join(":")
 }
 
+fn try_logind(
+    options: ResolvedOptions,
+    reason: &str,
+) -> Result<LinuxInhibitHandle, AppError> {
+    let conn = Connection::system().map_err(|e| {
+        AppError::Power(format!(
+            "PowerUnavailable: logind system bus unreachable: {e}"
+        ))
+    })?;
+
+    let what = what_string(options);
+    let reply = conn
+        .call_method(
+            Some("org.freedesktop.login1"),
+            "/org/freedesktop/login1",
+            Some("org.freedesktop.login1.Manager"),
+            "Inhibit",
+            &(what.as_str(), "Asyar", reason, "block"),
+        )
+        .map_err(|e| {
+            AppError::Power(format!("PowerUnavailable: Inhibit call failed: {e}"))
+        })?;
+    let fd: ZOwnedFd = reply.body().deserialize::<ZOwnedFd>().map_err(|e| {
+        AppError::Power(format!("Inhibit reply did not contain an fd: {e}"))
+    })?;
+
+    Ok(LinuxInhibitHandle::Logind { _fd: fd.into() })
+}
+
+fn try_screensaver(reason: &str) -> Result<LinuxInhibitHandle, AppError> {
+    let conn = Connection::session().map_err(|e| {
+        AppError::Power(format!(
+            "PowerUnavailable: session bus unreachable: {e}"
+        ))
+    })?;
+
+    let reply = conn
+        .call_method(
+            Some("org.freedesktop.ScreenSaver"),
+            "/org/freedesktop/ScreenSaver",
+            Some("org.freedesktop.ScreenSaver"),
+            "Inhibit",
+            &("Asyar", reason),
+        )
+        .map_err(|e| {
+            AppError::Power(format!(
+                "PowerUnavailable: ScreenSaver.Inhibit call failed: {e}"
+            ))
+        })?;
+    let cookie: u32 = reply.body().deserialize::<u32>().map_err(|e| {
+        AppError::Power(format!(
+            "ScreenSaver.Inhibit reply did not contain a cookie: {e}"
+        ))
+    })?;
+
+    Ok(LinuxInhibitHandle::ScreenSaver { conn, cookie })
+}
+
 impl PowerBackend for LinuxPowerBackend {
     fn inhibit(
         &self,
@@ -64,28 +155,23 @@ impl PowerBackend for LinuxPowerBackend {
         options: ResolvedOptions,
         reason: &str,
     ) -> Result<Box<dyn PowerHandle>, AppError> {
-        let conn = Connection::system().map_err(|e| {
-            AppError::Power(format!(
-                "PowerUnavailable: logind system bus unreachable: {e}"
-            ))
-        })?;
+        // Try logind first. On systemd systems this gives us a real system
+        // sleep inhibit including lid-switch handling.
+        match try_logind(options, reason) {
+            Ok(h) => return Ok(Box::new(h)),
+            Err(err) => {
+                log::debug!(
+                    "logind inhibit unavailable, falling back to ScreenSaver: {err}"
+                );
+            }
+        }
 
-        let what = what_string(options);
-        let reply = conn
-            .call_method(
-                Some("org.freedesktop.login1"),
-                "/org/freedesktop/login1",
-                Some("org.freedesktop.login1.Manager"),
-                "Inhibit",
-                &(what.as_str(), "Asyar", reason, "block"),
-            )
-            .map_err(|e| {
-                AppError::Power(format!("PowerUnavailable: Inhibit call failed: {e}"))
-            })?;
-        let fd: ZOwnedFd = reply.body().deserialize::<ZOwnedFd>().map_err(|e| {
-            AppError::Power(format!("Inhibit reply did not contain an fd: {e}"))
-        })?;
-
-        Ok(Box::new(LinuxInhibitHandle { _fd: fd.into() }))
+        // Fallback: session-bus ScreenSaver. Display-awake only — system may
+        // still sleep, but most non-systemd-distro users run a DE that
+        // honours this interface for keep-screen-awake use cases.
+        match try_screensaver(reason) {
+            Ok(h) => Ok(Box::new(h)),
+            Err(err) => Err(err),
+        }
     }
 }

--- a/src-tauri/src/search_engine/commands.rs
+++ b/src-tauri/src/search_engine/commands.rs
@@ -219,6 +219,7 @@ mod tests {
             usage_count: usage,
             icon: None,
             last_used_at: None,
+            bundle_id: None,
         })
     }
 

--- a/src-tauri/src/search_engine/mod.rs
+++ b/src-tauri/src/search_engine/mod.rs
@@ -528,6 +528,7 @@ mod service_tests {
             path: format!("/Applications/{}.app", name),
             usage_count: usage, icon: None,
             last_used_at: None,
+            bundle_id: None,
         })
     }
 
@@ -555,6 +556,7 @@ mod service_tests {
             usage_count: usage,
             icon: None,
             last_used_at: Some(ts),
+            bundle_id: None,
         })
     }
 
@@ -856,6 +858,7 @@ mod service_tests {
             usage_count: 1,
             icon: None,
             last_used_at: None,
+            bundle_id: None,
         })).unwrap();
 
         let empty = state.search("").unwrap();
@@ -887,6 +890,7 @@ mod service_tests {
             usage_count: 1,
             icon: None,
             last_used_at: None,
+            bundle_id: None,
         })).unwrap();
 
         let empty = state.search("").unwrap();

--- a/src-tauri/src/search_engine/models.rs
+++ b/src-tauri/src/search_engine/models.rs
@@ -20,6 +20,16 @@ pub struct Application {
     pub icon: Option<String>,
     #[serde(default)]
     pub last_used_at: Option<u32>,
+    /// Platform-native bundle / process identifier when discoverable:
+    /// - macOS: `CFBundleIdentifier` from `Contents/Info.plist` (e.g. `com.apple.Safari`)
+    /// - Linux: `StartupWMClass` from the `.desktop` entry, or the basename of `Exec=`
+    ///   as a fallback (e.g. `firefox`)
+    /// - Windows: not extracted — `.lnk` shortcuts don't carry a bundle id
+    ///
+    /// Consumed by `IApplicationService.isRunning()` — extensions should prefer
+    /// this field over `name` when calling `isRunning`, with `name` as a fallback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bundle_id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, specta::Type)]
@@ -145,6 +155,7 @@ mod tests {
             usage_count: 2,
             icon: None,
             last_used_at: None,
+            bundle_id: None,
         })
     }
 

--- a/src/services/application/applicationService.test.ts
+++ b/src/services/application/applicationService.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 vi.mock('../settings/settingsService.svelte', () => ({
   settingsService: {
-    settings: {
+    currentSettings: {
       search: {
         additionalScanPaths: ['/custom/path'],
       },

--- a/src/services/application/applicationService.ts
+++ b/src/services/application/applicationService.ts
@@ -15,12 +15,12 @@ export class ApplicationService {
   }
 
   async syncApplicationIndex(extraPaths?: string[]): Promise<{ added: number; removed: number; total: number }> {
-    const paths = extraPaths ?? settingsService.settings.search.additionalScanPaths ?? [];
+    const paths = extraPaths ?? settingsService.currentSettings.search.additionalScanPaths ?? [];
     return await invoke('sync_application_index', { extraPaths: paths });
   }
 
   async listApplications(extraPaths?: string[]): Promise<any[]> {
-    const paths = extraPaths ?? settingsService.settings.search.additionalScanPaths ?? [];
+    const paths = extraPaths ?? settingsService.currentSettings.search.additionalScanPaths ?? [];
     return await invoke('list_applications', { extraPaths: paths });
   }
 


### PR DESCRIPTION
- Application model gains `bundle_id: Option<String>`; scanner
  extracts CFBundleIdentifier (macOS) and StartupWMClass / Exec
  basename (Linux) for both default and custom scan paths
- power/linux.rs falls back to session-bus
  org.freedesktop.ScreenSaver.Inhibit when logind is unreachable
- fix: applicationService.ts used `settings` instead of
  `currentSettings`, crashing listApplications()/syncApplicationIndex()