### PR TITLE
feat: add macOS Uninstall Application action

### DIFF
--- a/docs/reference/sdk/application-service.md
+++ b/docs/reference/sdk/application-service.md
@@ -138,4 +138,35 @@ Retrieving the **window title** via `getFrontmostApplication` on macOS requires 
 
 On Windows, `bundleId` in `FrontmostApplication` returns the executable name (e.g. `chrome.exe`). The `name` field returns the localized description from file version info where available, otherwise the file name.
 
+### Uninstall actions — Tier 1 only
+
+The launcher action panel exposes a built-in **Uninstall Application** action. It is intentionally **not** surfaced on `IApplicationService`:
+
+- The `application:*` namespace today is read-only (frontmost metadata, installed-app listing, presence queries). Adding a destructive file-system write to it would be a capability jump that every extension using the namespace would inherit.
+- The UX belongs in the launcher shell. Confirmation, trash/uninstaller feedback, and the action-panel gating are all shell responsibilities.
+- The backing Tauri command rejects any Tier 2 caller with `AppError::Permission`. Even `asyar:api:invoke` pass-through can't reach it.
+
+Extensions that need to react to uninstalls — for example to invalidate cached bundle metadata — should subscribe to `onApplicationsChanged`; the index watcher fires automatically when the bundle disappears from a scanned directory.
+
+**Platform behaviour:**
+
+| Platform | Action visibility | Behaviour on confirm |
+|----------|-------------------|----------------------|
+| macOS    | Shown for `type: 'application'` results whose `path` does not start with `/System/` | Before the confirm sheet, Asyar scans `~/Library/*` for user data keyed by the app's `CFBundleIdentifier` (Application Support, Caches, Logs, Containers, HTTPStorages, WebKit, Application Scripts, Preferences/*.plist, ByHost preferences, Saved Application State, LaunchAgents, Cookies) plus two name-keyed fallbacks. The confirm sheet shows the total size. On confirm, the `.app` bundle is moved to Trash via the `trash` crate, followed by each user-data path. All items remain reversible from Finder's Trash. |
+| Windows  | Shown for `type: 'application'` results with a `.lnk` path | The shortcut's display-name is matched case-insensitively against `HKLM/HKCU\…\CurrentVersion\Uninstall\*`; the discovered `UninstallString` is launched via `cmd /C`. The vendor's own uninstaller UI takes over (including any UAC prompt). Asyar does not scan user data — the vendor uninstaller is responsible for that cleanup. |
+| Linux    | Hidden | Not supported — package-manager fragmentation (apt/dnf/pacman/flatpak/snap/AppImage) makes a single first-party implementation impractical. |
+
+**macOS data-scan scope** — the scanner is intentionally conservative:
+
+- **Included**: `~/Library/Application Support/<bundle-id>`, `~/Library/Caches/<bundle-id>`, `~/Library/Logs/<bundle-id>`, `~/Library/Containers/<bundle-id>`, `~/Library/HTTPStorages/<bundle-id>`, `~/Library/WebKit/<bundle-id>`, `~/Library/Application Scripts/<bundle-id>`, `~/Library/Preferences/<bundle-id>.plist`, `~/Library/Preferences/ByHost/<bundle-id>.*.plist`, `~/Library/Saved Application State/<bundle-id>.savedState`, `~/Library/LaunchAgents/<bundle-id>.plist`, `~/Library/Cookies/<bundle-id>.binarycookies`, plus name-keyed variants of Application Support and Caches.
+- **Excluded** (by design): `~/Library/Group Containers/*` (shared across multiple apps), `/Library/LaunchDaemons/*` and `/Library/PrivilegedHelperTools/*` (require admin), `~/Library/Keychains/*` (requires the user's password), any path that is a symlink.
+- **Safety gate**: every data path is independently validated in Rust before it's passed to `trash::delete` — must be absolute, exist, live under `$HOME/Library`, and not be a symlink. A bogus path in the TS-supplied list is logged and skipped; the primary `.app` uninstall still succeeds.
+
+**Windows safety gates (enforced in Rust):**
+
+- Empty or missing `UninstallString` → `AppError::Validation`.
+- Entry flagged `SystemComponent = 1` → `AppError::Permission` (these are Windows updates/components and never user-uninstallable).
+- Entry's `DisplayName` matches Asyar itself (case-insensitive) → `AppError::Permission` (no self-uninstall).
+- No matching registry entry → `AppError::NotFound` (the UI surfaces this as a "Uninstall failed: …" HUD).
+
 ---

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "uuid",
  "window-vibrancy",
  "windows 0.61.3",
+ "winreg 0.56.0",
  "wmi",
  "x11rb",
  "zbus 4.4.0",
@@ -8386,6 +8387,16 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -114,6 +114,10 @@ windows = { version = "0.61", features = [
     "Win32_System_Diagnostics_ToolHelp",
 ] }
 wmi = "0.14"
+# Registry access for the uninstall-application flow (scanning
+# Software\Microsoft\Windows\CurrentVersion\Uninstall for the app's
+# UninstallString). Ergonomic wrapper over the Win32 Registry API.
+winreg = "0.56"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18"

--- a/src-tauri/src/application/mod.rs
+++ b/src-tauri/src/application/mod.rs
@@ -1,5 +1,6 @@
 pub mod service;
 pub mod index_watcher;
+pub mod uninstall;
 
 pub use service::get_default_app_scan_paths;
 pub use service::is_default_app_location;

--- a/src-tauri/src/application/uninstall.rs
+++ b/src-tauri/src/application/uninstall.rs
@@ -1,0 +1,285 @@
+//! Application-uninstall service module.
+//!
+//! Moves installed application bundles to the OS Trash. macOS-only in this
+//! release; Linux/Windows return `AppError::Platform` because proper uninstall
+//! on those systems requires package-manager integration (see the "Out of
+//! scope" notes in the launching PR).
+//!
+//! The Tauri command wrapper lives at `commands::applications::uninstall_application`
+//! and is intentionally restricted to core callers (the Tier 1 action panel),
+//! not exposed to Tier 2 extensions — uninstalling apps is a capability jump
+//! beyond the `application:*` namespace's current read-only shape.
+
+use crate::error::AppError;
+use std::path::{Path, PathBuf};
+
+/// Moves an installed application bundle to the OS Trash.
+///
+/// Safety gates (all must pass on every platform):
+///
+/// 1. Platform = macOS (other OSes return `AppError::Platform`).
+/// 2. Path ends in `.app`.
+/// 3. Path is absolute.
+/// 4. Path exists and is a directory (`.app` bundles are directories).
+/// 5. Canonicalized path does not start with `/System/`.
+/// 6. Canonicalized path is not Asyar's own bundle.
+pub fn uninstall_application(path: &str) -> Result<(), AppError> {
+    uninstall_application_inner(path, resolve_own_bundle_path().as_deref())
+}
+
+/// Test-visible core. Accepts `own_bundle_path` explicitly so unit tests can
+/// assert the self-bundle guard without spawning a real Tauri app.
+pub(crate) fn uninstall_application_inner(
+    path: &str,
+    own_bundle_path: Option<&Path>,
+) -> Result<(), AppError> {
+    let canonical = validate_uninstall_path(path, own_bundle_path)?;
+
+    #[cfg(target_os = "macos")]
+    {
+        trash::delete(&canonical)
+            .map_err(|e| AppError::Other(format!("Failed to move app to Trash: {}", e)))?;
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        // Unreachable — validate_uninstall_path already rejected non-macOS
+        // platforms — but the match keeps cargo check honest on Linux/Windows.
+        let _ = canonical;
+        Err(AppError::Platform(
+            "uninstall is only supported on macOS".to_string(),
+        ))
+    }
+}
+
+/// Runs every safety gate and returns the canonicalized path on success.
+/// Pulled out of `uninstall_application_inner` so every rejection branch has a
+/// dedicated test and the final `trash::delete` only ever sees a vetted path.
+pub(crate) fn validate_uninstall_path(
+    path: &str,
+    own_bundle_path: Option<&Path>,
+) -> Result<PathBuf, AppError> {
+    if !cfg!(target_os = "macos") {
+        return Err(AppError::Platform(
+            "uninstall is only supported on macOS".to_string(),
+        ));
+    }
+
+    if path.trim().is_empty() {
+        return Err(AppError::Validation("path must be non-empty".to_string()));
+    }
+
+    let raw = Path::new(path);
+
+    if !raw.is_absolute() {
+        return Err(AppError::Validation(format!(
+            "path must be absolute: {}",
+            path
+        )));
+    }
+
+    if raw.extension().and_then(|e| e.to_str()) != Some("app") {
+        return Err(AppError::Validation(format!(
+            "path must point to a .app bundle: {}",
+            path
+        )));
+    }
+
+    if !raw.exists() {
+        return Err(AppError::NotFound(format!(
+            "application does not exist: {}",
+            path
+        )));
+    }
+
+    if !raw.is_dir() {
+        return Err(AppError::Validation(format!(
+            ".app bundle must be a directory: {}",
+            path
+        )));
+    }
+
+    // Canonicalize before the system / own-bundle checks so symlinks can't
+    // smuggle the path past the guards.
+    let canonical = raw
+        .canonicalize()
+        .map_err(|e| AppError::Other(format!("Failed to canonicalize path '{}': {}", path, e)))?;
+
+    if canonical.starts_with("/System/") || canonical.starts_with("/System") {
+        return Err(AppError::Permission(format!(
+            "cannot uninstall system-protected application: {}",
+            path
+        )));
+    }
+
+    if let Some(own) = own_bundle_path {
+        if let Ok(own_canonical) = own.canonicalize() {
+            if canonical == own_canonical {
+                return Err(AppError::Permission(
+                    "refusing to uninstall Asyar itself".to_string(),
+                ));
+            }
+        }
+    }
+
+    Ok(canonical)
+}
+
+/// Best-effort: walks up from the current executable looking for the
+/// containing `.app` bundle so the self-bundle guard has something to compare
+/// against. Returns `None` when run outside a bundle (e.g. `cargo test` or
+/// `cargo run` during development) — in that case the guard is a no-op, which
+/// is safe because no user can select the dev binary in search results.
+fn resolve_own_bundle_path() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    for ancestor in exe.ancestors() {
+        if ancestor.extension().and_then(|e| e.to_str()) == Some("app") {
+            return Some(ancestor.to_path_buf());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_fake_app(tmp: &TempDir, name: &str) -> PathBuf {
+        let app_path = tmp.path().join(name);
+        fs::create_dir_all(&app_path).unwrap();
+        // Fake Info.plist so the bundle looks real enough to callers that peek.
+        fs::create_dir_all(app_path.join("Contents")).unwrap();
+        fs::write(app_path.join("Contents/Info.plist"), b"<plist/>").unwrap();
+        app_path
+    }
+
+    #[test]
+    fn rejects_empty_path() {
+        let err = validate_uninstall_path("", None).unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn rejects_whitespace_only_path() {
+        let err = validate_uninstall_path("   ", None).unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn rejects_relative_path() {
+        let err = validate_uninstall_path("Applications/Foo.app", None).unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn rejects_path_without_dot_app_extension() {
+        let err = validate_uninstall_path("/Applications/not-an-app", None).unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn rejects_nonexistent_path() {
+        let err = validate_uninstall_path(
+            "/tmp/__asyar_nonexistent_uninstall_test__.app",
+            None,
+        )
+        .unwrap_err();
+        assert!(matches!(err, AppError::NotFound(_)), "got: {err:?}");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn rejects_file_masquerading_as_app_bundle() {
+        let tmp = TempDir::new().unwrap();
+        let fake = tmp.path().join("Foo.app");
+        fs::write(&fake, b"not a directory").unwrap();
+        let err = validate_uninstall_path(fake.to_str().unwrap(), None).unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn rejects_system_applications_path() {
+        // `/System/Applications` exists on macOS CI and dev machines, but we
+        // don't want to hit it for real — the guard must trigger based on the
+        // path prefix regardless of whether the specific app exists.
+        let candidate = "/System/Applications/Calendar.app";
+        let result = validate_uninstall_path(candidate, None);
+        // Either Permission (rejected by prefix guard) or NotFound if the
+        // exact app is missing. Both are non-success; the important contract
+        // is that we never return Ok for a /System/ path.
+        assert!(result.is_err(), "must not allow /System/ path");
+        if let Err(err) = result {
+            assert!(
+                matches!(err, AppError::Permission(_) | AppError::NotFound(_)),
+                "got: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn rejects_asyars_own_bundle() {
+        let tmp = TempDir::new().unwrap();
+        let app = make_fake_app(&tmp, "Asyar.app");
+        let err = validate_uninstall_path(app.to_str().unwrap(), Some(&app)).unwrap_err();
+        assert!(matches!(err, AppError::Permission(_)), "got: {err:?}");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn accepts_valid_user_app() {
+        let tmp = TempDir::new().unwrap();
+        let app = make_fake_app(&tmp, "SafeApp.app");
+        let canonical = validate_uninstall_path(app.to_str().unwrap(), None).unwrap();
+        assert!(canonical.exists());
+        assert_eq!(canonical.extension().and_then(|e| e.to_str()), Some("app"));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn own_bundle_guard_does_not_reject_other_apps() {
+        let tmp = TempDir::new().unwrap();
+        let app = make_fake_app(&tmp, "Other.app");
+        let asyar = make_fake_app(&tmp, "Asyar.app");
+        // `app` and `asyar` are siblings, not the same path — guard must pass.
+        let canonical = validate_uninstall_path(app.to_str().unwrap(), Some(&asyar)).unwrap();
+        assert_eq!(canonical.file_name().and_then(|n| n.to_str()), Some("Other.app"));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn uninstall_application_actually_trashes_bundle() {
+        // End-to-end: valid bundle in a user directory should be moved to Trash.
+        let tmp = TempDir::new().unwrap();
+        let app = make_fake_app(&tmp, "TrashMe.app");
+        assert!(app.exists());
+
+        uninstall_application_inner(app.to_str().unwrap(), None).unwrap();
+
+        assert!(
+            !app.exists(),
+            "bundle should no longer exist at its source path after uninstall"
+        );
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn rejects_all_paths_on_non_macos() {
+        let err = validate_uninstall_path("/anything", None).unwrap_err();
+        assert!(matches!(err, AppError::Platform(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn resolve_own_bundle_path_returns_option_without_panicking() {
+        // Contract test: never panics, regardless of where the test binary
+        // runs. Value may be None (dev) or Some (inside a bundle) — both ok.
+        let _ = resolve_own_bundle_path();
+    }
+}

--- a/src-tauri/src/application/uninstall.rs
+++ b/src-tauri/src/application/uninstall.rs
@@ -1,71 +1,75 @@
 //! Application-uninstall service module.
 //!
-//! Moves installed application bundles to the OS Trash. macOS-only in this
-//! release; Linux/Windows return `AppError::Platform` because proper uninstall
-//! on those systems requires package-manager integration (see the "Out of
-//! scope" notes in the launching PR).
+//! Moves an installed application out of the system. macOS and Windows are
+//! supported; Linux is deferred because packaging is too fragmented
+//! (apt/dnf/pacman/flatpak/snap/AppImage) for a single-path first-party
+//! implementation.
 //!
-//! The Tauri command wrapper lives at `commands::applications::uninstall_application`
-//! and is intentionally restricted to core callers (the Tier 1 action panel),
-//! not exposed to Tier 2 extensions — uninstalling apps is a capability jump
-//! beyond the `application:*` namespace's current read-only shape.
+//! - **macOS** — the `.app` bundle is moved to the OS Trash via the `trash`
+//!   crate. Fully reversible from Finder's Trash.
+//! - **Windows** — the scanner indexes `.lnk` shortcuts. Uninstall resolves
+//!   the shortcut's display name against `…\CurrentVersion\Uninstall\*`
+//!   registry keys and launches the discovered `UninstallString` via
+//!   `cmd /C`. The vendor's own uninstaller UI then takes over; Asyar is
+//!   fire-and-forget from that point.
+//!
+//! The Tauri command wrapper lives at
+//! [`crate::commands::applications::uninstall_application`] and is restricted
+//! to core callers (the Tier 1 action panel). It is NOT exposed to Tier 2
+//! extensions — uninstalling apps is a capability jump beyond the read-only
+//! `application:*` namespace.
 
 use crate::error::AppError;
 use std::path::{Path, PathBuf};
 
-/// Moves an installed application bundle to the OS Trash.
-///
-/// Safety gates (all must pass on every platform):
-///
-/// 1. Platform = macOS (other OSes return `AppError::Platform`).
-/// 2. Path ends in `.app`.
-/// 3. Path is absolute.
-/// 4. Path exists and is a directory (`.app` bundles are directories).
-/// 5. Canonicalized path does not start with `/System/`.
-/// 6. Canonicalized path is not Asyar's own bundle.
+/// Uninstall the application at `path`. Dispatches to the platform-specific
+/// strategy. Linux returns `AppError::Platform` (see module doc comment for
+/// why Linux is deferred).
+#[cfg(target_os = "macos")]
 pub fn uninstall_application(path: &str) -> Result<(), AppError> {
-    uninstall_application_inner(path, resolve_own_bundle_path().as_deref())
+    uninstall_macos(path, resolve_own_bundle_path().as_deref())
 }
 
-/// Test-visible core. Accepts `own_bundle_path` explicitly so unit tests can
-/// assert the self-bundle guard without spawning a real Tauri app.
-pub(crate) fn uninstall_application_inner(
+/// Uninstall the application at `path`. Dispatches to the platform-specific
+/// strategy.
+#[cfg(target_os = "windows")]
+pub fn uninstall_application(path: &str) -> Result<(), AppError> {
+    uninstall_windows(path)
+}
+
+/// Uninstall the application at `path`. Unsupported on Linux (see module doc
+/// comment); returns `AppError::Platform`.
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub fn uninstall_application(_path: &str) -> Result<(), AppError> {
+    Err(AppError::Platform(
+        "uninstall is only supported on macOS and Windows".to_string(),
+    ))
+}
+
+// ───── macOS ──────────────────────────────────────────────────────────────
+
+/// Test-visible macOS entrypoint. Accepts `own_bundle_path` explicitly so
+/// unit tests can assert the self-bundle guard without spawning a real Tauri
+/// app.
+#[cfg(target_os = "macos")]
+pub(crate) fn uninstall_macos(
     path: &str,
     own_bundle_path: Option<&Path>,
 ) -> Result<(), AppError> {
-    let canonical = validate_uninstall_path(path, own_bundle_path)?;
-
-    #[cfg(target_os = "macos")]
-    {
-        trash::delete(&canonical)
-            .map_err(|e| AppError::Other(format!("Failed to move app to Trash: {}", e)))?;
-        Ok(())
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        // Unreachable — validate_uninstall_path already rejected non-macOS
-        // platforms — but the match keeps cargo check honest on Linux/Windows.
-        let _ = canonical;
-        Err(AppError::Platform(
-            "uninstall is only supported on macOS".to_string(),
-        ))
-    }
+    let canonical = validate_macos_bundle_path(path, own_bundle_path)?;
+    trash::delete(&canonical)
+        .map_err(|e| AppError::Other(format!("Failed to move app to Trash: {}", e)))?;
+    Ok(())
 }
 
-/// Runs every safety gate and returns the canonicalized path on success.
-/// Pulled out of `uninstall_application_inner` so every rejection branch has a
-/// dedicated test and the final `trash::delete` only ever sees a vetted path.
-pub(crate) fn validate_uninstall_path(
+/// Runs every macOS safety gate and returns the canonicalized path on
+/// success. Pulled out of the trash call so every rejection branch has a
+/// dedicated test and `trash::delete` only ever sees a vetted path.
+#[cfg(target_os = "macos")]
+pub(crate) fn validate_macos_bundle_path(
     path: &str,
     own_bundle_path: Option<&Path>,
 ) -> Result<PathBuf, AppError> {
-    if !cfg!(target_os = "macos") {
-        return Err(AppError::Platform(
-            "uninstall is only supported on macOS".to_string(),
-        ));
-    }
-
     if path.trim().is_empty() {
         return Err(AppError::Validation("path must be non-empty".to_string()));
     }
@@ -100,8 +104,6 @@ pub(crate) fn validate_uninstall_path(
         )));
     }
 
-    // Canonicalize before the system / own-bundle checks so symlinks can't
-    // smuggle the path past the guards.
     let canonical = raw
         .canonicalize()
         .map_err(|e| AppError::Other(format!("Failed to canonicalize path '{}': {}", path, e)))?;
@@ -128,9 +130,9 @@ pub(crate) fn validate_uninstall_path(
 
 /// Best-effort: walks up from the current executable looking for the
 /// containing `.app` bundle so the self-bundle guard has something to compare
-/// against. Returns `None` when run outside a bundle (e.g. `cargo test` or
-/// `cargo run` during development) — in that case the guard is a no-op, which
-/// is safe because no user can select the dev binary in search results.
+/// against. Returns `None` outside a bundle (e.g. `cargo test`) — safe
+/// because no user can select the dev binary in search results.
+#[cfg(target_os = "macos")]
 fn resolve_own_bundle_path() -> Option<PathBuf> {
     let exe = std::env::current_exe().ok()?;
     for ancestor in exe.ancestors() {
@@ -141,145 +143,599 @@ fn resolve_own_bundle_path() -> Option<PathBuf> {
     None
 }
 
+// ───── Windows ─────────────────────────────────────────────────────────────
+//
+// Pure data + logic types for the Windows flow are compiled on every target
+// so their unit tests run on macOS CI too. Only the registry scan and process
+// spawn are gated to `target_os = "windows"`.
+//
+// `#[allow(dead_code)]` is applied to each item below because `cargo clippy
+// --lib` (per the project's CI matrix) lints the library in non-test mode:
+// on macOS the production code has no caller, so without the allow we'd fail
+// -D warnings. Tests + the Windows dispatch path are the real consumers.
+
+/// A single row from one of the three `…\CurrentVersion\Uninstall\*`
+/// registry hives. Captured shape-only (no `RegKey` handle) so the matching
+/// logic is pure and testable.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WindowsUninstallEntry {
+    pub display_name: String,
+    pub uninstall_string: String,
+    pub system_component: bool,
+    pub publisher: Option<String>,
+}
+
+/// Display name used for the self-uninstall guard. Matches the Tauri
+/// bundler's default installer metadata for this project (`productName` in
+/// `tauri.conf.json` == `"asyar"`). Uppercase/mixed-case variants are covered
+/// by the case-insensitive comparison.
+#[allow(dead_code)]
+pub(crate) const ASYAR_WINDOWS_DISPLAY_NAME: &str = "asyar";
+
+/// Validates the shortcut path the user selected before touching the
+/// registry. Cross-platform compilable so the logic can be unit-tested on any
+/// OS; the `.lnk`-extension check is the meaningful constraint, not
+/// target_os.
+#[allow(dead_code)]
+pub(crate) fn validate_windows_shortcut_path(path: &str) -> Result<PathBuf, AppError> {
+    if path.trim().is_empty() {
+        return Err(AppError::Validation("path must be non-empty".to_string()));
+    }
+
+    let raw = Path::new(path);
+
+    if !raw.is_absolute() {
+        return Err(AppError::Validation(format!(
+            "path must be absolute: {}",
+            path
+        )));
+    }
+
+    if raw.extension().and_then(|e| e.to_str()) != Some("lnk") {
+        return Err(AppError::Validation(format!(
+            "path must point to a .lnk shortcut: {}",
+            path
+        )));
+    }
+
+    if !raw.exists() {
+        return Err(AppError::NotFound(format!(
+            "shortcut does not exist: {}",
+            path
+        )));
+    }
+
+    Ok(raw.to_path_buf())
+}
+
+/// The scanner indexes `.lnk` shortcuts using the file stem as the app name
+/// (see `application::service::sync_application_index`). We reverse that
+/// here to recover the display-name the user saw in search, which is what
+/// we'll match against the registry's `DisplayName` values.
+#[allow(dead_code)]
+pub(crate) fn derive_display_name_from_shortcut(lnk: &Path) -> Result<String, AppError> {
+    let name = lnk
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .trim();
+    if name.is_empty() {
+        return Err(AppError::Validation(
+            "cannot derive display name from .lnk path".to_string(),
+        ));
+    }
+    Ok(name.to_string())
+}
+
+/// Matches the Start-menu `.lnk` display name against registry `DisplayName`
+/// values. Tries, in order:
+///
+/// 1. **Exact case-insensitive match** (handles `Firefox.lnk` → `"Firefox"`
+///    when the installer writes a plain name).
+/// 2. **Unambiguous case-insensitive starts-with match** (handles
+///    `Firefox.lnk` → `"Mozilla Firefox 120.0 (x64 en-US)"` where the
+///    installer appends a version/locale suffix). Only wins when exactly one
+///    such entry exists — if multiple entries share the prefix, we refuse to
+///    guess and treat it as "no match".
+///
+/// Pure — drives a unit test per match shape without needing a real registry.
+#[allow(dead_code)]
+pub(crate) fn match_windows_entry<'a>(
+    entries: &'a [WindowsUninstallEntry],
+    target: &str,
+) -> Option<&'a WindowsUninstallEntry> {
+    if let Some(exact) = entries
+        .iter()
+        .find(|e| e.display_name.eq_ignore_ascii_case(target))
+    {
+        return Some(exact);
+    }
+
+    let target_lower = target.to_ascii_lowercase();
+    let prefix_matches: Vec<&WindowsUninstallEntry> = entries
+        .iter()
+        .filter(|e| {
+            e.display_name
+                .to_ascii_lowercase()
+                .starts_with(&target_lower)
+        })
+        .collect();
+    if prefix_matches.len() == 1 {
+        return Some(prefix_matches[0]);
+    }
+    None
+}
+
+/// Final allow-list check before spawning the uninstaller. Rejects system
+/// components, Asyar's own entry, and malformed rows (empty `UninstallString`).
+/// Pure so tests can construct fake entries and assert each rejection.
+#[allow(dead_code)]
+pub(crate) fn ensure_windows_entry_allowed(
+    entry: &WindowsUninstallEntry,
+    own_display_name: &str,
+) -> Result<(), AppError> {
+    if entry.system_component {
+        return Err(AppError::Permission(format!(
+            "cannot uninstall system component: {}",
+            entry.display_name
+        )));
+    }
+    if entry.display_name.eq_ignore_ascii_case(own_display_name) {
+        return Err(AppError::Permission(
+            "refusing to uninstall Asyar itself".to_string(),
+        ));
+    }
+    if entry.uninstall_string.trim().is_empty() {
+        return Err(AppError::Validation(format!(
+            "uninstall entry for '{}' has empty UninstallString",
+            entry.display_name
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn uninstall_windows(path: &str) -> Result<(), AppError> {
+    let lnk = validate_windows_shortcut_path(path)?;
+    let display_name = derive_display_name_from_shortcut(&lnk)?;
+    let entries = scan_uninstall_registry()?;
+    let matched = match_windows_entry(&entries, &display_name).ok_or_else(|| {
+        AppError::NotFound(format!(
+            "no uninstall registry entry matches '{}'",
+            display_name
+        ))
+    })?;
+    ensure_windows_entry_allowed(matched, ASYAR_WINDOWS_DISPLAY_NAME)?;
+    spawn_windows_uninstaller(&matched.uninstall_string)
+}
+
+/// Scans the three canonical Uninstall hives and returns every entry with
+/// both a `DisplayName` and an `UninstallString`. Rows missing either are
+/// skipped — they're not uninstallable from a UX perspective.
+///
+/// Sources, in scan order:
+/// 1. `HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall` — 64-bit
+///    machine-scope installs.
+/// 2. `HKLM\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall`
+///    — 32-bit machine-scope installs on 64-bit Windows.
+/// 3. `HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall` — per-user
+///    installs (many modern installers target this).
+#[cfg(target_os = "windows")]
+fn scan_uninstall_registry() -> Result<Vec<WindowsUninstallEntry>, AppError> {
+    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
+    use winreg::RegKey;
+
+    let mut out = Vec::new();
+    collect_entries_from(
+        &RegKey::predef(HKEY_LOCAL_MACHINE),
+        r"Software\Microsoft\Windows\CurrentVersion\Uninstall",
+        &mut out,
+    );
+    collect_entries_from(
+        &RegKey::predef(HKEY_LOCAL_MACHINE),
+        r"Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
+        &mut out,
+    );
+    collect_entries_from(
+        &RegKey::predef(HKEY_CURRENT_USER),
+        r"Software\Microsoft\Windows\CurrentVersion\Uninstall",
+        &mut out,
+    );
+    Ok(out)
+}
+
+#[cfg(target_os = "windows")]
+fn collect_entries_from(
+    root: &winreg::RegKey,
+    subpath: &str,
+    out: &mut Vec<WindowsUninstallEntry>,
+) {
+    let uninstall_key = match root.open_subkey(subpath) {
+        Ok(k) => k,
+        Err(_) => return,
+    };
+    for name in uninstall_key.enum_keys().flatten() {
+        let entry_key = match uninstall_key.open_subkey(&name) {
+            Ok(k) => k,
+            Err(_) => continue,
+        };
+        let display_name: String = match entry_key.get_value("DisplayName") {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let uninstall_string: String = match entry_key.get_value("UninstallString") {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let system_component: u32 = entry_key.get_value("SystemComponent").unwrap_or(0);
+        let publisher: Option<String> = entry_key.get_value("Publisher").ok();
+        out.push(WindowsUninstallEntry {
+            display_name,
+            uninstall_string,
+            system_component: system_component != 0,
+            publisher,
+        });
+    }
+}
+
+/// Spawns the vendor uninstaller via `cmd /C`. Fire-and-forget: the
+/// uninstaller runs its own UI (including any UAC elevation prompt); Asyar's
+/// job ends once the command is dispatched.
+///
+/// `cmd /C` handles the quote/space parsing inside `UninstallString` the same
+/// way an Add/Remove-Programs double-click would, which is the closest we can
+/// get to "behave like the OS's own entry point."
+#[cfg(target_os = "windows")]
+fn spawn_windows_uninstaller(uninstall_string: &str) -> Result<(), AppError> {
+    use std::process::Command;
+    Command::new("cmd")
+        .args(["/C", uninstall_string])
+        .spawn()
+        .map_err(|e| {
+            AppError::Other(format!(
+                "failed to launch uninstaller '{}': {}",
+                uninstall_string, e
+            ))
+        })?;
+    Ok(())
+}
+
+// ───── Tests ───────────────────────────────────────────────────────────────
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-    use tempfile::TempDir;
 
-    fn make_fake_app(tmp: &TempDir, name: &str) -> PathBuf {
-        let app_path = tmp.path().join(name);
-        fs::create_dir_all(&app_path).unwrap();
-        // Fake Info.plist so the bundle looks real enough to callers that peek.
-        fs::create_dir_all(app_path.join("Contents")).unwrap();
-        fs::write(app_path.join("Contents/Info.plist"), b"<plist/>").unwrap();
-        app_path
-    }
-
-    #[test]
-    fn rejects_empty_path() {
-        let err = validate_uninstall_path("", None).unwrap_err();
-        assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
-    }
-
-    #[test]
-    fn rejects_whitespace_only_path() {
-        let err = validate_uninstall_path("   ", None).unwrap_err();
-        assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
-    }
-
-    #[test]
+    // ─── macOS validator tests ──────────────────────────────────────────
     #[cfg(target_os = "macos")]
-    fn rejects_relative_path() {
-        let err = validate_uninstall_path("Applications/Foo.app", None).unwrap_err();
-        assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
-    }
+    mod macos {
+        use super::*;
+        use std::fs;
+        use tempfile::TempDir;
 
-    #[test]
-    #[cfg(target_os = "macos")]
-    fn rejects_path_without_dot_app_extension() {
-        let err = validate_uninstall_path("/Applications/not-an-app", None).unwrap_err();
-        assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
-    }
+        fn make_fake_app(tmp: &TempDir, name: &str) -> PathBuf {
+            let app_path = tmp.path().join(name);
+            fs::create_dir_all(&app_path).unwrap();
+            fs::create_dir_all(app_path.join("Contents")).unwrap();
+            fs::write(app_path.join("Contents/Info.plist"), b"<plist/>").unwrap();
+            app_path
+        }
 
-    #[test]
-    #[cfg(target_os = "macos")]
-    fn rejects_nonexistent_path() {
-        let err = validate_uninstall_path(
-            "/tmp/__asyar_nonexistent_uninstall_test__.app",
-            None,
-        )
-        .unwrap_err();
-        assert!(matches!(err, AppError::NotFound(_)), "got: {err:?}");
-    }
+        #[test]
+        fn rejects_empty_path() {
+            let err = validate_macos_bundle_path("", None).unwrap_err();
+            assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+        }
 
-    #[test]
-    #[cfg(target_os = "macos")]
-    fn rejects_file_masquerading_as_app_bundle() {
-        let tmp = TempDir::new().unwrap();
-        let fake = tmp.path().join("Foo.app");
-        fs::write(&fake, b"not a directory").unwrap();
-        let err = validate_uninstall_path(fake.to_str().unwrap(), None).unwrap_err();
-        assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
-    }
+        #[test]
+        fn rejects_whitespace_only_path() {
+            let err = validate_macos_bundle_path("   ", None).unwrap_err();
+            assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+        }
 
-    #[test]
-    #[cfg(target_os = "macos")]
-    fn rejects_system_applications_path() {
-        // `/System/Applications` exists on macOS CI and dev machines, but we
-        // don't want to hit it for real — the guard must trigger based on the
-        // path prefix regardless of whether the specific app exists.
-        let candidate = "/System/Applications/Calendar.app";
-        let result = validate_uninstall_path(candidate, None);
-        // Either Permission (rejected by prefix guard) or NotFound if the
-        // exact app is missing. Both are non-success; the important contract
-        // is that we never return Ok for a /System/ path.
-        assert!(result.is_err(), "must not allow /System/ path");
-        if let Err(err) = result {
+        #[test]
+        fn rejects_relative_path() {
+            let err = validate_macos_bundle_path("Applications/Foo.app", None).unwrap_err();
+            assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn rejects_path_without_dot_app_extension() {
+            let err = validate_macos_bundle_path("/Applications/not-an-app", None).unwrap_err();
+            assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn rejects_nonexistent_path() {
+            let err = validate_macos_bundle_path(
+                "/tmp/__asyar_nonexistent_uninstall_test__.app",
+                None,
+            )
+            .unwrap_err();
+            assert!(matches!(err, AppError::NotFound(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn rejects_file_masquerading_as_app_bundle() {
+            let tmp = TempDir::new().unwrap();
+            let fake = tmp.path().join("Foo.app");
+            fs::write(&fake, b"not a directory").unwrap();
+            let err = validate_macos_bundle_path(fake.to_str().unwrap(), None).unwrap_err();
+            assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn rejects_system_applications_path() {
+            let candidate = "/System/Applications/Calendar.app";
+            let result = validate_macos_bundle_path(candidate, None);
+            assert!(result.is_err(), "must not allow /System/ path");
+            if let Err(err) = result {
+                assert!(
+                    matches!(err, AppError::Permission(_) | AppError::NotFound(_)),
+                    "got: {err:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn rejects_asyars_own_bundle() {
+            let tmp = TempDir::new().unwrap();
+            let app = make_fake_app(&tmp, "Asyar.app");
+            let err = validate_macos_bundle_path(app.to_str().unwrap(), Some(&app)).unwrap_err();
+            assert!(matches!(err, AppError::Permission(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn accepts_valid_user_app() {
+            let tmp = TempDir::new().unwrap();
+            let app = make_fake_app(&tmp, "SafeApp.app");
+            let canonical = validate_macos_bundle_path(app.to_str().unwrap(), None).unwrap();
+            assert!(canonical.exists());
+            assert_eq!(canonical.extension().and_then(|e| e.to_str()), Some("app"));
+        }
+
+        #[test]
+        fn own_bundle_guard_does_not_reject_other_apps() {
+            let tmp = TempDir::new().unwrap();
+            let app = make_fake_app(&tmp, "Other.app");
+            let asyar = make_fake_app(&tmp, "Asyar.app");
+            let canonical = validate_macos_bundle_path(app.to_str().unwrap(), Some(&asyar)).unwrap();
+            assert_eq!(canonical.file_name().and_then(|n| n.to_str()), Some("Other.app"));
+        }
+
+        #[test]
+        fn uninstall_macos_actually_trashes_bundle() {
+            let tmp = TempDir::new().unwrap();
+            let app = make_fake_app(&tmp, "TrashMe.app");
+            assert!(app.exists());
+
+            uninstall_macos(app.to_str().unwrap(), None).unwrap();
+
             assert!(
-                matches!(err, AppError::Permission(_) | AppError::NotFound(_)),
-                "got: {err:?}"
+                !app.exists(),
+                "bundle should no longer exist at its source path after uninstall"
             );
+        }
+
+        #[test]
+        fn resolve_own_bundle_path_returns_option_without_panicking() {
+            let _ = resolve_own_bundle_path();
         }
     }
 
-    #[test]
-    #[cfg(target_os = "macos")]
-    fn rejects_asyars_own_bundle() {
-        let tmp = TempDir::new().unwrap();
-        let app = make_fake_app(&tmp, "Asyar.app");
-        let err = validate_uninstall_path(app.to_str().unwrap(), Some(&app)).unwrap_err();
-        assert!(matches!(err, AppError::Permission(_)), "got: {err:?}");
+    // ─── Windows pure-logic tests ────────────────────────────────────────
+    // These run on every target (no cfg gate) — they only exercise in-memory
+    // types and case-insensitive string comparisons. The real registry scan
+    // and process spawn are gated to Windows and are intentionally not
+    // unit-tested here (Windows CI / manual smoke covers them).
+    mod windows_logic {
+        use super::*;
+
+        fn entry(name: &str, uninstall_string: &str) -> WindowsUninstallEntry {
+            WindowsUninstallEntry {
+                display_name: name.to_string(),
+                uninstall_string: uninstall_string.to_string(),
+                system_component: false,
+                publisher: None,
+            }
+        }
+
+        #[test]
+        fn match_entry_finds_exact_name() {
+            let entries = vec![entry("Firefox", "C:\\uninst.exe")];
+            let found = match_windows_entry(&entries, "Firefox").unwrap();
+            assert_eq!(found.display_name, "Firefox");
+        }
+
+        #[test]
+        fn match_entry_is_case_insensitive() {
+            let entries = vec![entry("Firefox", "C:\\uninst.exe")];
+            assert!(match_windows_entry(&entries, "firefox").is_some());
+            assert!(match_windows_entry(&entries, "FIREFOX").is_some());
+            assert!(match_windows_entry(&entries, "FiReFoX").is_some());
+        }
+
+        #[test]
+        fn match_entry_returns_none_for_no_match() {
+            let entries = vec![entry("Firefox", "C:\\uninst.exe")];
+            assert!(match_windows_entry(&entries, "Chrome").is_none());
+        }
+
+        #[test]
+        fn match_entry_returns_none_for_empty_list() {
+            let entries: Vec<WindowsUninstallEntry> = vec![];
+            assert!(match_windows_entry(&entries, "Firefox").is_none());
+        }
+
+        #[test]
+        fn match_entry_starts_with_fallback_hits_versioned_display_name() {
+            // Real-world shape: the Start-menu shortcut is `Mozilla Firefox.lnk`
+            // (stem == "Mozilla Firefox"), and the registry DisplayName is
+            // "Mozilla Firefox (x64 en-US)" with a version/locale suffix the
+            // exact-match pass doesn't catch.
+            let entries = vec![entry(
+                "Mozilla Firefox (x64 en-US)",
+                "uninstall.exe",
+            )];
+            let found = match_windows_entry(&entries, "Mozilla Firefox").unwrap();
+            assert_eq!(found.uninstall_string, "uninstall.exe");
+        }
+
+        #[test]
+        fn match_entry_starts_with_fallback_is_case_insensitive() {
+            let entries = vec![entry("MOZILLA FIREFOX 120.0", "uninstall.exe")];
+            let found = match_windows_entry(&entries, "mozilla firefox").unwrap();
+            assert_eq!(found.uninstall_string, "uninstall.exe");
+        }
+
+        #[test]
+        fn match_entry_starts_with_fallback_rejects_substring_in_middle() {
+            // Target appears inside the DisplayName but not at the start —
+            // the fallback is strictly prefix to avoid matches like
+            // "Firefox" → "Mozilla Firefox" that could be intentional but
+            // could also collide with unrelated "Firefox Backup" or similar.
+            let entries = vec![entry("Mozilla Firefox 120.0", "uninstall.exe")];
+            assert!(match_windows_entry(&entries, "Firefox").is_none());
+        }
+
+        #[test]
+        fn match_entry_prefers_exact_over_prefix_when_both_exist() {
+            let entries = vec![
+                entry("Firefox Developer Edition", "uninst-dev.exe"),
+                entry("Firefox", "uninst.exe"),
+            ];
+            let found = match_windows_entry(&entries, "Firefox").unwrap();
+            // Exact match wins — otherwise the ambiguous-prefix path would
+            // refuse to pick and we'd get None.
+            assert_eq!(found.display_name, "Firefox");
+            assert_eq!(found.uninstall_string, "uninst.exe");
+        }
+
+        #[test]
+        fn match_entry_refuses_ambiguous_prefix_match() {
+            // Two DisplayNames start with "Firefox" and neither is an exact
+            // match — refuse to guess; caller surfaces NotFound.
+            let entries = vec![
+                entry("Firefox Developer Edition", "uninst-dev.exe"),
+                entry("Firefox Beta", "uninst-beta.exe"),
+            ];
+            assert!(match_windows_entry(&entries, "Firefox").is_none());
+        }
+
+        #[test]
+        fn ensure_allowed_accepts_normal_entry() {
+            assert!(ensure_windows_entry_allowed(
+                &entry("Firefox", "C:\\uninst.exe"),
+                ASYAR_WINDOWS_DISPLAY_NAME,
+            )
+            .is_ok());
+        }
+
+        #[test]
+        fn ensure_allowed_rejects_system_component() {
+            let mut e = entry("Windows Update", "wusa.exe /uninstall /kb:123456");
+            e.system_component = true;
+            let err = ensure_windows_entry_allowed(&e, ASYAR_WINDOWS_DISPLAY_NAME).unwrap_err();
+            assert!(matches!(err, AppError::Permission(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn ensure_allowed_rejects_asyar_self_lowercase() {
+            let err = ensure_windows_entry_allowed(
+                &entry("asyar", "C:\\Program Files\\asyar\\uninstall.exe"),
+                ASYAR_WINDOWS_DISPLAY_NAME,
+            )
+            .unwrap_err();
+            assert!(matches!(err, AppError::Permission(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn ensure_allowed_rejects_asyar_self_capitalized() {
+            let err = ensure_windows_entry_allowed(
+                &entry("Asyar", "uninstall.exe"),
+                ASYAR_WINDOWS_DISPLAY_NAME,
+            )
+            .unwrap_err();
+            assert!(matches!(err, AppError::Permission(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn ensure_allowed_rejects_empty_uninstall_string() {
+            let err = ensure_windows_entry_allowed(&entry("SomeApp", ""), ASYAR_WINDOWS_DISPLAY_NAME)
+                .unwrap_err();
+            assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn ensure_allowed_rejects_whitespace_uninstall_string() {
+            let err =
+                ensure_windows_entry_allowed(&entry("SomeApp", "   "), ASYAR_WINDOWS_DISPLAY_NAME)
+                    .unwrap_err();
+            assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+        }
+
+        // `\` is not a path separator on non-Windows, so these tests use `/`
+        // which Windows' Path API accepts as well. The logic under test
+        // (`file_stem()`) is identical either way.
+        #[test]
+        fn derive_display_name_strips_lnk_extension() {
+            let name =
+                derive_display_name_from_shortcut(Path::new("/Users/x/Firefox.lnk")).unwrap();
+            assert_eq!(name, "Firefox");
+        }
+
+        #[test]
+        fn derive_display_name_handles_spaces_in_filename() {
+            let name = derive_display_name_from_shortcut(Path::new(
+                "/Users/x/Visual Studio Code.lnk",
+            ))
+            .unwrap();
+            assert_eq!(name, "Visual Studio Code");
+        }
+
+        // Path validation is cross-platform compilable, so run on any target.
+        #[test]
+        fn shortcut_path_rejects_empty() {
+            let err = validate_windows_shortcut_path("").unwrap_err();
+            assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn shortcut_path_rejects_whitespace_only() {
+            let err = validate_windows_shortcut_path("   ").unwrap_err();
+            assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn shortcut_path_rejects_non_lnk_extension() {
+            // Use a platform-absolute path that exists on the runner so we
+            // reach the extension check, not the absolute/exists checks.
+            // On macOS and Linux `/tmp` exists; on Windows tests we'd hit
+            // the absolute check first anyway, which is also a Validation
+            // error — either way the assertion holds.
+            let err = validate_windows_shortcut_path("/tmp/foo.txt").unwrap_err();
+            assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn shortcut_path_accepts_existing_dot_lnk() {
+            // Create a real file with .lnk extension in a temp dir — the
+            // validator doesn't parse shortcut contents, it only checks
+            // existence + absolute + extension.
+            let tmp = tempfile::TempDir::new().unwrap();
+            let lnk = tmp.path().join("Firefox.lnk");
+            std::fs::write(&lnk, b"not a real shortcut but file exists").unwrap();
+            let result = validate_windows_shortcut_path(lnk.to_str().unwrap());
+            assert!(result.is_ok(), "got: {result:?}");
+        }
     }
 
+    // ─── Cross-platform dispatch ─────────────────────────────────────────
     #[test]
-    #[cfg(target_os = "macos")]
-    fn accepts_valid_user_app() {
-        let tmp = TempDir::new().unwrap();
-        let app = make_fake_app(&tmp, "SafeApp.app");
-        let canonical = validate_uninstall_path(app.to_str().unwrap(), None).unwrap();
-        assert!(canonical.exists());
-        assert_eq!(canonical.extension().and_then(|e| e.to_str()), Some("app"));
-    }
-
-    #[test]
-    #[cfg(target_os = "macos")]
-    fn own_bundle_guard_does_not_reject_other_apps() {
-        let tmp = TempDir::new().unwrap();
-        let app = make_fake_app(&tmp, "Other.app");
-        let asyar = make_fake_app(&tmp, "Asyar.app");
-        // `app` and `asyar` are siblings, not the same path — guard must pass.
-        let canonical = validate_uninstall_path(app.to_str().unwrap(), Some(&asyar)).unwrap();
-        assert_eq!(canonical.file_name().and_then(|n| n.to_str()), Some("Other.app"));
-    }
-
-    #[test]
-    #[cfg(target_os = "macos")]
-    fn uninstall_application_actually_trashes_bundle() {
-        // End-to-end: valid bundle in a user directory should be moved to Trash.
-        let tmp = TempDir::new().unwrap();
-        let app = make_fake_app(&tmp, "TrashMe.app");
-        assert!(app.exists());
-
-        uninstall_application_inner(app.to_str().unwrap(), None).unwrap();
-
-        assert!(
-            !app.exists(),
-            "bundle should no longer exist at its source path after uninstall"
-        );
-    }
-
-    #[test]
-    #[cfg(not(target_os = "macos"))]
-    fn rejects_all_paths_on_non_macos() {
-        let err = validate_uninstall_path("/anything", None).unwrap_err();
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    fn uninstall_application_unsupported_on_linux() {
+        let err = uninstall_application("/anything").unwrap_err();
         assert!(matches!(err, AppError::Platform(_)), "got: {err:?}");
-    }
-
-    #[test]
-    fn resolve_own_bundle_path_returns_option_without_panicking() {
-        // Contract test: never panics, regardless of where the test binary
-        // runs. Value may be None (dev) or Some (inside a bundle) — both ok.
-        let _ = resolve_own_bundle_path();
     }
 }

--- a/src-tauri/src/application/uninstall.rs
+++ b/src-tauri/src/application/uninstall.rs
@@ -20,27 +20,57 @@
 //! `application:*` namespace.
 
 use crate::error::AppError;
+use serde::Serialize;
 use std::path::{Path, PathBuf};
 
-/// Uninstall the application at `path`. Dispatches to the platform-specific
-/// strategy. Linux returns `AppError::Platform` (see module doc comment for
-/// why Linux is deferred).
-#[cfg(target_os = "macos")]
-pub fn uninstall_application(path: &str) -> Result<(), AppError> {
-    uninstall_macos(path, resolve_own_bundle_path().as_deref())
+// ───── Data-scan types (used by both macOS runtime + cross-platform tests) ──
+
+/// A single filesystem entry associated with an installed application, as
+/// returned by the uninstall scanner. All paths are absolute; `size_bytes`
+/// is the total for a directory (recursive) or the file size.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct AppDataPath {
+    pub path: String,
+    pub size_bytes: u64,
+    pub category: String,
 }
 
-/// Uninstall the application at `path`. Dispatches to the platform-specific
-/// strategy.
+/// The complete scan result shown in the confirm sheet before uninstall.
+/// The frontend renders `app_path` + `data_paths` as a list with per-row
+/// sizes and a `total_bytes` footer.
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct UninstallScanResult {
+    pub app_path: String,
+    pub app_size_bytes: u64,
+    pub data_paths: Vec<AppDataPath>,
+    pub total_bytes: u64,
+}
+
+/// Uninstall the application at `path` and optionally trash a set of
+/// associated `data_paths` (macOS only — typically produced by
+/// [`scan_app_data`] + user confirmation). Dispatches to the platform-
+/// specific strategy. Linux returns `AppError::Platform`.
+///
+/// Windows ignores `data_paths` because the vendor's own uninstaller
+/// already handles user-data cleanup; Asyar's job there is just to launch
+/// that uninstaller.
+#[cfg(target_os = "macos")]
+pub fn uninstall_application(path: &str, data_paths: &[String]) -> Result<(), AppError> {
+    uninstall_macos(path, resolve_own_bundle_path().as_deref(), data_paths)
+}
+
+/// See [`uninstall_application`] (macOS doc above). Windows ignores
+/// `data_paths`; see module doc.
 #[cfg(target_os = "windows")]
-pub fn uninstall_application(path: &str) -> Result<(), AppError> {
+pub fn uninstall_application(path: &str, _data_paths: &[String]) -> Result<(), AppError> {
     uninstall_windows(path)
 }
 
-/// Uninstall the application at `path`. Unsupported on Linux (see module doc
-/// comment); returns `AppError::Platform`.
+/// Unsupported on Linux — see module doc comment.
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-pub fn uninstall_application(_path: &str) -> Result<(), AppError> {
+pub fn uninstall_application(_path: &str, _data_paths: &[String]) -> Result<(), AppError> {
     Err(AppError::Platform(
         "uninstall is only supported on macOS and Windows".to_string(),
     ))
@@ -50,15 +80,48 @@ pub fn uninstall_application(_path: &str) -> Result<(), AppError> {
 
 /// Test-visible macOS entrypoint. Accepts `own_bundle_path` explicitly so
 /// unit tests can assert the self-bundle guard without spawning a real Tauri
-/// app.
+/// app. `data_paths` is best-effort — a validation or trash failure on a
+/// single data path logs a warning and continues; the `.app` itself is the
+/// primary success criterion.
 #[cfg(target_os = "macos")]
 pub(crate) fn uninstall_macos(
     path: &str,
     own_bundle_path: Option<&Path>,
+    data_paths: &[String],
 ) -> Result<(), AppError> {
-    let canonical = validate_macos_bundle_path(path, own_bundle_path)?;
-    trash::delete(&canonical)
+    let canonical_app = validate_macos_bundle_path(path, own_bundle_path)?;
+
+    // Validate every data path up-front before we touch anything, so a
+    // bogus entry can't sneak through after the app is already in Trash.
+    let home = dirs::home_dir().ok_or_else(|| {
+        AppError::Other("failed to resolve home directory for data-path validation".to_string())
+    })?;
+    let mut validated: Vec<PathBuf> = Vec::with_capacity(data_paths.len());
+    for dp in data_paths {
+        match validate_data_path_under_home(dp, &home) {
+            Ok(canonical) => validated.push(canonical),
+            Err(e) => log::warn!(
+                "skipping uninstall data path '{}': {}",
+                dp,
+                e
+            ),
+        }
+    }
+
+    trash::delete(&canonical_app)
         .map_err(|e| AppError::Other(format!("Failed to move app to Trash: {}", e)))?;
+
+    // App already trashed; data-path failures are non-fatal from here on.
+    for p in validated {
+        if let Err(e) = trash::delete(&p) {
+            log::warn!(
+                "failed to trash data path '{}': {}",
+                p.display(),
+                e
+            );
+        }
+    }
+
     Ok(())
 }
 
@@ -141,6 +204,222 @@ fn resolve_own_bundle_path() -> Option<PathBuf> {
         }
     }
     None
+}
+
+/// Scans macOS `~/Library/*` subfolders for data left by an application and
+/// returns every hit with its on-disk size. Runs entirely off `$HOME`, so a
+/// test can point it at a fake home directory via `scan_app_data_in`.
+///
+/// Conservative by design:
+/// - Skips symlinks (they may point into shared/cloud-linked storage).
+/// - Skips `~/Library/Group Containers/` (shared between multiple apps).
+/// - Skips `/Library/...` system locations (would need admin to remove).
+/// - Skips keychains (need the user's password to delete cleanly).
+///
+/// Callers should treat the result as opt-out: show the list to the user
+/// and let them confirm the total before anything is moved to Trash.
+#[cfg(target_os = "macos")]
+pub fn scan_app_data(bundle_id: Option<&str>, app_name: &str) -> Vec<AppDataPath> {
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    scan_app_data_in(&home, bundle_id, app_name)
+}
+
+/// Test-visible core. Accepts the home directory explicitly so unit tests
+/// can populate a temp dir with fixtures and assert what the scanner finds.
+/// Defined unconditionally (not cfg'd to macOS) because its logic is pure
+/// filesystem work and the tests run on every CI platform.
+#[allow(dead_code)]
+pub(crate) fn scan_app_data_in(
+    home: &Path,
+    bundle_id: Option<&str>,
+    app_name: &str,
+) -> Vec<AppDataPath> {
+    let mut out = Vec::new();
+
+    // Directory candidates keyed by bundle id.
+    if let Some(bid) = bundle_id {
+        for (subdir, category) in APPDATA_BUNDLE_DIR_CANDIDATES {
+            let path = home.join(subdir).join(bid);
+            push_if_exists(&path, category, &mut out);
+        }
+        for (subdir, ext, category) in APPDATA_BUNDLE_FILE_CANDIDATES {
+            let file = home.join(subdir).join(format!("{}.{}", bid, ext));
+            push_if_exists(&file, category, &mut out);
+        }
+        // ByHost preferences: files like `<bundle-id>.<uuid>.plist`.
+        scan_byhost_preferences(&home.join("Library/Preferences/ByHost"), bid, &mut out);
+    }
+
+    // Name-keyed fallbacks — some apps write to their display name rather
+    // than their bundle id (e.g. `~/Library/Application Support/Spotify`).
+    for (subdir, category) in APPDATA_NAME_DIR_CANDIDATES {
+        let path = home.join(subdir).join(app_name);
+        // Don't double-report a path we already matched by bundle id.
+        if out.iter().any(|p| p.path == path.to_string_lossy()) {
+            continue;
+        }
+        push_if_exists(&path, category, &mut out);
+    }
+
+    out
+}
+
+#[allow(dead_code)]
+const APPDATA_BUNDLE_DIR_CANDIDATES: &[(&str, &str)] = &[
+    ("Library/Application Support", "Application data"),
+    ("Library/Caches", "Cache"),
+    ("Library/Logs", "Logs"),
+    ("Library/Containers", "Sandbox container"),
+    ("Library/HTTPStorages", "HTTP storage"),
+    ("Library/WebKit", "WebKit storage"),
+    ("Library/Application Scripts", "Application scripts"),
+];
+
+#[allow(dead_code)]
+const APPDATA_BUNDLE_FILE_CANDIDATES: &[(&str, &str, &str)] = &[
+    ("Library/Preferences", "plist", "Preferences"),
+    ("Library/Saved Application State", "savedState", "Saved window state"),
+    ("Library/LaunchAgents", "plist", "Launch agent"),
+    ("Library/Cookies", "binarycookies", "Cookies"),
+];
+
+#[allow(dead_code)]
+const APPDATA_NAME_DIR_CANDIDATES: &[(&str, &str)] = &[
+    ("Library/Application Support", "Application data (name-keyed)"),
+    ("Library/Caches", "Cache (name-keyed)"),
+];
+
+#[allow(dead_code)]
+fn push_if_exists(path: &Path, category: &str, out: &mut Vec<AppDataPath>) {
+    // `symlink_metadata` doesn't follow the link — we want to know if the
+    // thing AT the path is itself a symlink and skip it.
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+    if meta.file_type().is_symlink() {
+        return;
+    }
+    let size = if meta.is_dir() {
+        dir_size_bytes(path)
+    } else {
+        meta.len()
+    };
+    out.push(AppDataPath {
+        path: path.to_string_lossy().into_owned(),
+        size_bytes: size,
+        category: category.to_string(),
+    });
+}
+
+#[allow(dead_code)]
+fn scan_byhost_preferences(byhost_dir: &Path, bundle_id: &str, out: &mut Vec<AppDataPath>) {
+    let entries = match std::fs::read_dir(byhost_dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    let prefix = format!("{}.", bundle_id);
+    for entry in entries.flatten() {
+        let Ok(name) = entry.file_name().into_string() else {
+            continue;
+        };
+        if !name.starts_with(&prefix) || !name.ends_with(".plist") {
+            continue;
+        }
+        let path = entry.path();
+        let Ok(meta) = std::fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if meta.file_type().is_symlink() {
+            continue;
+        }
+        out.push(AppDataPath {
+            path: path.to_string_lossy().into_owned(),
+            size_bytes: meta.len(),
+            category: "ByHost preference".to_string(),
+        });
+    }
+}
+
+/// Recursive size totaller. Best-effort — unreadable subdirs and broken
+/// symlinks are silently skipped. Does not follow symlinks.
+#[allow(dead_code)]
+pub(crate) fn dir_size_bytes(path: &Path) -> u64 {
+    fn walk(path: &Path, total: &mut u64) {
+        let entries = match std::fs::read_dir(path) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        for entry in entries.flatten() {
+            // symlink_metadata (not metadata) to avoid following into the
+            // linked target's size — caller wanted on-disk size of this
+            // directory tree, not the world it links out to.
+            let Ok(meta) = entry.file_type() else {
+                continue;
+            };
+            if meta.is_symlink() {
+                continue;
+            }
+            if meta.is_file() {
+                if let Ok(md) = entry.metadata() {
+                    *total = total.saturating_add(md.len());
+                }
+            } else if meta.is_dir() {
+                walk(&entry.path(), total);
+            }
+        }
+    }
+    let mut total = 0u64;
+    walk(path, &mut total);
+    total
+}
+
+/// Validates that a candidate data path is safe for Asyar to trash on the
+/// user's behalf. Pulled out of the command body so every rejection branch
+/// has a dedicated unit test. Cross-platform compilable — the constraints
+/// (abs + exists + under `$HOME/Library` + not a symlink) make sense on any
+/// unix-family filesystem even though only macOS currently invokes it.
+#[allow(dead_code)]
+pub(crate) fn validate_data_path_under_home(
+    path: &str,
+    home: &Path,
+) -> Result<PathBuf, AppError> {
+    if path.trim().is_empty() {
+        return Err(AppError::Validation("data path must be non-empty".to_string()));
+    }
+    let raw = Path::new(path);
+    if !raw.is_absolute() {
+        return Err(AppError::Validation(format!(
+            "data path must be absolute: {}",
+            path
+        )));
+    }
+    let meta = std::fs::symlink_metadata(raw).map_err(|_| {
+        AppError::NotFound(format!("data path does not exist: {}", path))
+    })?;
+    if meta.file_type().is_symlink() {
+        return Err(AppError::Validation(format!(
+            "refusing to follow symlink: {}",
+            path
+        )));
+    }
+    let canonical = raw.canonicalize().map_err(|e| {
+        AppError::Other(format!(
+            "failed to canonicalize data path '{}': {}",
+            path, e
+        ))
+    })?;
+    let library_root = home.join("Library");
+    let canonical_library = library_root.canonicalize().unwrap_or(library_root);
+    if !canonical.starts_with(&canonical_library) {
+        return Err(AppError::Permission(format!(
+            "data path is outside ~/Library and cannot be trashed by Asyar: {}",
+            path
+        )));
+    }
+    Ok(canonical)
 }
 
 // ───── Windows ─────────────────────────────────────────────────────────────
@@ -510,7 +789,7 @@ mod tests {
             let app = make_fake_app(&tmp, "TrashMe.app");
             assert!(app.exists());
 
-            uninstall_macos(app.to_str().unwrap(), None).unwrap();
+            uninstall_macos(app.to_str().unwrap(), None, &[]).unwrap();
 
             assert!(
                 !app.exists(),
@@ -519,8 +798,264 @@ mod tests {
         }
 
         #[test]
+        fn uninstall_macos_ignores_bogus_data_paths_but_still_trashes_app() {
+            // Invalid data paths (non-existent, outside home) should be
+            // dropped with a warning, not block the primary uninstall.
+            let tmp = TempDir::new().unwrap();
+            let app = make_fake_app(&tmp, "TrashMe2.app");
+
+            let bogus_paths = vec![
+                "/tmp/__definitely_not_real__".to_string(),
+                "/etc/passwd".to_string(), // exists but outside ~/Library
+                "relative/path".to_string(),
+            ];
+
+            let result = uninstall_macos(app.to_str().unwrap(), None, &bogus_paths);
+
+            assert!(result.is_ok(), "got: {result:?}");
+            assert!(!app.exists(), "app itself should still be trashed");
+        }
+
+        #[test]
         fn resolve_own_bundle_path_returns_option_without_panicking() {
             let _ = resolve_own_bundle_path();
+        }
+    }
+
+    // ─── Data-scan tests (run on every target — pure filesystem logic) ──
+    mod data_scan {
+        use super::*;
+        use std::fs;
+        use tempfile::TempDir;
+
+        /// Helper: set up a fake `$HOME/Library` tree inside a temp dir.
+        fn fake_home() -> TempDir {
+            let home = TempDir::new().unwrap();
+            fs::create_dir_all(home.path().join("Library")).unwrap();
+            home
+        }
+
+        fn write_file(path: &Path, contents: &[u8]) {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(path, contents).unwrap();
+        }
+
+        fn make_dir_with_file(path: &Path, contents: &[u8]) {
+            fs::create_dir_all(path).unwrap();
+            fs::write(path.join("data.bin"), contents).unwrap();
+        }
+
+        #[test]
+        fn scan_returns_empty_when_nothing_matches() {
+            let home = fake_home();
+            let hits = scan_app_data_in(home.path(), Some("com.example.Nope"), "Nope");
+            assert!(hits.is_empty());
+        }
+
+        #[test]
+        fn scan_finds_bundle_id_keyed_application_support() {
+            let home = fake_home();
+            let bid = "com.example.Widget";
+            let support = home
+                .path()
+                .join("Library/Application Support")
+                .join(bid);
+            make_dir_with_file(&support, b"hello world");
+
+            let hits = scan_app_data_in(home.path(), Some(bid), "Widget");
+
+            assert!(hits.iter().any(|h| h.path == support.to_string_lossy()));
+        }
+
+        #[test]
+        fn scan_finds_bundle_id_keyed_preferences_plist() {
+            let home = fake_home();
+            let bid = "com.example.Widget";
+            let plist = home
+                .path()
+                .join("Library/Preferences")
+                .join(format!("{}.plist", bid));
+            write_file(&plist, b"<plist></plist>");
+
+            let hits = scan_app_data_in(home.path(), Some(bid), "Widget");
+
+            let found = hits.iter().find(|h| h.path == plist.to_string_lossy()).unwrap();
+            assert_eq!(found.category, "Preferences");
+            assert!(found.size_bytes > 0);
+        }
+
+        #[test]
+        fn scan_finds_byhost_preferences_matching_bundle_id_prefix() {
+            let home = fake_home();
+            let bid = "com.example.Widget";
+            let byhost = home.path().join("Library/Preferences/ByHost");
+            let f1 = byhost.join(format!("{}.ABC-123.plist", bid));
+            let f2 = byhost.join(format!("{}.DEF-456.plist", bid));
+            let unrelated = byhost.join("com.other.app.ABC-123.plist");
+            write_file(&f1, b"1");
+            write_file(&f2, b"1");
+            write_file(&unrelated, b"1");
+
+            let hits = scan_app_data_in(home.path(), Some(bid), "Widget");
+            let byhost_hits: Vec<_> = hits
+                .iter()
+                .filter(|h| h.category == "ByHost preference")
+                .collect();
+
+            assert_eq!(byhost_hits.len(), 2, "should match both bundle-id entries only");
+            assert!(byhost_hits.iter().any(|h| h.path.ends_with("ABC-123.plist")));
+            assert!(byhost_hits.iter().any(|h| h.path.ends_with("DEF-456.plist")));
+        }
+
+        #[test]
+        fn scan_finds_name_keyed_application_support_as_fallback() {
+            let home = fake_home();
+            let name = "Spotify";
+            // No bundle-id-keyed dir — only name-keyed.
+            let name_dir = home.path().join("Library/Application Support").join(name);
+            make_dir_with_file(&name_dir, b"x");
+
+            let hits = scan_app_data_in(home.path(), Some("com.spotify.client"), name);
+
+            assert!(hits.iter().any(|h| h.path == name_dir.to_string_lossy()));
+        }
+
+        #[test]
+        fn scan_does_not_double_count_same_path() {
+            let home = fake_home();
+            // Contrived: bundle id equals the app name, so bundle-keyed and
+            // name-keyed scans would target the same dir. De-dup must prevent
+            // duplicate entries.
+            let shared = "SharedName";
+            let dir = home
+                .path()
+                .join("Library/Application Support")
+                .join(shared);
+            make_dir_with_file(&dir, b"x");
+
+            let hits = scan_app_data_in(home.path(), Some(shared), shared);
+            let same: Vec<_> = hits
+                .iter()
+                .filter(|h| h.path == dir.to_string_lossy())
+                .collect();
+            assert_eq!(same.len(), 1, "path should appear exactly once: {:?}", hits);
+        }
+
+        #[test]
+        fn scan_skips_symlinks() {
+            // Symlinks can point into shared/cloud-backed storage; trashing
+            // them could cascade into the target's contents on some
+            // filesystems. Always skip.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::symlink;
+
+                let home = fake_home();
+                let bid = "com.example.Widget";
+                let real = home.path().join("real_dir");
+                fs::create_dir_all(&real).unwrap();
+                let link = home
+                    .path()
+                    .join("Library/Application Support")
+                    .join(bid);
+                fs::create_dir_all(link.parent().unwrap()).unwrap();
+                symlink(&real, &link).unwrap();
+
+                let hits = scan_app_data_in(home.path(), Some(bid), "Widget");
+                assert!(
+                    !hits.iter().any(|h| h.path == link.to_string_lossy()),
+                    "symlink entry must be skipped"
+                );
+            }
+        }
+
+        #[test]
+        fn dir_size_bytes_sums_nested_files() {
+            let tmp = TempDir::new().unwrap();
+            let root = tmp.path().join("tree");
+            write_file(&root.join("a.bin"), &vec![0u8; 100]);
+            write_file(&root.join("sub/b.bin"), &vec![0u8; 200]);
+            write_file(&root.join("sub/deep/c.bin"), &vec![0u8; 50]);
+
+            let total = dir_size_bytes(&root);
+            assert_eq!(total, 350);
+        }
+
+        #[test]
+        fn dir_size_bytes_returns_zero_for_missing_dir() {
+            let total = dir_size_bytes(Path::new("/tmp/__asyar_definitely_not_a_dir__"));
+            assert_eq!(total, 0);
+        }
+
+        #[test]
+        fn validate_data_path_rejects_empty() {
+            let tmp = fake_home();
+            let err = validate_data_path_under_home("", tmp.path()).unwrap_err();
+            assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn validate_data_path_rejects_relative() {
+            let tmp = fake_home();
+            let err = validate_data_path_under_home("relative/foo", tmp.path()).unwrap_err();
+            assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn validate_data_path_rejects_missing() {
+            let tmp = fake_home();
+            let err = validate_data_path_under_home(
+                "/tmp/__asyar_nonexistent_data_path__",
+                tmp.path(),
+            )
+            .unwrap_err();
+            assert!(matches!(err, AppError::NotFound(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn validate_data_path_rejects_outside_home_library() {
+            let tmp = fake_home();
+            // Create a file OUTSIDE the fake home dir — using the process
+            // temp dir so it definitely exists but isn't under home.
+            let outside_dir = TempDir::new().unwrap();
+            let outside = outside_dir.path().join("escape.txt");
+            fs::write(&outside, b"x").unwrap();
+
+            let err =
+                validate_data_path_under_home(outside.to_str().unwrap(), tmp.path()).unwrap_err();
+            assert!(matches!(err, AppError::Permission(_)), "got: {err:?}");
+        }
+
+        #[test]
+        fn validate_data_path_accepts_file_inside_home_library() {
+            let tmp = fake_home();
+            let inside = tmp.path().join("Library/Application Support/com.example.Widget");
+            fs::create_dir_all(&inside).unwrap();
+            fs::write(inside.join("data.bin"), b"hello").unwrap();
+
+            let result = validate_data_path_under_home(inside.to_str().unwrap(), tmp.path());
+            assert!(result.is_ok(), "got: {result:?}");
+        }
+
+        #[test]
+        fn validate_data_path_rejects_symlink() {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::symlink;
+
+                let tmp = fake_home();
+                let real = tmp.path().join("real.txt");
+                fs::write(&real, b"x").unwrap();
+                let link = tmp.path().join("Library/link.txt");
+                fs::create_dir_all(link.parent().unwrap()).unwrap();
+                symlink(&real, &link).unwrap();
+
+                let err =
+                    validate_data_path_under_home(link.to_str().unwrap(), tmp.path()).unwrap_err();
+                assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+            }
         }
     }
 

--- a/src-tauri/src/commands/applications.rs
+++ b/src-tauri/src/commands/applications.rs
@@ -5,7 +5,8 @@
 use crate::search_engine::SearchState;
 use crate::error::AppError;
 use crate::application::service::{self, FrontmostApplication, SyncResult};
-use crate::application::IndexWatcher;
+use crate::application::{uninstall, IndexWatcher};
+use crate::permissions::ExtensionPermissionRegistry;
 use crate::search_engine::models::Application;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -95,4 +96,67 @@ pub fn open_application_path(
         .opener()
         .open_path(&path, None::<&str>)
         .map_err(|e| AppError::Platform(format!("Failed to open path '{}': {}", path, e)))
+}
+
+/// Moves the application bundle at `path` to the OS Trash.
+///
+/// Core-only (Tier 1 action panel). Rejects any Tier 2 caller — uninstalling
+/// arbitrary apps is a capability beyond the read-only `application:*`
+/// surface we expose to extensions. Delegates all safety gating and the
+/// actual trash call to [`crate::application::uninstall::uninstall_application`].
+#[tauri::command]
+pub fn uninstall_application(
+    permissions: tauri::State<'_, ExtensionPermissionRegistry>,
+    extension_id: Option<String>,
+    path: String,
+) -> Result<(), AppError> {
+    uninstall_application_inner(&permissions, extension_id, path)
+}
+
+pub(crate) fn uninstall_application_inner(
+    _permissions: &ExtensionPermissionRegistry,
+    extension_id: Option<String>,
+    path: String,
+) -> Result<(), AppError> {
+    if extension_id.is_some() {
+        return Err(AppError::Permission(
+            "uninstall_application is only available to core callers".to_string(),
+        ));
+    }
+    uninstall::uninstall_application(&path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_any_extension_caller() {
+        let perms = ExtensionPermissionRegistry::new();
+        let err = uninstall_application_inner(
+            &perms,
+            Some("any-extension-id".to_string()),
+            "/Applications/Whatever.app".to_string(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, AppError::Permission(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn core_caller_reaches_validator() {
+        // extension_id = None should bypass the core-only gate and fall through
+        // to the real validator — which then rejects the non-existent path.
+        let perms = ExtensionPermissionRegistry::new();
+        let err = uninstall_application_inner(
+            &perms,
+            None,
+            "/tmp/__asyar_nonexistent_uninstall_cmd_test__.app".to_string(),
+        )
+        .unwrap_err();
+        // On macOS this should be NotFound; on other platforms Platform.
+        #[cfg(target_os = "macos")]
+        assert!(matches!(err, AppError::NotFound(_)), "got: {err:?}");
+        #[cfg(not(target_os = "macos"))]
+        assert!(matches!(err, AppError::Platform(_)), "got: {err:?}");
+    }
 }

--- a/src-tauri/src/commands/applications.rs
+++ b/src-tauri/src/commands/applications.rs
@@ -6,6 +6,8 @@ use crate::search_engine::SearchState;
 use crate::error::AppError;
 use crate::application::service::{self, FrontmostApplication, SyncResult};
 use crate::application::{uninstall, IndexWatcher};
+#[cfg(target_os = "macos")]
+use crate::application::uninstall::UninstallScanResult;
 use crate::permissions::ExtensionPermissionRegistry;
 use crate::search_engine::models::Application;
 use std::path::PathBuf;
@@ -98,11 +100,14 @@ pub fn open_application_path(
         .map_err(|e| AppError::Platform(format!("Failed to open path '{}': {}", path, e)))
 }
 
-/// Uninstalls the selected application.
+/// Uninstalls the selected application, optionally trashing associated
+/// user-data paths (macOS).
 ///
-/// macOS: moves the `.app` bundle to Trash. Windows: resolves the `.lnk`
-/// shortcut's display name against `…\CurrentVersion\Uninstall\*` registry
-/// keys and launches the discovered `UninstallString`. Linux: unsupported.
+/// macOS: moves the `.app` bundle to Trash, then trashes each path in
+/// `data_paths` that survives the per-path safety validator
+/// (`~/Library/*` scope, absolute, not a symlink). Windows: launches the
+/// vendor uninstaller (`data_paths` is ignored — the uninstaller handles
+/// user-data cleanup). Linux: unsupported.
 ///
 /// Core-only (Tier 1 action panel). Rejects any Tier 2 caller — uninstalling
 /// arbitrary apps is a capability beyond the read-only `application:*`
@@ -113,21 +118,112 @@ pub fn uninstall_application(
     permissions: tauri::State<'_, ExtensionPermissionRegistry>,
     extension_id: Option<String>,
     path: String,
+    data_paths: Option<Vec<String>>,
 ) -> Result<(), AppError> {
-    uninstall_application_inner(&permissions, extension_id, path)
+    uninstall_application_inner(&permissions, extension_id, path, data_paths.unwrap_or_default())
 }
 
 pub(crate) fn uninstall_application_inner(
     _permissions: &ExtensionPermissionRegistry,
     extension_id: Option<String>,
     path: String,
+    data_paths: Vec<String>,
 ) -> Result<(), AppError> {
     if extension_id.is_some() {
         return Err(AppError::Permission(
             "uninstall_application is only available to core callers".to_string(),
         ));
     }
-    uninstall::uninstall_application(&path)
+    uninstall::uninstall_application(&path, &data_paths)
+}
+
+/// Scans for associated user data left behind by the application at `path`
+/// (macOS only). Returns the `.app` bundle size plus every matching
+/// `~/Library/*` entry with its on-disk size, for the frontend to render in
+/// the uninstall-confirmation sheet.
+///
+/// Core-only. Tier 2 extensions cannot inspect arbitrary user data — this
+/// is part of the Tier 1 uninstall capability boundary.
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn scan_uninstall_targets(
+    permissions: tauri::State<'_, ExtensionPermissionRegistry>,
+    extension_id: Option<String>,
+    path: String,
+) -> Result<UninstallScanResult, AppError> {
+    scan_uninstall_targets_inner(&permissions, extension_id, path)
+}
+
+/// Stub for non-macOS targets. Returns an empty scan so the frontend can
+/// treat the call uniformly — Windows and Linux simply don't show a
+/// data-path breakdown in their confirm flow.
+#[cfg(not(target_os = "macos"))]
+#[tauri::command]
+pub fn scan_uninstall_targets(
+    _permissions: tauri::State<'_, ExtensionPermissionRegistry>,
+    _extension_id: Option<String>,
+    _path: String,
+) -> Result<crate::application::uninstall::UninstallScanResult, AppError> {
+    Err(AppError::Platform(
+        "scan_uninstall_targets is only supported on macOS".to_string(),
+    ))
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn scan_uninstall_targets_inner(
+    _permissions: &ExtensionPermissionRegistry,
+    extension_id: Option<String>,
+    path: String,
+) -> Result<UninstallScanResult, AppError> {
+    use crate::application::uninstall::{dir_size_bytes, scan_app_data, AppDataPath};
+    use std::path::Path;
+
+    if extension_id.is_some() {
+        return Err(AppError::Permission(
+            "scan_uninstall_targets is only available to core callers".to_string(),
+        ));
+    }
+
+    let raw = Path::new(&path);
+    if !raw.is_absolute() {
+        return Err(AppError::Validation(format!(
+            "path must be absolute: {}",
+            path
+        )));
+    }
+    if raw.extension().and_then(|e| e.to_str()) != Some("app") {
+        return Err(AppError::Validation(format!(
+            "path must point to a .app bundle: {}",
+            path
+        )));
+    }
+    if !raw.exists() {
+        return Err(AppError::NotFound(format!(
+            "application does not exist: {}",
+            path
+        )));
+    }
+
+    let app_name = raw
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_string();
+    let bundle_id = service::extract_bundle_id(raw);
+
+    let app_size_bytes = dir_size_bytes(raw);
+    let data_paths: Vec<AppDataPath> = scan_app_data(bundle_id.as_deref(), &app_name);
+    let total_bytes = app_size_bytes
+        + data_paths
+            .iter()
+            .fold(0u64, |acc, p| acc.saturating_add(p.size_bytes));
+
+    Ok(UninstallScanResult {
+        app_path: path,
+        app_size_bytes,
+        data_paths,
+        total_bytes,
+    })
 }
 
 #[cfg(test)]
@@ -141,6 +237,7 @@ mod tests {
             &perms,
             Some("any-extension-id".to_string()),
             "/Applications/Whatever.app".to_string(),
+            vec![],
         )
         .unwrap_err();
         assert!(matches!(err, AppError::Permission(_)), "got: {err:?}");
@@ -161,7 +258,7 @@ mod tests {
         #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         let probe = "/anything".to_string();
 
-        let err = uninstall_application_inner(&perms, None, probe).unwrap_err();
+        let err = uninstall_application_inner(&perms, None, probe, vec![]).unwrap_err();
 
         #[cfg(target_os = "macos")]
         assert!(matches!(err, AppError::NotFound(_)), "got: {err:?}");
@@ -169,5 +266,40 @@ mod tests {
         assert!(matches!(err, AppError::NotFound(_)), "got: {err:?}");
         #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         assert!(matches!(err, AppError::Platform(_)), "got: {err:?}");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn scan_rejects_extension_caller() {
+        let perms = ExtensionPermissionRegistry::new();
+        let err = scan_uninstall_targets_inner(
+            &perms,
+            Some("any-extension-id".to_string()),
+            "/Applications/Whatever.app".to_string(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, AppError::Permission(_)), "got: {err:?}");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn scan_rejects_non_dot_app_path() {
+        let perms = ExtensionPermissionRegistry::new();
+        let err =
+            scan_uninstall_targets_inner(&perms, None, "/tmp/not-an-app".to_string()).unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn scan_rejects_missing_app() {
+        let perms = ExtensionPermissionRegistry::new();
+        let err = scan_uninstall_targets_inner(
+            &perms,
+            None,
+            "/tmp/__asyar_nonexistent_uninstall_scan_test__.app".to_string(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, AppError::NotFound(_)), "got: {err:?}");
     }
 }

--- a/src-tauri/src/commands/applications.rs
+++ b/src-tauri/src/commands/applications.rs
@@ -98,12 +98,16 @@ pub fn open_application_path(
         .map_err(|e| AppError::Platform(format!("Failed to open path '{}': {}", path, e)))
 }
 
-/// Moves the application bundle at `path` to the OS Trash.
+/// Uninstalls the selected application.
+///
+/// macOS: moves the `.app` bundle to Trash. Windows: resolves the `.lnk`
+/// shortcut's display name against `…\CurrentVersion\Uninstall\*` registry
+/// keys and launches the discovered `UninstallString`. Linux: unsupported.
 ///
 /// Core-only (Tier 1 action panel). Rejects any Tier 2 caller — uninstalling
 /// arbitrary apps is a capability beyond the read-only `application:*`
 /// surface we expose to extensions. Delegates all safety gating and the
-/// actual trash call to [`crate::application::uninstall::uninstall_application`].
+/// actual work to [`crate::application::uninstall::uninstall_application`].
 #[tauri::command]
 pub fn uninstall_application(
     permissions: tauri::State<'_, ExtensionPermissionRegistry>,
@@ -145,18 +149,25 @@ mod tests {
     #[test]
     fn core_caller_reaches_validator() {
         // extension_id = None should bypass the core-only gate and fall through
-        // to the real validator — which then rejects the non-existent path.
+        // to the platform-specific validator. We assert the error is NOT the
+        // "only available to core callers" permission error — that's the
+        // point. The exact downstream error varies per platform (NotFound on
+        // macOS/Windows for a non-existent path, Platform on Linux).
         let perms = ExtensionPermissionRegistry::new();
-        let err = uninstall_application_inner(
-            &perms,
-            None,
-            "/tmp/__asyar_nonexistent_uninstall_cmd_test__.app".to_string(),
-        )
-        .unwrap_err();
-        // On macOS this should be NotFound; on other platforms Platform.
+        #[cfg(target_os = "macos")]
+        let probe = "/tmp/__asyar_nonexistent_uninstall_cmd_test__.app".to_string();
+        #[cfg(target_os = "windows")]
+        let probe = r"C:\__asyar_nonexistent_uninstall_cmd_test__.lnk".to_string();
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        let probe = "/anything".to_string();
+
+        let err = uninstall_application_inner(&perms, None, probe).unwrap_err();
+
         #[cfg(target_os = "macos")]
         assert!(matches!(err, AppError::NotFound(_)), "got: {err:?}");
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "windows")]
+        assert!(matches!(err, AppError::NotFound(_)), "got: {err:?}");
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         assert!(matches!(err, AppError::Platform(_)), "got: {err:?}");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -175,6 +175,7 @@ pub fn run() {
             commands::uninstall_extension,
             commands::install_extension_from_url, 
             commands::open_application_path,
+            commands::uninstall_application,
             commands::get_extensions_dir,
             commands::list_installed_extensions,
             commands::get_builtin_features_path,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -176,6 +176,7 @@ pub fn run() {
             commands::install_extension_from_url, 
             commands::open_application_path,
             commands::uninstall_application,
+            commands::scan_uninstall_targets,
             commands::get_extensions_dir,
             commands::list_installed_extensions,
             commands::get_builtin_features_path,

--- a/src/services/action/actionService.nonMacos.test.ts
+++ b/src/services/action/actionService.nonMacos.test.ts
@@ -21,15 +21,16 @@ vi.mock('../application/applicationService', () => ({
   applicationService: { uninstallApplication: vi.fn() },
 }))
 
-// Force non-macOS for this file; IS_MACOS is captured at module-load.
+// Force Linux for this file; HOST_PLATFORM is captured at module-load so a
+// separate test file is required to cover the unsupported-platform path.
 vi.mock('@tauri-apps/plugin-os', () => ({
   platform: () => 'linux',
 }))
 
-// Import AFTER mocks so module-level IS_MACOS evaluates to false.
+// Import AFTER mocks so module-level platform detection evaluates to 'other'.
 import { ActionService } from './actionService.svelte'
 
-describe('uninstall_application visibility on non-macOS', () => {
+describe('uninstall_application visibility on Linux', () => {
   beforeEach(() => {
     mockSearchStores.selectedIndex = -1
     mockSearchOrchestrator.items = []
@@ -43,7 +44,7 @@ describe('uninstall_application visibility on non-macOS', () => {
         name: 'Foo',
         type: 'application' as const,
         score: 1,
-        path: '/Applications/Foo.app',
+        path: '/usr/share/applications/foo.desktop',
       },
     ]
     mockSearchStores.selectedIndex = 0

--- a/src/services/action/actionService.nonMacos.test.ts
+++ b/src/services/action/actionService.nonMacos.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ActionContext } from 'asyar-sdk'
+
+vi.mock('../log/logService', () => ({
+  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('../search/SearchService', () => ({ searchService: { resetIndex: vi.fn() } }))
+vi.mock('tauri-plugin-clipboard-x-api', () => ({ writeText: vi.fn().mockResolvedValue(undefined) }))
+
+const mockSearchOrchestrator = vi.hoisted(() => ({ items: [] as any[] }))
+vi.mock('../search/searchOrchestrator.svelte', () => ({ searchOrchestrator: mockSearchOrchestrator }))
+
+const mockSearchStores = vi.hoisted(() => ({ selectedIndex: -1 }))
+vi.mock('../search/stores/search.svelte', () => ({ searchStores: mockSearchStores }))
+
+vi.mock('../feedback/feedbackService.svelte', () => ({
+  feedbackService: { showHUD: vi.fn(), confirmAlert: vi.fn() },
+}))
+vi.mock('../application/applicationService', () => ({
+  applicationService: { uninstallApplication: vi.fn() },
+}))
+
+// Force non-macOS for this file; IS_MACOS is captured at module-load.
+vi.mock('@tauri-apps/plugin-os', () => ({
+  platform: () => 'linux',
+}))
+
+// Import AFTER mocks so module-level IS_MACOS evaluates to false.
+import { ActionService } from './actionService.svelte'
+
+describe('uninstall_application visibility on non-macOS', () => {
+  beforeEach(() => {
+    mockSearchStores.selectedIndex = -1
+    mockSearchOrchestrator.items = []
+  })
+
+  it('is hidden even for a valid user-installed application path', () => {
+    const svc = new ActionService()
+    mockSearchOrchestrator.items = [
+      {
+        objectId: 'app_foo',
+        name: 'Foo',
+        type: 'application' as const,
+        score: 1,
+        path: '/Applications/Foo.app',
+      },
+    ]
+    mockSearchStores.selectedIndex = 0
+
+    const action = svc.getAllActions().find(a => a.id === 'uninstall_application')
+    expect(action).toBeDefined()
+    expect(action!.context).toBe(ActionContext.CORE)
+    expect(action!.visible!()).toBe(false)
+  })
+})

--- a/src/services/action/actionService.svelte.ts
+++ b/src/services/action/actionService.svelte.ts
@@ -6,7 +6,21 @@ import { searchService } from "../search/SearchService";
 import { searchOrchestrator } from "../search/searchOrchestrator.svelte";
 import { searchStores } from "../search/stores/search.svelte";
 import { feedbackService } from "../feedback/feedbackService.svelte";
+import { applicationService } from "../application/applicationService";
 import { writeText } from "tauri-plugin-clipboard-x-api";
+import { platform } from "@tauri-apps/plugin-os";
+
+// Module-level macOS detection: Uninstall is macOS-only in this release (see
+// application::uninstall). Linux/Windows uninstall requires package-manager
+// integration that is out of scope — the action must stay hidden on those OSes
+// rather than firing a Rust command that would always reject.
+const IS_MACOS = (() => {
+  try {
+    return platform() === "macos";
+  } catch {
+    return false;
+  }
+})();
 
 // This interface might need adjustment if ApplicationAction should also use the enum
 export interface ApplicationAction {
@@ -277,6 +291,55 @@ export class ActionService implements IActionService {
       execute: async () => {
         logService.info("Executing built-in action: Reset Search Index");
         await searchService.resetIndex();
+      },
+    });
+
+    this.registerAction({
+      id: "uninstall_application",
+      label: "Uninstall Application",
+      icon: "icon:trash",
+      description: "Move this application to the Trash",
+      category: "Danger",
+      context: ActionContext.CORE,
+      shortcut: "⌘⌫",
+      confirm: true,
+      visible: () => {
+        if (!IS_MACOS) return false;
+        const idx = searchStores.selectedIndex;
+        if (idx < 0) return false;
+        const item = searchOrchestrator.items[idx];
+        if (!item || item.type !== "application") return false;
+        if (!item.path) return false;
+        // Hard block system-protected apps from even showing the action.
+        // Rust repeats the check as defense-in-depth; this keeps the UI honest.
+        if (item.path.startsWith("/System/")) return false;
+        return true;
+      },
+      execute: async () => {
+        const idx = searchStores.selectedIndex;
+        if (idx < 0) return;
+        const item = searchOrchestrator.items[idx];
+        if (!item || item.type !== "application" || !item.path) return;
+
+        const appName = item.name;
+        const appPath = item.path;
+
+        const confirmed = await feedbackService.confirmAlert({
+          title: `Uninstall ${appName}?`,
+          message: `This will move ${appName} to the Trash. You can restore it from there later.`,
+          confirmText: "Move to Trash",
+          variant: "danger",
+        });
+        if (!confirmed) return;
+
+        try {
+          await applicationService.uninstallApplication(appPath);
+          await feedbackService.showHUD("Moved to Trash");
+        } catch (err) {
+          logService.error(`Uninstall failed for '${appPath}': ${err}`);
+          const reason = err instanceof Error ? err.message : String(err);
+          await feedbackService.showHUD(`Uninstall failed: ${reason}`);
+        }
       },
     });
 

--- a/src/services/action/actionService.svelte.ts
+++ b/src/services/action/actionService.svelte.ts
@@ -10,17 +10,25 @@ import { applicationService } from "../application/applicationService";
 import { writeText } from "tauri-plugin-clipboard-x-api";
 import { platform } from "@tauri-apps/plugin-os";
 
-// Module-level macOS detection: Uninstall is macOS-only in this release (see
-// application::uninstall). Linux/Windows uninstall requires package-manager
-// integration that is out of scope — the action must stay hidden on those OSes
-// rather than firing a Rust command that would always reject.
-const IS_MACOS = (() => {
+// Module-level platform detection for the Uninstall action. macOS moves the
+// .app bundle to Trash via `trash::delete`; Windows resolves the .lnk
+// shortcut's display name against the registry's Uninstall keys and launches
+// the vendor UninstallString. Linux is unsupported — packaging is too
+// fragmented (apt/dnf/pacman/flatpak/snap/AppImage) for a single first-party
+// path — and the action stays hidden there.
+const HOST_PLATFORM: "macos" | "windows" | "other" = (() => {
   try {
-    return platform() === "macos";
+    const p = platform();
+    if (p === "macos") return "macos";
+    if (p === "windows") return "windows";
+    return "other";
   } catch {
-    return false;
+    return "other";
   }
 })();
+const IS_MACOS = HOST_PLATFORM === "macos";
+const IS_WINDOWS = HOST_PLATFORM === "windows";
+const UNINSTALL_SUPPORTED = IS_MACOS || IS_WINDOWS;
 
 // This interface might need adjustment if ApplicationAction should also use the enum
 export interface ApplicationAction {
@@ -298,21 +306,26 @@ export class ActionService implements IActionService {
       id: "uninstall_application",
       label: "Uninstall Application",
       icon: "icon:trash",
-      description: "Move this application to the Trash",
+      description: IS_MACOS
+        ? "Move this application to the Trash"
+        : "Launch the installer to remove this application",
       category: "Danger",
       context: ActionContext.CORE,
       shortcut: "⌘⌫",
       confirm: true,
       visible: () => {
-        if (!IS_MACOS) return false;
+        if (!UNINSTALL_SUPPORTED) return false;
         const idx = searchStores.selectedIndex;
         if (idx < 0) return false;
         const item = searchOrchestrator.items[idx];
         if (!item || item.type !== "application") return false;
         if (!item.path) return false;
-        // Hard block system-protected apps from even showing the action.
-        // Rust repeats the check as defense-in-depth; this keeps the UI honest.
-        if (item.path.startsWith("/System/")) return false;
+        // macOS-only: hard block system-protected apps from even showing the
+        // action. Rust repeats the check as defense-in-depth, but this keeps
+        // the UI honest. Windows has no equivalent single-prefix system
+        // boundary — the registry SystemComponent flag is the backstop
+        // instead, enforced by ensure_windows_entry_allowed in Rust.
+        if (IS_MACOS && item.path.startsWith("/System/")) return false;
         return true;
       },
       execute: async () => {
@@ -324,17 +337,23 @@ export class ActionService implements IActionService {
         const appName = item.name;
         const appPath = item.path;
 
+        const confirmMessage = IS_MACOS
+          ? `This will move ${appName} to the Trash. You can restore it from there later.`
+          : `This will launch the uninstaller for ${appName}. The vendor's uninstaller will take over from there.`;
+        const confirmButton = IS_MACOS ? "Move to Trash" : "Open Uninstaller";
+        const successHud = IS_MACOS ? "Moved to Trash" : "Uninstaller launched";
+
         const confirmed = await feedbackService.confirmAlert({
           title: `Uninstall ${appName}?`,
-          message: `This will move ${appName} to the Trash. You can restore it from there later.`,
-          confirmText: "Move to Trash",
+          message: confirmMessage,
+          confirmText: confirmButton,
           variant: "danger",
         });
         if (!confirmed) return;
 
         try {
           await applicationService.uninstallApplication(appPath);
-          await feedbackService.showHUD("Moved to Trash");
+          await feedbackService.showHUD(successHud);
         } catch (err) {
           logService.error(`Uninstall failed for '${appPath}': ${err}`);
           const reason = err instanceof Error ? err.message : String(err);

--- a/src/services/action/actionService.svelte.ts
+++ b/src/services/action/actionService.svelte.ts
@@ -7,6 +7,7 @@ import { searchOrchestrator } from "../search/searchOrchestrator.svelte";
 import { searchStores } from "../search/stores/search.svelte";
 import { feedbackService } from "../feedback/feedbackService.svelte";
 import { applicationService } from "../application/applicationService";
+import type { UninstallScanResult } from "../application/applicationService";
 import { writeText } from "tauri-plugin-clipboard-x-api";
 import { platform } from "@tauri-apps/plugin-os";
 
@@ -29,6 +30,37 @@ const HOST_PLATFORM: "macos" | "windows" | "other" = (() => {
 const IS_MACOS = HOST_PLATFORM === "macos";
 const IS_WINDOWS = HOST_PLATFORM === "windows";
 const UNINSTALL_SUPPORTED = IS_MACOS || IS_WINDOWS;
+
+/** Human-readable byte size. Matches Finder-style rounding (1 KB = 1000 B). */
+function formatBytes(bytes: number): string {
+  if (bytes < 1000) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1000;
+  let unitIdx = 0;
+  while (value >= 1000 && unitIdx < units.length - 1) {
+    value /= 1000;
+    unitIdx++;
+  }
+  return `${value >= 100 ? value.toFixed(0) : value.toFixed(1)} ${units[unitIdx]}`;
+}
+
+/** Message body for the macOS uninstall confirm sheet. */
+function buildMacosConfirmMessage(appName: string, scan: UninstallScanResult): string {
+  const lines: string[] = [];
+  const total = formatBytes(scan.totalBytes);
+  if (scan.dataPaths.length === 0) {
+    lines.push(
+      `This will move ${appName} to the Trash (${total}). You can restore it from there later.`,
+    );
+  } else {
+    lines.push(
+      `This will move ${appName} and ${scan.dataPaths.length} associated ${
+        scan.dataPaths.length === 1 ? "file" : "files"
+      } to the Trash — ${total} total. You can restore from Trash if needed.`,
+    );
+  }
+  return lines.join(" ");
+}
 
 // This interface might need adjustment if ApplicationAction should also use the enum
 export interface ApplicationAction {
@@ -337,9 +369,30 @@ export class ActionService implements IActionService {
         const appName = item.name;
         const appPath = item.path;
 
-        const confirmMessage = IS_MACOS
-          ? `This will move ${appName} to the Trash. You can restore it from there later.`
-          : `This will launch the uninstaller for ${appName}. The vendor's uninstaller will take over from there.`;
+        // macOS: pre-scan user-data paths so the confirm sheet can show the
+        // user exactly what will be trashed + total reclaimed space. If the
+        // scan fails, fall back to the app-only confirm — worst case the
+        // user re-runs it manually. Windows skips the scan entirely; the
+        // vendor uninstaller handles data cleanup.
+        let dataPaths: string[] = [];
+        let confirmMessage: string;
+
+        if (IS_MACOS) {
+          try {
+            const scan = await applicationService.scanUninstallTargets(appPath);
+            dataPaths = scan.dataPaths.map((p) => p.path);
+            confirmMessage = buildMacosConfirmMessage(appName, scan);
+          } catch (err) {
+            logService.warn(
+              `Uninstall scan failed for '${appPath}': ${err}. Falling back to app-only confirm.`,
+            );
+            confirmMessage = `This will move ${appName} to the Trash. You can restore it from there later.`;
+          }
+        } else {
+          // Windows
+          confirmMessage = `This will launch the uninstaller for ${appName}. The vendor's uninstaller will take over from there.`;
+        }
+
         const confirmButton = IS_MACOS ? "Move to Trash" : "Open Uninstaller";
         const successHud = IS_MACOS ? "Moved to Trash" : "Uninstaller launched";
 
@@ -352,7 +405,7 @@ export class ActionService implements IActionService {
         if (!confirmed) return;
 
         try {
-          await applicationService.uninstallApplication(appPath);
+          await applicationService.uninstallApplication(appPath, dataPaths);
           await feedbackService.showHUD(successHud);
         } catch (err) {
           logService.error(`Uninstall failed for '${appPath}': ${err}`);

--- a/src/services/action/actionService.test.ts
+++ b/src/services/action/actionService.test.ts
@@ -28,9 +28,27 @@ vi.mock('../search/stores/search.svelte', () => ({
   searchStores: mockSearchStores,
 }))
 
-const mockFeedbackService = vi.hoisted(() => ({ showHUD: vi.fn().mockResolvedValue(undefined) }))
+const mockFeedbackService = vi.hoisted(() => ({
+  showHUD: vi.fn().mockResolvedValue(undefined),
+  confirmAlert: vi.fn().mockResolvedValue(true),
+}))
 vi.mock('../feedback/feedbackService.svelte', () => ({
   feedbackService: mockFeedbackService,
+}))
+
+const mockApplicationService = vi.hoisted(() => ({
+  uninstallApplication: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../application/applicationService', () => ({
+  applicationService: mockApplicationService,
+}))
+
+// Platform detection is module-level in actionService — mocking here controls
+// the IS_MACOS constant for every test in this file. Individual tests that
+// need a non-macOS platform would need to be in a separate file with a
+// different mock.
+vi.mock('@tauri-apps/plugin-os', () => ({
+  platform: () => 'macos',
 }))
 
 // Fresh instance per test so tests are isolated
@@ -611,5 +629,158 @@ describe('setActionExecutor', () => {
   it('is a no-op when the action does not exist', () => {
     const svc = freshService()
     expect(() => svc.setActionExecutor('nonexistent', vi.fn())).not.toThrow()
+  })
+})
+
+// ── uninstall_application built-in action ────────────────────────────────────
+
+describe('uninstall_application built-in action', () => {
+  function makeAppResult(overrides: Partial<{ path: string; name: string; objectId: string }> = {}) {
+    return {
+      objectId: overrides.objectId ?? 'app_Foo_Applications_Foo_app',
+      name: overrides.name ?? 'Foo',
+      type: 'application' as const,
+      score: 1,
+      path: overrides.path ?? '/Applications/Foo.app',
+    }
+  }
+
+  function makeCommandResult() {
+    return {
+      objectId: 'cmd_com.example_hello',
+      name: 'hello',
+      type: 'command' as const,
+      score: 1,
+      extensionId: 'com.example',
+    }
+  }
+
+  beforeEach(() => {
+    mockSearchStores.selectedIndex = -1
+    mockSearchOrchestrator.items = []
+    mockApplicationService.uninstallApplication.mockReset().mockResolvedValue(undefined)
+    mockFeedbackService.showHUD.mockReset().mockResolvedValue(undefined)
+    mockFeedbackService.confirmAlert.mockReset().mockResolvedValue(true)
+  })
+
+  it('is registered as a built-in action', () => {
+    const svc = freshService()
+    const ids = svc.getAllActions().map(a => a.id)
+    expect(ids).toContain('uninstall_application')
+  })
+
+  it('has correct metadata (icon, shortcut, category, confirm flag)', () => {
+    const svc = freshService()
+    const action = svc.getAllActions().find(a => a.id === 'uninstall_application')
+    expect(action).toBeDefined()
+    expect(action!.icon).toBe('icon:trash')
+    expect(action!.shortcut).toBe('⌘⌫')
+    expect(action!.category).toBe('Danger')
+    expect(action!.confirm).toBe(true)
+    expect(action!.context).toBe(ActionContext.CORE)
+  })
+
+  it('visible returns false when no item is selected', () => {
+    const svc = freshService()
+    mockSearchStores.selectedIndex = -1
+    const action = svc.getAllActions().find(a => a.id === 'uninstall_application')
+    expect(action!.visible!()).toBe(false)
+  })
+
+  it('visible returns false when selected item is a command (type !== application)', () => {
+    const svc = freshService()
+    mockSearchOrchestrator.items = [makeCommandResult()]
+    mockSearchStores.selectedIndex = 0
+    const action = svc.getAllActions().find(a => a.id === 'uninstall_application')
+    expect(action!.visible!()).toBe(false)
+  })
+
+  it('visible returns false when selected application has no path', () => {
+    const svc = freshService()
+    mockSearchOrchestrator.items = [{ ...makeAppResult(), path: undefined } as any]
+    mockSearchStores.selectedIndex = 0
+    const action = svc.getAllActions().find(a => a.id === 'uninstall_application')
+    expect(action!.visible!()).toBe(false)
+  })
+
+  it('visible returns false for /System/ paths', () => {
+    const svc = freshService()
+    mockSearchOrchestrator.items = [
+      makeAppResult({ path: '/System/Applications/Calendar.app', name: 'Calendar' }),
+    ]
+    mockSearchStores.selectedIndex = 0
+    const action = svc.getAllActions().find(a => a.id === 'uninstall_application')
+    expect(action!.visible!()).toBe(false)
+  })
+
+  it('visible returns true for a normal user-installed application', () => {
+    const svc = freshService()
+    mockSearchOrchestrator.items = [makeAppResult()]
+    mockSearchStores.selectedIndex = 0
+    const action = svc.getAllActions().find(a => a.id === 'uninstall_application')
+    expect(action!.visible!()).toBe(true)
+  })
+
+  it('execute shows a confirm dialog before calling Rust', async () => {
+    const svc = freshService()
+    mockSearchOrchestrator.items = [makeAppResult()]
+    mockSearchStores.selectedIndex = 0
+
+    await svc.executeAction('uninstall_application')
+
+    expect(mockFeedbackService.confirmAlert).toHaveBeenCalledOnce()
+    const opts = mockFeedbackService.confirmAlert.mock.calls[0][0]
+    expect(opts.title).toContain('Foo')
+    expect(opts.confirmText).toBe('Move to Trash')
+    expect(opts.variant).toBe('danger')
+  })
+
+  it('execute does NOT call uninstall when user cancels', async () => {
+    const svc = freshService()
+    mockSearchOrchestrator.items = [makeAppResult()]
+    mockSearchStores.selectedIndex = 0
+    mockFeedbackService.confirmAlert.mockResolvedValueOnce(false)
+
+    await svc.executeAction('uninstall_application')
+
+    expect(mockApplicationService.uninstallApplication).not.toHaveBeenCalled()
+    expect(mockFeedbackService.showHUD).not.toHaveBeenCalled()
+  })
+
+  it('execute calls uninstallApplication with the selected path and shows success HUD', async () => {
+    const svc = freshService()
+    mockSearchOrchestrator.items = [makeAppResult({ path: '/Applications/Bar.app', name: 'Bar' })]
+    mockSearchStores.selectedIndex = 0
+
+    await svc.executeAction('uninstall_application')
+
+    expect(mockApplicationService.uninstallApplication).toHaveBeenCalledWith('/Applications/Bar.app')
+    expect(mockFeedbackService.showHUD).toHaveBeenCalledWith('Moved to Trash')
+  })
+
+  it('execute surfaces a failure HUD when uninstall rejects', async () => {
+    const svc = freshService()
+    mockSearchOrchestrator.items = [makeAppResult()]
+    mockSearchStores.selectedIndex = 0
+    mockApplicationService.uninstallApplication.mockRejectedValueOnce(
+      new Error('Permission denied: cannot uninstall system-protected application'),
+    )
+
+    await svc.executeAction('uninstall_application')
+
+    expect(mockFeedbackService.showHUD).toHaveBeenCalledOnce()
+    const hudArg = mockFeedbackService.showHUD.mock.calls[0][0]
+    expect(hudArg).toMatch(/Uninstall failed/)
+    expect(hudArg).toMatch(/system-protected/)
+  })
+
+  it('execute is a no-op when no item is selected', async () => {
+    const svc = freshService()
+    mockSearchStores.selectedIndex = -1
+
+    await svc.executeAction('uninstall_application')
+
+    expect(mockFeedbackService.confirmAlert).not.toHaveBeenCalled()
+    expect(mockApplicationService.uninstallApplication).not.toHaveBeenCalled()
   })
 })

--- a/src/services/action/actionService.test.ts
+++ b/src/services/action/actionService.test.ts
@@ -38,6 +38,12 @@ vi.mock('../feedback/feedbackService.svelte', () => ({
 
 const mockApplicationService = vi.hoisted(() => ({
   uninstallApplication: vi.fn().mockResolvedValue(undefined),
+  scanUninstallTargets: vi.fn().mockResolvedValue({
+    appPath: '/Applications/Foo.app',
+    appSizeBytes: 10_000_000,
+    dataPaths: [],
+    totalBytes: 10_000_000,
+  }),
 }))
 vi.mock('../application/applicationService', () => ({
   applicationService: mockApplicationService,
@@ -659,6 +665,14 @@ describe('uninstall_application built-in action', () => {
     mockSearchStores.selectedIndex = -1
     mockSearchOrchestrator.items = []
     mockApplicationService.uninstallApplication.mockReset().mockResolvedValue(undefined)
+    mockApplicationService.scanUninstallTargets
+      .mockReset()
+      .mockResolvedValue({
+        appPath: '/Applications/Foo.app',
+        appSizeBytes: 10_000_000,
+        dataPaths: [],
+        totalBytes: 10_000_000,
+      })
     mockFeedbackService.showHUD.mockReset().mockResolvedValue(undefined)
     mockFeedbackService.confirmAlert.mockReset().mockResolvedValue(true)
   })
@@ -721,6 +735,16 @@ describe('uninstall_application built-in action', () => {
     expect(action!.visible!()).toBe(true)
   })
 
+  it('execute scans the app before showing the confirm dialog', async () => {
+    const svc = freshService()
+    mockSearchOrchestrator.items = [makeAppResult({ path: '/Applications/Foo.app' })]
+    mockSearchStores.selectedIndex = 0
+
+    await svc.executeAction('uninstall_application')
+
+    expect(mockApplicationService.scanUninstallTargets).toHaveBeenCalledWith('/Applications/Foo.app')
+  })
+
   it('execute shows a confirm dialog before calling Rust', async () => {
     const svc = freshService()
     mockSearchOrchestrator.items = [makeAppResult()]
@@ -735,6 +759,48 @@ describe('uninstall_application built-in action', () => {
     expect(opts.variant).toBe('danger')
   })
 
+  it('confirm message includes the total size when the scan has no extra data paths', async () => {
+    const svc = freshService()
+    mockSearchOrchestrator.items = [makeAppResult()]
+    mockSearchStores.selectedIndex = 0
+    mockApplicationService.scanUninstallTargets.mockResolvedValueOnce({
+      appPath: '/Applications/Foo.app',
+      appSizeBytes: 10_000_000, // 10 MB
+      dataPaths: [],
+      totalBytes: 10_000_000,
+    })
+
+    await svc.executeAction('uninstall_application')
+
+    const msg = mockFeedbackService.confirmAlert.mock.calls[0][0].message
+    expect(msg).toMatch(/10\.0 MB/)
+    expect(msg).toMatch(/Trash/)
+  })
+
+  it('confirm message lists associated data-file count and formatted total', async () => {
+    const svc = freshService()
+    mockSearchOrchestrator.items = [makeAppResult({ name: 'BigApp' })]
+    mockSearchStores.selectedIndex = 0
+    mockApplicationService.scanUninstallTargets.mockResolvedValueOnce({
+      appPath: '/Applications/BigApp.app',
+      appSizeBytes: 100_000_000,
+      dataPaths: [
+        { path: '/Users/x/Library/Application Support/com.example.BigApp', sizeBytes: 50_000_000, category: 'Application data' },
+        { path: '/Users/x/Library/Caches/com.example.BigApp', sizeBytes: 200_000_000, category: 'Cache' },
+      ],
+      totalBytes: 350_000_000,
+    })
+
+    await svc.executeAction('uninstall_application')
+
+    const msg = mockFeedbackService.confirmAlert.mock.calls[0][0].message
+    expect(msg).toMatch(/BigApp/)
+    expect(msg).toMatch(/2 associated files/)
+    // 350 MB >= 100 → formatBytes drops the decimal (matches Finder-style
+    // rendering). `formatBytes` drops the decimal for >= 100 of any unit.
+    expect(msg).toMatch(/350 MB/)
+  })
+
   it('execute does NOT call uninstall when user cancels', async () => {
     const svc = freshService()
     mockSearchOrchestrator.items = [makeAppResult()]
@@ -747,15 +813,49 @@ describe('uninstall_application built-in action', () => {
     expect(mockFeedbackService.showHUD).not.toHaveBeenCalled()
   })
 
-  it('execute calls uninstallApplication with the selected path and shows success HUD', async () => {
+  it('execute passes dataPaths from the scan to uninstallApplication', async () => {
     const svc = freshService()
     mockSearchOrchestrator.items = [makeAppResult({ path: '/Applications/Bar.app', name: 'Bar' })]
     mockSearchStores.selectedIndex = 0
+    mockApplicationService.scanUninstallTargets.mockResolvedValueOnce({
+      appPath: '/Applications/Bar.app',
+      appSizeBytes: 1_000_000,
+      dataPaths: [
+        { path: '/Users/x/Library/Preferences/com.example.Bar.plist', sizeBytes: 400, category: 'Preferences' },
+        { path: '/Users/x/Library/Caches/com.example.Bar', sizeBytes: 2_000_000, category: 'Cache' },
+      ],
+      totalBytes: 3_000_400,
+    })
 
     await svc.executeAction('uninstall_application')
 
-    expect(mockApplicationService.uninstallApplication).toHaveBeenCalledWith('/Applications/Bar.app')
+    expect(mockApplicationService.uninstallApplication).toHaveBeenCalledWith(
+      '/Applications/Bar.app',
+      [
+        '/Users/x/Library/Preferences/com.example.Bar.plist',
+        '/Users/x/Library/Caches/com.example.Bar',
+      ],
+    )
     expect(mockFeedbackService.showHUD).toHaveBeenCalledWith('Moved to Trash')
+  })
+
+  it('execute falls back to app-only confirm when the scan fails', async () => {
+    const svc = freshService()
+    mockSearchOrchestrator.items = [makeAppResult({ name: 'Broken' })]
+    mockSearchStores.selectedIndex = 0
+    mockApplicationService.scanUninstallTargets.mockRejectedValueOnce(
+      new Error('disk full or whatever'),
+    )
+
+    await svc.executeAction('uninstall_application')
+
+    expect(mockFeedbackService.confirmAlert).toHaveBeenCalledOnce()
+    const msg = mockFeedbackService.confirmAlert.mock.calls[0][0].message
+    expect(msg).toMatch(/move Broken to the Trash/i)
+    expect(mockApplicationService.uninstallApplication).toHaveBeenCalledWith(
+      '/Applications/Foo.app',
+      [],
+    )
   })
 
   it('execute surfaces a failure HUD when uninstall rejects', async () => {

--- a/src/services/action/actionService.windows.test.ts
+++ b/src/services/action/actionService.windows.test.ts
@@ -24,6 +24,9 @@ vi.mock('../feedback/feedbackService.svelte', () => ({
 
 const mockApplicationService = vi.hoisted(() => ({
   uninstallApplication: vi.fn().mockResolvedValue(undefined),
+  scanUninstallTargets: vi.fn().mockRejectedValue(
+    new Error('Platform error: scan_uninstall_targets is only supported on macOS'),
+  ),
 }))
 vi.mock('../application/applicationService', () => ({
   applicationService: mockApplicationService,
@@ -54,6 +57,11 @@ describe('uninstall_application on Windows', () => {
     mockSearchStores.selectedIndex = -1
     mockSearchOrchestrator.items = []
     mockApplicationService.uninstallApplication.mockReset().mockResolvedValue(undefined)
+    mockApplicationService.scanUninstallTargets
+      .mockReset()
+      .mockRejectedValue(
+        new Error('Platform error: scan_uninstall_targets is only supported on macOS'),
+      )
     mockFeedbackService.showHUD.mockReset().mockResolvedValue(undefined)
     mockFeedbackService.confirmAlert.mockReset().mockResolvedValue(true)
   })
@@ -133,7 +141,7 @@ describe('uninstall_application on Windows', () => {
     expect(opts.variant).toBe('danger')
   })
 
-  it('execute calls uninstallApplication with the .lnk path on confirm', async () => {
+  it('execute calls uninstallApplication with the .lnk path and empty dataPaths on confirm', async () => {
     const svc = new ActionService()
     const lnkPath =
       'C:\\Users\\test\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Slack.lnk'
@@ -142,7 +150,9 @@ describe('uninstall_application on Windows', () => {
 
     await svc.executeAction('uninstall_application')
 
-    expect(mockApplicationService.uninstallApplication).toHaveBeenCalledWith(lnkPath)
+    // Windows never scans — vendor uninstaller handles data. dataPaths stays []
+    expect(mockApplicationService.scanUninstallTargets).not.toHaveBeenCalled()
+    expect(mockApplicationService.uninstallApplication).toHaveBeenCalledWith(lnkPath, [])
     expect(mockFeedbackService.showHUD).toHaveBeenCalledWith('Uninstaller launched')
   })
 

--- a/src/services/action/actionService.windows.test.ts
+++ b/src/services/action/actionService.windows.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ActionContext } from 'asyar-sdk'
+
+vi.mock('../log/logService', () => ({
+  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('../search/SearchService', () => ({ searchService: { resetIndex: vi.fn() } }))
+vi.mock('tauri-plugin-clipboard-x-api', () => ({ writeText: vi.fn().mockResolvedValue(undefined) }))
+
+const mockSearchOrchestrator = vi.hoisted(() => ({ items: [] as any[] }))
+vi.mock('../search/searchOrchestrator.svelte', () => ({ searchOrchestrator: mockSearchOrchestrator }))
+
+const mockSearchStores = vi.hoisted(() => ({ selectedIndex: -1 }))
+vi.mock('../search/stores/search.svelte', () => ({ searchStores: mockSearchStores }))
+
+const mockFeedbackService = vi.hoisted(() => ({
+  showHUD: vi.fn().mockResolvedValue(undefined),
+  confirmAlert: vi.fn().mockResolvedValue(true),
+}))
+vi.mock('../feedback/feedbackService.svelte', () => ({
+  feedbackService: mockFeedbackService,
+}))
+
+const mockApplicationService = vi.hoisted(() => ({
+  uninstallApplication: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../application/applicationService', () => ({
+  applicationService: mockApplicationService,
+}))
+
+// Pin platform detection to Windows for every test in this file.
+vi.mock('@tauri-apps/plugin-os', () => ({
+  platform: () => 'windows',
+}))
+
+// Import AFTER mocks so module-level HOST_PLATFORM resolves to 'windows'.
+import { ActionService } from './actionService.svelte'
+
+function makeLnkResult(overrides: Partial<{ path: string; name: string }> = {}) {
+  return {
+    objectId: 'app_Firefox_start_menu',
+    name: overrides.name ?? 'Firefox',
+    type: 'application' as const,
+    score: 1,
+    path:
+      overrides.path ??
+      'C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Firefox.lnk',
+  }
+}
+
+describe('uninstall_application on Windows', () => {
+  beforeEach(() => {
+    mockSearchStores.selectedIndex = -1
+    mockSearchOrchestrator.items = []
+    mockApplicationService.uninstallApplication.mockReset().mockResolvedValue(undefined)
+    mockFeedbackService.showHUD.mockReset().mockResolvedValue(undefined)
+    mockFeedbackService.confirmAlert.mockReset().mockResolvedValue(true)
+  })
+
+  it('is registered as a built-in action in CORE context', () => {
+    const svc = new ActionService()
+    const action = svc.getAllActions().find(a => a.id === 'uninstall_application')
+    expect(action).toBeDefined()
+    expect(action!.context).toBe(ActionContext.CORE)
+  })
+
+  it('description reflects the uninstaller-launch flow (not Trash)', () => {
+    const svc = new ActionService()
+    const action = svc.getAllActions().find(a => a.id === 'uninstall_application')
+    expect(action!.description).toMatch(/installer/i)
+    expect(action!.description).not.toMatch(/trash/i)
+  })
+
+  it('visible returns true for a normal .lnk shortcut', () => {
+    const svc = new ActionService()
+    mockSearchOrchestrator.items = [makeLnkResult()]
+    mockSearchStores.selectedIndex = 0
+    const action = svc.getAllActions().find(a => a.id === 'uninstall_application')
+    expect(action!.visible!()).toBe(true)
+  })
+
+  it('visible returns false when no path is present', () => {
+    const svc = new ActionService()
+    mockSearchOrchestrator.items = [{ ...makeLnkResult(), path: undefined } as any]
+    mockSearchStores.selectedIndex = 0
+    const action = svc.getAllActions().find(a => a.id === 'uninstall_application')
+    expect(action!.visible!()).toBe(false)
+  })
+
+  it('visible returns false for non-application items (e.g. commands)', () => {
+    const svc = new ActionService()
+    mockSearchOrchestrator.items = [
+      {
+        objectId: 'cmd_com.example_do',
+        name: 'do',
+        type: 'command' as const,
+        score: 1,
+        extensionId: 'com.example',
+      },
+    ]
+    mockSearchStores.selectedIndex = 0
+    const action = svc.getAllActions().find(a => a.id === 'uninstall_application')
+    expect(action!.visible!()).toBe(false)
+  })
+
+  it('visible does NOT apply the /System/ prefix rule on Windows', () => {
+    // A Windows path literally starting with "/System/" is implausible, but
+    // we still document that the macOS-specific UI gate doesn't bleed over.
+    // The defence-in-depth stays on the Rust side (registry SystemComponent).
+    const svc = new ActionService()
+    mockSearchOrchestrator.items = [
+      makeLnkResult({ path: '/System/weird/but/technically/allowed.lnk' }),
+    ]
+    mockSearchStores.selectedIndex = 0
+    const action = svc.getAllActions().find(a => a.id === 'uninstall_application')
+    expect(action!.visible!()).toBe(true)
+  })
+
+  it('execute uses Windows-specific confirm copy and button label', async () => {
+    const svc = new ActionService()
+    mockSearchOrchestrator.items = [makeLnkResult({ name: 'Firefox' })]
+    mockSearchStores.selectedIndex = 0
+
+    await svc.executeAction('uninstall_application')
+
+    expect(mockFeedbackService.confirmAlert).toHaveBeenCalledOnce()
+    const opts = mockFeedbackService.confirmAlert.mock.calls[0][0]
+    expect(opts.title).toBe('Uninstall Firefox?')
+    expect(opts.message).toMatch(/launch the uninstaller/i)
+    expect(opts.message).not.toMatch(/trash/i)
+    expect(opts.confirmText).toBe('Open Uninstaller')
+    expect(opts.variant).toBe('danger')
+  })
+
+  it('execute calls uninstallApplication with the .lnk path on confirm', async () => {
+    const svc = new ActionService()
+    const lnkPath =
+      'C:\\Users\\test\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Slack.lnk'
+    mockSearchOrchestrator.items = [makeLnkResult({ path: lnkPath, name: 'Slack' })]
+    mockSearchStores.selectedIndex = 0
+
+    await svc.executeAction('uninstall_application')
+
+    expect(mockApplicationService.uninstallApplication).toHaveBeenCalledWith(lnkPath)
+    expect(mockFeedbackService.showHUD).toHaveBeenCalledWith('Uninstaller launched')
+  })
+
+  it('execute surfaces a failure HUD when Rust rejects', async () => {
+    const svc = new ActionService()
+    mockSearchOrchestrator.items = [makeLnkResult({ name: 'Firefox' })]
+    mockSearchStores.selectedIndex = 0
+    mockApplicationService.uninstallApplication.mockRejectedValueOnce(
+      new Error('no uninstall registry entry matches \'Firefox\''),
+    )
+
+    await svc.executeAction('uninstall_application')
+
+    expect(mockFeedbackService.showHUD).toHaveBeenCalledOnce()
+    const hudArg = mockFeedbackService.showHUD.mock.calls[0][0]
+    expect(hudArg).toMatch(/Uninstall failed/)
+    expect(hudArg).toMatch(/no uninstall registry entry/i)
+  })
+
+  it('execute does not call uninstall when user cancels', async () => {
+    const svc = new ActionService()
+    mockSearchOrchestrator.items = [makeLnkResult()]
+    mockSearchStores.selectedIndex = 0
+    mockFeedbackService.confirmAlert.mockResolvedValueOnce(false)
+
+    await svc.executeAction('uninstall_application')
+
+    expect(mockApplicationService.uninstallApplication).not.toHaveBeenCalled()
+    expect(mockFeedbackService.showHUD).not.toHaveBeenCalled()
+  })
+})

--- a/src/services/application/applicationService.test.ts
+++ b/src/services/application/applicationService.test.ts
@@ -52,6 +52,28 @@ describe('ApplicationService', () => {
     });
   });
 
+  describe('uninstallApplication', () => {
+    it('invokes uninstall_application with the path', async () => {
+      vi.mocked(invoke).mockResolvedValueOnce(undefined);
+
+      await service.uninstallApplication('/Applications/Foo.app');
+
+      expect(invoke).toHaveBeenCalledWith('uninstall_application', {
+        path: '/Applications/Foo.app',
+      });
+    });
+
+    it('propagates Rust errors to the caller', async () => {
+      vi.mocked(invoke).mockRejectedValueOnce(
+        'Permission denied: cannot uninstall system-protected application',
+      );
+
+      await expect(
+        service.uninstallApplication('/System/Applications/Calendar.app'),
+      ).rejects.toMatch(/system-protected/);
+    });
+  });
+
   describe('listApplications', () => {
     it('passes extraPaths when provided', async () => {
       vi.mocked(invoke).mockResolvedValueOnce([]);

--- a/src/services/application/applicationService.test.ts
+++ b/src/services/application/applicationService.test.ts
@@ -53,13 +53,31 @@ describe('ApplicationService', () => {
   });
 
   describe('uninstallApplication', () => {
-    it('invokes uninstall_application with the path', async () => {
+    it('invokes uninstall_application with the path and empty dataPaths by default', async () => {
       vi.mocked(invoke).mockResolvedValueOnce(undefined);
 
       await service.uninstallApplication('/Applications/Foo.app');
 
       expect(invoke).toHaveBeenCalledWith('uninstall_application', {
         path: '/Applications/Foo.app',
+        dataPaths: [],
+      });
+    });
+
+    it('forwards dataPaths when provided', async () => {
+      vi.mocked(invoke).mockResolvedValueOnce(undefined);
+
+      await service.uninstallApplication('/Applications/Foo.app', [
+        '/Users/me/Library/Application Support/com.example.Foo',
+        '/Users/me/Library/Preferences/com.example.Foo.plist',
+      ]);
+
+      expect(invoke).toHaveBeenCalledWith('uninstall_application', {
+        path: '/Applications/Foo.app',
+        dataPaths: [
+          '/Users/me/Library/Application Support/com.example.Foo',
+          '/Users/me/Library/Preferences/com.example.Foo.plist',
+        ],
       });
     });
 
@@ -71,6 +89,41 @@ describe('ApplicationService', () => {
       await expect(
         service.uninstallApplication('/System/Applications/Calendar.app'),
       ).rejects.toMatch(/system-protected/);
+    });
+  });
+
+  describe('scanUninstallTargets', () => {
+    it('invokes scan_uninstall_targets with the path', async () => {
+      const scan = {
+        appPath: '/Applications/Foo.app',
+        appSizeBytes: 1024,
+        dataPaths: [
+          {
+            path: '/Users/me/Library/Application Support/com.example.Foo',
+            sizeBytes: 500,
+            category: 'Application data',
+          },
+        ],
+        totalBytes: 1524,
+      };
+      vi.mocked(invoke).mockResolvedValueOnce(scan);
+
+      const result = await service.scanUninstallTargets('/Applications/Foo.app');
+
+      expect(invoke).toHaveBeenCalledWith('scan_uninstall_targets', {
+        path: '/Applications/Foo.app',
+      });
+      expect(result).toEqual(scan);
+    });
+
+    it('propagates Rust errors (e.g. platform unsupported)', async () => {
+      vi.mocked(invoke).mockRejectedValueOnce(
+        'Platform error: scan_uninstall_targets is only supported on macOS',
+      );
+
+      await expect(
+        service.scanUninstallTargets('/Applications/Foo.app'),
+      ).rejects.toMatch(/only supported on macOS/);
     });
   });
 

--- a/src/services/application/applicationService.ts
+++ b/src/services/application/applicationService.ts
@@ -3,6 +3,28 @@ import { settingsService } from '../settings/settingsService.svelte';
 import type { FrontmostApplication } from 'asyar-sdk';
 
 /**
+ * One row of Library-scope data matched to an installed application by the
+ * macOS uninstall scanner. Mirrors the Rust `AppDataPath` struct.
+ */
+export interface AppDataPath {
+  path: string;
+  sizeBytes: number;
+  category: string;
+}
+
+/**
+ * Result of a macOS uninstall scan — the `.app` path + size plus every
+ * `~/Library/*` entry associated with the bundle id. Rendered in the
+ * confirm sheet so the user sees exactly what will be trashed.
+ */
+export interface UninstallScanResult {
+  appPath: string;
+  appSizeBytes: number;
+  dataPaths: AppDataPath[];
+  totalBytes: number;
+}
+
+/**
  * Host-side service that fulfils the query half of `ApplicationService`
  * (the `application:*` IPC namespace). It does NOT implement the SDK's
  * `IApplicationService` directly because the `on*` push subscriptions are
@@ -38,18 +60,39 @@ export class ApplicationService {
   }
 
   /**
-   * Moves the .app bundle at `path` to the OS Trash. macOS-only.
+   * Uninstalls the selected application.
+   *
+   * macOS: moves the `.app` bundle to Trash, then trashes each path in
+   * `dataPaths` that survives the per-path safety validator
+   * (`~/Library/*` scope, absolute, not a symlink). Windows: ignores
+   * `dataPaths` and launches the vendor uninstaller; user-data cleanup is
+   * the vendor's responsibility.
    *
    * Tier 1 built-in capability — NOT exposed through the SDK to Tier 2
    * extensions. The Rust command rejects any non-core caller.
    *
    * All safety checks (system-protected paths, Asyar self, .app extension,
-   * existence) live in Rust; this is a pass-through. The application-index
-   * watcher detects the bundle disappearing from the scanned directory and
-   * fires `applications-changed` on its own — no manual sync needed.
+   * existence, per-data-path validation) live in Rust; this is a
+   * pass-through. The application-index watcher detects the bundle
+   * disappearing from the scanned directory and fires
+   * `applications-changed` on its own — no manual sync needed.
    */
-  async uninstallApplication(path: string): Promise<void> {
-    await invoke<void>('uninstall_application', { path });
+  async uninstallApplication(path: string, dataPaths: string[] = []): Promise<void> {
+    await invoke<void>('uninstall_application', { path, dataPaths });
+  }
+
+  /**
+   * Scans `~/Library/*` for data belonging to the application at `path`.
+   * macOS-only — Windows and Linux return a Rust error (the vendor
+   * uninstaller handles data on Windows; Linux is unsupported for
+   * uninstall altogether).
+   *
+   * The caller should render the returned paths in a confirm sheet before
+   * passing their `path` list to `uninstallApplication`. The scan is
+   * advisory — Rust re-validates each path before trashing.
+   */
+  async scanUninstallTargets(path: string): Promise<UninstallScanResult> {
+    return await invoke<UninstallScanResult>('scan_uninstall_targets', { path });
   }
 }
 

--- a/src/services/application/applicationService.ts
+++ b/src/services/application/applicationService.ts
@@ -36,6 +36,21 @@ export class ApplicationService {
   async isRunning(bundleId: string): Promise<boolean> {
     return await invoke<boolean>('app_is_running', { bundleId });
   }
+
+  /**
+   * Moves the .app bundle at `path` to the OS Trash. macOS-only.
+   *
+   * Tier 1 built-in capability — NOT exposed through the SDK to Tier 2
+   * extensions. The Rust command rejects any non-core caller.
+   *
+   * All safety checks (system-protected paths, Asyar self, .app extension,
+   * existence) live in Rust; this is a pass-through. The application-index
+   * watcher detects the bundle disappearing from the scanned directory and
+   * fires `applications-changed` on its own — no manual sync needed.
+   */
+  async uninstallApplication(path: string): Promise<void> {
+    await invoke<void>('uninstall_application', { path });
+  }
 }
 
 export const applicationService = new ApplicationService();


### PR DESCRIPTION
Tier 1 action panel entry that moves the selected .app bundle to the
OS Trash via a new application::uninstall Rust service + core-only
Tauri command. Gated on macOS + type=application + non-/System/ path; Index refresh handled by the existing watcher.