### PR TITLE
fix(compact): preserve extension view across hide/show in compact mode

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -229,12 +229,14 @@ pub fn set_focus_lock(state: tauri::State<'_, AppState>, locked: bool) {
     state.focus_locked.store(locked, Ordering::Relaxed);
 }
 
-/// Mirrors the launcher's "has a non-empty query" state into Rust so the
-/// panel resign handler can decide whether to collapse compact geometry on
-/// hide without racing JS.
+/// Mirrors `!isCompactIdle` from the launcher frontend so the panel resign
+/// handler can tell whether the window is in a committed expanded state
+/// (typed query, active extension view, active context chip, Show More)
+/// that must survive hide/show without racing JS. TS owns the decision;
+/// this command is a pure sink.
 #[tauri::command]
-pub fn set_launcher_has_query(state: tauri::State<'_, AppState>, has_query: bool) {
-    state.launcher_has_query.store(has_query, Ordering::Relaxed);
+pub fn set_launcher_keep_expanded(state: tauri::State<'_, AppState>, keep_expanded: bool) {
+    state.launcher_keep_expanded.store(keep_expanded, Ordering::Relaxed);
 }
 
 /// Validates a launcher height value before it reaches platform window APIs.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -343,6 +343,10 @@ fn read_launch_view(app: &tauri::AppHandle) -> &'static str {
 /// to compact geometry before `order_out`. Pure so it's unit-testable
 /// without the NSPanel machinery: collapse iff the user is in compact
 /// launchView AND TS has not flagged a committed expanded state.
+///
+/// macOS-only: Windows/Linux hide via `window.hide()` and never touch
+/// geometry, so this decision has no consumer there.
+#[cfg(target_os = "macos")]
 fn should_collapse_on_resign(compact_mode: bool, keep_expanded: bool) -> bool {
     compact_mode && !keep_expanded
 }
@@ -782,7 +786,7 @@ fn setup_global_shortcut(app_handle: &tauri::AppHandle) {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "macos"))]
 mod resign_collapse_tests {
     use super::should_collapse_on_resign;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,10 +22,13 @@ pub struct AppState {
     pub snippets_enabled: AtomicBool,
     /// Tracks whether the launcher window is currently visible.
     pub asyar_visible: AtomicBool,
-    /// Mirrors whether the launcher search box has a non-empty query. Read by
-    /// the panel resign handler to decide whether to reset compact geometry
-    /// on hide — a user-typed query should keep the expanded view across hides.
-    pub launcher_has_query: AtomicBool,
+    /// Mirrors `!isCompactIdle` from the TS side — true whenever the launcher
+    /// is in an expanded state the user has committed to (typed query, active
+    /// extension view, active context chip, Show More click). Read by the
+    /// panel resign handler to decide whether to reset compact geometry on
+    /// hide. TS owns the decision because it depends on UI-only state
+    /// (navigation stack, context chips); Rust just receives the answer.
+    pub launcher_keep_expanded: AtomicBool,
     /// The currently active snippet definitions (keyword → expansion text).
     pub active_snippets: Mutex<HashMap<String, String>>,
     /// Guards against registering the global event listener more than once.
@@ -130,7 +133,7 @@ pub fn run() {
             launcher_shortcut: Mutex::new(String::from("Alt+Space")),
             snippets_enabled: AtomicBool::new(false),
             asyar_visible: AtomicBool::new(false),
-            launcher_has_query: AtomicBool::new(false),
+            launcher_keep_expanded: AtomicBool::new(false),
             active_snippets: Mutex::new(HashMap::new()),
             listener_started: AtomicBool::new(false),
             #[cfg(target_os = "windows")]
@@ -142,7 +145,7 @@ pub fn run() {
         .setup(setup_app)
         .invoke_handler(tauri::generate_handler![
             commands::set_focus_lock,
-            commands::set_launcher_has_query,
+            commands::set_launcher_keep_expanded,
             commands::set_launcher_height,
             commands::mark_launcher_ready,
             commands::update_show_more_bar_style,
@@ -334,6 +337,14 @@ fn read_launch_view(app: &tauri::AppHandle) -> &'static str {
     use tauri_plugin_store::StoreExt;
     let Ok(store) = app.store("settings.dat") else { return "default"; };
     parse_launch_view(store.get("settings").as_ref())
+}
+
+/// Decides whether the panel resign handler should pre-collapse the window
+/// to compact geometry before `order_out`. Pure so it's unit-testable
+/// without the NSPanel machinery: collapse iff the user is in compact
+/// launchView AND TS has not flagged a committed expanded state.
+fn should_collapse_on_resign(compact_mode: bool, keep_expanded: bool) -> bool {
+    compact_mode && !keep_expanded
 }
 
 /// Pure JSON-navigation helper extracted from `read_launch_view`. Returns
@@ -534,14 +545,16 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 // If the user pressed Show More and then hid without typing,
                 // collapse to compact geometry before the window goes away —
                 // otherwise the next panel.show() paints the stale 560 frame
-                // before JS can shrink it. A non-empty query is a real
-                // expansion the user wants to keep, so skip then.
+                // before JS can shrink it. `launcher_keep_expanded` mirrors
+                // `!isCompactIdle` from TS, so any committed expanded state
+                // (typed query, extension view, context chip, Show More)
+                // keeps the 560 geometry across hides.
                 let compact_mode = read_launch_view(&handle_clone) == "compact";
-                let has_query = state.launcher_has_query.load(Ordering::Relaxed);
+                let keep_expanded = state.launcher_keep_expanded.load(Ordering::Relaxed);
                 let handle_for_main = handle_clone.clone();
                 let panel = panel.clone();
                 let _ = handle_clone.run_on_main_thread(move || {
-                    if compact_mode && !has_query {
+                    if should_collapse_on_resign(compact_mode, keep_expanded) {
                         if let Some(window) = handle_for_main.get_webview_window(SPOTLIGHT_LABEL) {
                             crate::platform::macos::set_launcher_window_height(
                                 &window,
@@ -766,6 +779,34 @@ fn setup_global_shortcut(app_handle: &tauri::AppHandle) {
     // Register the shortcut
     if let Err(e) = shortcut_manager.register(shortcut) {
         log::error!("Failed to register shortcut: {}", e);
+    }
+}
+
+#[cfg(test)]
+mod resign_collapse_tests {
+    use super::should_collapse_on_resign;
+
+    #[test]
+    fn collapses_when_compact_and_not_keep_expanded() {
+        assert!(should_collapse_on_resign(true, false));
+    }
+
+    #[test]
+    fn does_not_collapse_when_keep_expanded_is_set() {
+        // Mirrors the bug: user entered an extension view, TS mirrored
+        // `!isCompactIdle` as true. Rust must not clobber that on hide.
+        assert!(!should_collapse_on_resign(true, true));
+    }
+
+    #[test]
+    fn does_not_collapse_when_launch_view_is_default() {
+        // Non-compact launchView: the shrink is a no-op by design.
+        assert!(!should_collapse_on_resign(false, false));
+    }
+
+    #[test]
+    fn does_not_collapse_when_default_mode_and_keep_expanded() {
+        assert!(!should_collapse_on_resign(false, true));
     }
 }
 

--- a/src/lib/ipc/commands.ts
+++ b/src/lib/ipc/commands.ts
@@ -151,8 +151,8 @@ export async function markLauncherReady(expanded: boolean): Promise<void> {
   return invoke('mark_launcher_ready', { expanded });
 }
 
-export async function setLauncherHasQuery(hasQuery: boolean): Promise<void> {
-  return invoke('set_launcher_has_query', { hasQuery });
+export async function setLauncherKeepExpanded(keepExpanded: boolean): Promise<void> {
+  return invoke('set_launcher_keep_expanded', { keepExpanded });
 }
 
 export interface ShowMoreBarStyle {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -107,7 +107,7 @@
   // service so the dependencies (controller.*, searchOrchestrator.*,
   // settingsService.*) are tracked by Svelte's reactivity graph.
   $effect(() => { compactSync.updateSearchExpandSticky(); });
-  $effect(() => { compactSync.syncHasQuery(); });
+  $effect(() => { compactSync.syncKeepExpanded(); });
   $effect(() => { compactSync.applyLauncherHeight(); });
 
   onMount(() => compactSync.onMount());

--- a/src/services/launcher/compactSyncService.svelte.test.ts
+++ b/src/services/launcher/compactSyncService.svelte.test.ts
@@ -1,0 +1,114 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('../theme/nativeBarSync', () => ({
+  startNativeBarStyleSync: vi.fn(),
+}));
+
+vi.mock('../log/logService', () => ({
+  logService: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { CompactSyncService, type CompactSyncDeps } from './compactSyncService.svelte';
+import { invoke } from '@tauri-apps/api/core';
+
+interface MutableDeps {
+  initialized: boolean;
+  launchView: string;
+  activeView: unknown;
+  activeContext: unknown;
+  localSearchValue: string;
+  isSearchLoading: boolean;
+  currentError: unknown;
+  lastCompletedQuery: string | null;
+}
+
+function makeDeps(overrides: Partial<MutableDeps> = {}): { state: MutableDeps; deps: CompactSyncDeps } {
+  const state: MutableDeps = {
+    initialized: true,
+    launchView: 'compact',
+    activeView: null,
+    activeContext: null,
+    localSearchValue: '',
+    isSearchLoading: false,
+    currentError: null,
+    lastCompletedQuery: null,
+    ...overrides,
+  };
+  const deps: CompactSyncDeps = {
+    getInitialized: () => state.initialized,
+    getLaunchView: () => state.launchView,
+    getActiveView: () => state.activeView,
+    getActiveContext: () => state.activeContext,
+    getLocalSearchValue: () => state.localSearchValue,
+    getIsSearchLoading: () => state.isSearchLoading,
+    getCurrentError: () => state.currentError,
+    getLastCompletedQuery: () => state.lastCompletedQuery,
+  };
+  return { state, deps };
+}
+
+describe('CompactSyncService.syncKeepExpanded', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mirrors keepExpanded=false when the launcher is in the compact idle state', () => {
+    const { deps } = makeDeps(); // compact + nothing active → isCompactIdle true
+    const svc = new CompactSyncService(deps);
+
+    svc.syncKeepExpanded();
+
+    expect(invoke).toHaveBeenCalledWith('set_launcher_keep_expanded', { keepExpanded: false });
+  });
+
+  it('mirrors keepExpanded=true when an extension view is active, even with empty query', () => {
+    // Regression for the reopen-in-compact bug: viewManager clears the query
+    // when navigating, so a `has_query`-only proxy would say "collapse OK".
+    // keepExpanded must cover activeView independently.
+    const { deps } = makeDeps({ activeView: 'ext-id/view' });
+    const svc = new CompactSyncService(deps);
+
+    svc.syncKeepExpanded();
+
+    expect(invoke).toHaveBeenCalledWith('set_launcher_keep_expanded', { keepExpanded: true });
+  });
+
+  it('mirrors keepExpanded=true when a context chip is active', () => {
+    const { deps } = makeDeps({ activeContext: { provider: { id: 'google' }, query: '' } });
+    const svc = new CompactSyncService(deps);
+
+    svc.syncKeepExpanded();
+
+    expect(invoke).toHaveBeenCalledWith('set_launcher_keep_expanded', { keepExpanded: true });
+  });
+
+  it('deduplicates — calling twice with the same state only invokes once', () => {
+    const { deps } = makeDeps({ activeView: 'ext/view' });
+    const svc = new CompactSyncService(deps);
+
+    svc.syncKeepExpanded();
+    svc.syncKeepExpanded();
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-emits when the underlying decision flips back to idle', () => {
+    const { state, deps } = makeDeps({ activeView: 'ext/view' });
+    const svc = new CompactSyncService(deps);
+
+    svc.syncKeepExpanded();
+    state.activeView = null;
+    svc.syncKeepExpanded();
+
+    expect(invoke).toHaveBeenNthCalledWith(1, 'set_launcher_keep_expanded', { keepExpanded: true });
+    expect(invoke).toHaveBeenNthCalledWith(2, 'set_launcher_keep_expanded', { keepExpanded: false });
+  });
+});

--- a/src/services/launcher/compactSyncService.svelte.ts
+++ b/src/services/launcher/compactSyncService.svelte.ts
@@ -13,7 +13,7 @@ import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import {
   setLauncherHeight,
   markLauncherReady,
-  setLauncherHasQuery,
+  setLauncherKeepExpanded,
 } from '../../lib/ipc/commands';
 import { startNativeBarStyleSync } from '../theme/nativeBarSync';
 import { logService } from '../log/logService';
@@ -41,7 +41,7 @@ export class CompactSyncService {
   #lastApplied = -1;
   #pendingRaf1 = 0;
   #pendingRaf2 = 0;
-  #lastHasQuery: boolean | null = null;
+  #lastKeepExpanded: boolean | null = null;
   #deps: CompactSyncDeps;
 
   constructor(deps: CompactSyncDeps) {
@@ -83,16 +83,18 @@ export class CompactSyncService {
   }
 
   /**
-   * Mirrors query presence into Rust's AppState so the panel resign
-   * handler can tell a typed-query expansion from a transient Show More
-   * click. No-ops if the boolean hasn't flipped.
+   * Mirrors `!isCompactIdle` into Rust's AppState so the panel resign
+   * handler knows whether the launcher is in a committed expanded state
+   * (typed query, active extension view, active context chip, Show More
+   * click) that must not be collapsed on hide. TS is the single source of
+   * truth; Rust is a sink. No-ops if the boolean hasn't flipped.
    */
-  syncHasQuery(): void {
-    const hasQuery = !!this.#deps.getLocalSearchValue();
-    if (hasQuery === this.#lastHasQuery) return;
-    this.#lastHasQuery = hasQuery;
-    setLauncherHasQuery(hasQuery).catch((e) =>
-      logService.debug(`[compact] setLauncherHasQuery failed: ${e}`),
+  syncKeepExpanded(): void {
+    const keepExpanded = !this.isCompactIdle;
+    if (keepExpanded === this.#lastKeepExpanded) return;
+    this.#lastKeepExpanded = keepExpanded;
+    setLauncherKeepExpanded(keepExpanded).catch((e) =>
+      logService.debug(`[compact] setLauncherKeepExpanded failed: ${e}`),
     );
   }
 


### PR DESCRIPTION
In compact mode, hiding the launcher while an extension view was
active shrank the NSWindow to 96px and reopened clipped — the
Rust resign handler's launcher_has_query proxy didn't cover
activeView/activeContext. Replace it with launcher_keep_expanded,
mirrored from TS's canonical !isCompactIdle, so any committed
expanded state survives hide/show.