### PR TITLE
refactor(extensions): narrow manifest type, add background + command mode

### DIFF
--- a/src-tauri/src/extensions/discovery.rs
+++ b/src-tauri/src/extensions/discovery.rs
@@ -7,6 +7,126 @@ use super::scheduler;
 use super::{DropdownOption, PreferenceDeclaration, PreferenceType};
 use std::collections::HashSet;
 
+/// Legal values for `manifest.type`.
+const EXTENSION_TYPE_EXTENSION: &str = "extension";
+const EXTENSION_TYPE_THEME: &str = "theme";
+
+/// Legal values for `commands[].mode`.
+const COMMAND_MODE_VIEW: &str = "view";
+const COMMAND_MODE_BACKGROUND: &str = "background";
+
+/// Enforce the semantic invariants of the new manifest schema beyond what
+/// serde alone expresses. `#[serde(deny_unknown_fields)]` on the struct
+/// handles legacy-field rejection; this function handles the cross-field
+/// rules from `docs/superpowers/plans/2026-04-21-tier2-worker-view-split.md`
+/// §4.1.
+pub fn validate_manifest(m: &ExtensionManifest) -> Result<(), AppError> {
+    // `type` defaults to "extension" when absent. Narrow the legal set.
+    let ext_type = m
+        .extension_type
+        .as_deref()
+        .unwrap_or(EXTENSION_TYPE_EXTENSION);
+    match ext_type {
+        EXTENSION_TYPE_EXTENSION | EXTENSION_TYPE_THEME => {}
+        other => {
+            return Err(AppError::Validation(format!(
+                "Extension '{}' has unsupported type '{}'. Legal values: \"extension\", \"theme\".",
+                m.id, other
+            )));
+        }
+    }
+
+    if ext_type == EXTENSION_TYPE_THEME {
+        if !m.commands.is_empty() {
+            return Err(AppError::Validation(format!(
+                "Theme extension '{}' must not declare commands ({} found).",
+                m.id,
+                m.commands.len()
+            )));
+        }
+        if m.background.is_some() {
+            return Err(AppError::Validation(format!(
+                "Theme extension '{}' must not declare a background bundle.",
+                m.id
+            )));
+        }
+        return Ok(());
+    }
+
+    // type === "extension": must contribute something — either at least one
+    // command, or `searchable: true` (the built-in calculator pattern), or
+    // a reserved `background.main` bundle (for future push-event-only
+    // extensions). An otherwise-empty manifest is user error.
+    if m.commands.is_empty()
+        && !m.searchable.unwrap_or(false)
+        && m.background.is_none()
+    {
+        return Err(AppError::Validation(format!(
+            "Extension '{}' (type=\"extension\") has no commands, is not searchable, and declares no background bundle — it contributes nothing.",
+            m.id
+        )));
+    }
+
+    let mut has_background_command = false;
+    for cmd in &m.commands {
+        let mode = cmd.mode.as_deref().unwrap_or(COMMAND_MODE_VIEW);
+        match mode {
+            COMMAND_MODE_VIEW => {
+                let component_ok = cmd
+                    .component
+                    .as_ref()
+                    .map(|s| !s.trim().is_empty())
+                    .unwrap_or(false);
+                if !component_ok {
+                    return Err(AppError::Validation(format!(
+                        "Command '{}' in extension '{}' has mode=\"view\" but no non-empty `component` field.",
+                        cmd.id, m.id
+                    )));
+                }
+            }
+            COMMAND_MODE_BACKGROUND => {
+                if cmd.component.is_some() {
+                    return Err(AppError::Validation(format!(
+                        "Command '{}' in extension '{}' has mode=\"background\" and must not declare `component`.",
+                        cmd.id, m.id
+                    )));
+                }
+                has_background_command = true;
+            }
+            other => {
+                return Err(AppError::Validation(format!(
+                    "Command '{}' in extension '{}' has unsupported mode '{}'. Legal values: \"view\", \"background\".",
+                    cmd.id, m.id, other
+                )));
+            }
+        }
+    }
+
+    if has_background_command {
+        let main_ok = m
+            .background
+            .as_ref()
+            .map(|b| !b.main.trim().is_empty())
+            .unwrap_or(false);
+        if !main_ok {
+            return Err(AppError::Validation(format!(
+                "Extension '{}' declares at least one mode=\"background\" command but has no non-empty `background.main`.",
+                m.id
+            )));
+        }
+    } else if m.background.is_some() {
+        // Legal but unusual: a push-event-only extension may reserve a
+        // worker bundle without yet declaring any background commands.
+        // Surface as a warning to catch plausible author mistakes.
+        warn!(
+            "Extension '{}' declares a background bundle but no mode=\"background\" commands; the worker will still mount.",
+            m.id
+        );
+    }
+
+    Ok(())
+}
+
 pub fn validate_preferences(prefs: &[PreferenceDeclaration]) -> Result<(), String> {
     let name_re = regex::Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap();
     let mut seen = HashSet::new();
@@ -258,6 +378,7 @@ pub fn read_manifest(path: &Path) -> Result<ExtensionManifest, AppError> {
         .map_err(AppError::Io)?;
     let manifest: ExtensionManifest = serde_json::from_str(&content)
         .map_err(AppError::Json)?;
+    validate_manifest(&manifest)?;
     crate::extensions::validate_permission_args(&manifest)?;
     Ok(manifest)
 }
@@ -349,10 +470,9 @@ mod compatibility_tests {
             description: "Test extension".to_string(),
             author: None,
             extension_type: None,
-            default_view: None,
+            background: None,
             searchable: None,
             icon: None,
-            main: None,
             commands: vec![],
             permissions: None,
             permission_args: None,
@@ -524,9 +644,9 @@ mod discovery_tests {
             name: "Test".to_string(),
             description: String::new(),
             trigger: None,
-            result_type: None,
+            mode: Some("background".into()),
+            component: None,
             icon: None,
-            view: None,
             schedule: Some(ScheduleDeclaration { interval_seconds: 5 }),
             preferences: None,
             actions: None,
@@ -548,9 +668,9 @@ mod discovery_tests {
             name: "Test".to_string(),
             description: String::new(),
             trigger: None,
-            result_type: None,
+            mode: Some("background".into()),
+            component: None,
             icon: None,
-            view: None,
             schedule: Some(ScheduleDeclaration { interval_seconds: 300 }),
             preferences: None,
             actions: None,
@@ -595,6 +715,8 @@ mod discovery_tests {
                 "id": "c",
                 "name": "C",
                 "description": "x",
+                "mode": "view",
+                "component": "MainView",
                 "preferences": [{ "name": "", "type": "textfield", "title": "bad" }]
             }]
         }"#;
@@ -622,7 +744,9 @@ mod discovery_tests {
             "version": "1.0.0",
             "description": "x",
             "author": "t",
-            "commands": [],
+            "commands": [
+                { "id": "c", "name": "C", "mode": "view", "component": "MainView" }
+            ],
             "preferences": [
                 { "name": "x", "type": "dropdown", "title": "X" }
             ]
@@ -649,7 +773,9 @@ mod discovery_tests {
             "version": "1.0.0",
             "description": "x",
             "author": "t",
-            "commands": [],
+            "commands": [
+                { "id": "c", "name": "C", "mode": "view", "component": "MainView" }
+            ],
             "preferences": [
                 { "name": "api_key", "type": "textfield", "title": "API Key" }
             ]
@@ -836,5 +962,455 @@ mod action_validation_tests {
         let ext_actions = vec![action("ext-only", "Ext Action")];
         let cmd_actions = vec![action("cmd-only", "Cmd Action")];
         assert!(validate_actions_cross_scope(&ext_actions, &[&cmd_actions]).is_ok());
+    }
+}
+
+#[cfg(test)]
+mod manifest_schema_tests {
+    //! Covers the new manifest schema introduced by the Tier 2 worker/view
+    //! split (plan: docs/superpowers/plans/2026-04-21-tier2-worker-view-split.md
+    //! §4.1). Every test walks a JSON fixture through `read_manifest`-style
+    //! parsing (serde + `validate_manifest`) so the top-level
+    //! `deny_unknown_fields` contract and the semantic rules are both
+    //! exercised from the same vantage point.
+
+    use super::*;
+
+    /// Parse + validate; returns the full pipeline error whether serde or
+    /// validator raises it.
+    fn parse(json: &str) -> Result<ExtensionManifest, AppError> {
+        let manifest: ExtensionManifest = serde_json::from_str(json)
+            .map_err(AppError::Json)?;
+        validate_manifest(&manifest)?;
+        Ok(manifest)
+    }
+
+    // ── Happy paths ─────────────────────────────────────────────────────
+
+    #[test]
+    fn valid_minimal_extension_parses() {
+        let json = r#"{
+            "id": "org.test.min",
+            "name": "Min",
+            "version": "1.0.0",
+            "background": { "main": "dist/worker.js" },
+            "commands": [
+                { "id": "run", "name": "Run", "mode": "background" }
+            ]
+        }"#;
+        let m = parse(json).expect("minimal extension must parse");
+        assert_eq!(m.extension_type, None);
+        assert_eq!(m.commands.len(), 1);
+        assert_eq!(m.commands[0].mode.as_deref(), Some("background"));
+    }
+
+    #[test]
+    fn type_absent_defaults_to_extension() {
+        let json = r#"{
+            "id": "org.test.default",
+            "name": "Default",
+            "version": "0.1.0",
+            "commands": [
+                { "id": "open", "name": "Open", "mode": "view", "component": "MainView" }
+            ]
+        }"#;
+        parse(json).expect("type absent should default to extension and validate");
+    }
+
+    #[test]
+    fn valid_theme_manifest_parses() {
+        let json = r#"{
+            "id": "org.test.theme",
+            "name": "Theme",
+            "version": "1.0.0",
+            "type": "theme"
+        }"#;
+        let m = parse(json).expect("valid theme must parse");
+        assert_eq!(m.extension_type.as_deref(), Some("theme"));
+        assert!(m.commands.is_empty());
+        assert!(m.background.is_none());
+    }
+
+    #[test]
+    fn valid_mixed_extension_with_background_and_view_parses() {
+        let json = r#"{
+            "id": "org.test.mixed",
+            "name": "Mixed",
+            "version": "2.0.0",
+            "type": "extension",
+            "background": { "main": "dist/worker.js" },
+            "commands": [
+                { "id": "open", "name": "Open", "mode": "view", "component": "MainView" },
+                { "id": "tick", "name": "Tick", "mode": "background",
+                  "schedule": { "intervalSeconds": 60 } }
+            ]
+        }"#;
+        let m = parse(json).expect("mixed extension must parse");
+        assert_eq!(m.commands.len(), 2);
+        assert_eq!(m.background.as_ref().unwrap().main, "dist/worker.js");
+    }
+
+    #[test]
+    fn background_main_without_background_commands_is_warning_not_error() {
+        // Push-event-only extensions (future fs-watch style) may mount a
+        // worker without exposing any user-invocable background commands.
+        let json = r#"{
+            "id": "org.test.pushonly",
+            "name": "Push Only",
+            "version": "1.0.0",
+            "type": "extension",
+            "background": { "main": "dist/worker.js" },
+            "commands": [
+                { "id": "open", "name": "Open", "mode": "view", "component": "MainView" }
+            ]
+        }"#;
+        parse(json).expect("background.main without background commands should be legal (warning only)");
+    }
+
+    // ── Rejects legacy fields (deny_unknown_fields) ─────────────────────
+
+    #[test]
+    fn rejects_legacy_top_level_type_view() {
+        let json = r#"{
+            "id": "org.test.legacy",
+            "name": "Legacy",
+            "version": "1.0.0",
+            "type": "view",
+            "commands": [
+                { "id": "open", "name": "Open", "mode": "view", "component": "MainView" }
+            ]
+        }"#;
+        let err = parse(json).expect_err("legacy type \"view\" must be rejected");
+        // Validator-level rejection (not serde) because "view" is a legal
+        // JSON string, just not a legal value for the narrowed set.
+        let msg = format!("{}", err);
+        assert!(msg.contains("unsupported type"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_legacy_top_level_type_result() {
+        let json = r#"{
+            "id": "org.test.legacy",
+            "name": "Legacy",
+            "version": "1.0.0",
+            "type": "result",
+            "commands": []
+        }"#;
+        let err = parse(json).expect_err("legacy type \"result\" must be rejected");
+        assert!(format!("{err}").contains("unsupported type"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_legacy_command_result_type_field() {
+        let json = r#"{
+            "id": "org.test.legacy-cmd",
+            "name": "Legacy Cmd",
+            "version": "1.0.0",
+            "commands": [
+                { "id": "run", "name": "Run", "resultType": "no-view" }
+            ]
+        }"#;
+        let err = parse(json).expect_err("legacy command.resultType must be rejected at parse time");
+        let msg = format!("{err}");
+        assert!(msg.contains("resultType") || msg.contains("unknown field"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_legacy_top_level_default_view_field() {
+        let json = r#"{
+            "id": "org.test.legacy-dv",
+            "name": "Legacy DV",
+            "version": "1.0.0",
+            "defaultView": "SomeView",
+            "commands": [
+                { "id": "open", "name": "Open", "mode": "view", "component": "MainView" }
+            ]
+        }"#;
+        let err = parse(json).expect_err("legacy defaultView must be rejected at parse time");
+        let msg = format!("{err}");
+        assert!(msg.contains("defaultView") || msg.contains("unknown field"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_legacy_top_level_main_field() {
+        let json = r#"{
+            "id": "org.test.legacy-main",
+            "name": "Legacy Main",
+            "version": "1.0.0",
+            "main": "dist/index.js",
+            "commands": [
+                { "id": "run", "name": "Run", "mode": "background" }
+            ]
+        }"#;
+        let err = parse(json).expect_err("legacy top-level main must be rejected at parse time");
+        let msg = format!("{err}");
+        assert!(msg.contains("main") || msg.contains("unknown field"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_field() {
+        let json = r#"{
+            "id": "org.test.unknown",
+            "name": "Unknown",
+            "version": "1.0.0",
+            "commands": [
+                { "id": "run", "name": "Run", "mode": "background" }
+            ],
+            "mysteryField": true
+        }"#;
+        let err = parse(json).expect_err("unknown top-level field must be rejected");
+        assert!(format!("{err}").contains("unknown field"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_legacy_command_view_field() {
+        // The old schema had an optional `view` field on commands; it was
+        // shadowed by the new `component` field so must be rejected.
+        let json = r#"{
+            "id": "org.test.legacy-view",
+            "name": "Legacy View",
+            "version": "1.0.0",
+            "commands": [
+                { "id": "open", "name": "Open", "mode": "view", "view": "MainView" }
+            ]
+        }"#;
+        let err = parse(json).expect_err("legacy command.view must be rejected at parse time");
+        let msg = format!("{err}");
+        assert!(msg.contains("view") || msg.contains("unknown field"), "got: {msg}");
+    }
+
+    // ── Semantic validator rules ────────────────────────────────────────
+
+    #[test]
+    fn mode_view_without_component_is_rejected() {
+        let json = r#"{
+            "id": "org.test.no-component",
+            "name": "No Component",
+            "version": "1.0.0",
+            "commands": [
+                { "id": "open", "name": "Open", "mode": "view" }
+            ]
+        }"#;
+        let err = parse(json).expect_err("mode=view missing component must fail validation");
+        assert!(format!("{err}").contains("component"), "got: {err}");
+    }
+
+    #[test]
+    fn mode_view_with_empty_component_is_rejected() {
+        let json = r#"{
+            "id": "org.test.empty-component",
+            "name": "Empty Component",
+            "version": "1.0.0",
+            "commands": [
+                { "id": "open", "name": "Open", "mode": "view", "component": "   " }
+            ]
+        }"#;
+        let err = parse(json).expect_err("mode=view with whitespace-only component must fail validation");
+        assert!(format!("{err}").contains("component"), "got: {err}");
+    }
+
+    #[test]
+    fn mode_background_with_component_is_rejected() {
+        let json = r#"{
+            "id": "org.test.bg-component",
+            "name": "BG with Component",
+            "version": "1.0.0",
+            "background": { "main": "dist/worker.js" },
+            "commands": [
+                { "id": "tick", "name": "Tick", "mode": "background", "component": "SomeView" }
+            ]
+        }"#;
+        let err = parse(json).expect_err("mode=background with component must fail validation");
+        assert!(format!("{err}").contains("component"), "got: {err}");
+    }
+
+    #[test]
+    fn background_command_without_background_main_is_rejected() {
+        let json = r#"{
+            "id": "org.test.no-bg-main",
+            "name": "No BG Main",
+            "version": "1.0.0",
+            "commands": [
+                { "id": "tick", "name": "Tick", "mode": "background" }
+            ]
+        }"#;
+        let err = parse(json)
+            .expect_err("mode=background without background.main must fail validation");
+        assert!(format!("{err}").contains("background.main"), "got: {err}");
+    }
+
+    #[test]
+    fn background_command_with_blank_background_main_is_rejected() {
+        let json = r#"{
+            "id": "org.test.blank-bg-main",
+            "name": "Blank BG Main",
+            "version": "1.0.0",
+            "background": { "main": "   " },
+            "commands": [
+                { "id": "tick", "name": "Tick", "mode": "background" }
+            ]
+        }"#;
+        let err = parse(json)
+            .expect_err("mode=background with whitespace-only background.main must fail validation");
+        assert!(format!("{err}").contains("background.main"), "got: {err}");
+    }
+
+    #[test]
+    fn theme_with_commands_is_rejected() {
+        let json = r#"{
+            "id": "org.test.theme-cmd",
+            "name": "Theme With Cmd",
+            "version": "1.0.0",
+            "type": "theme",
+            "commands": [
+                { "id": "open", "name": "Open", "mode": "view", "component": "V" }
+            ]
+        }"#;
+        let err = parse(json).expect_err("theme with commands must fail validation");
+        assert!(format!("{err}").contains("commands"), "got: {err}");
+    }
+
+    #[test]
+    fn theme_with_background_is_rejected() {
+        let json = r#"{
+            "id": "org.test.theme-bg",
+            "name": "Theme With Background",
+            "version": "1.0.0",
+            "type": "theme",
+            "background": { "main": "dist/worker.js" }
+        }"#;
+        let err = parse(json).expect_err("theme with background must fail validation");
+        assert!(format!("{err}").contains("background"), "got: {err}");
+    }
+
+    #[test]
+    fn extension_type_with_no_commands_and_no_contribution_is_rejected() {
+        // An "extension" that declares nothing — no commands, no background,
+        // not searchable — contributes nothing and is rejected.
+        let json = r#"{
+            "id": "org.test.empty",
+            "name": "Empty",
+            "version": "1.0.0",
+            "type": "extension"
+        }"#;
+        let err = parse(json).expect_err("fully-empty type=extension must fail validation");
+        assert!(format!("{err}").contains("contributes nothing"), "got: {err}");
+    }
+
+    #[test]
+    fn searchable_extension_with_no_commands_is_allowed() {
+        // The built-in Calculator pattern: a search-only extension that
+        // implements its surface through the Rust search engine and exposes
+        // no user-invocable commands of its own.
+        let json = r#"{
+            "id": "calculator",
+            "name": "Calculator",
+            "version": "1.0.0",
+            "type": "extension",
+            "searchable": true
+        }"#;
+        parse(json).expect("searchable extension with no commands should be legal");
+    }
+
+    /// Integration-style: every in-repo manifest.json (five extensions +
+    /// all built-in features) must parse + validate under the new schema.
+    /// This is the test that would fail if the migration script ever drifted
+    /// out of sync with the Rust validator. Runs only when the workspace
+    /// root is reachable from this crate — skipped in isolated test envs.
+    #[test]
+    fn every_in_repo_manifest_parses_and_validates() {
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")  // asyar-launcher/
+            .join(".."); // workspace root
+
+        if !repo_root.exists() {
+            // Running outside the workspace (e.g. from a tarball). Skip.
+            return;
+        }
+
+        let manifest_paths: Vec<std::path::PathBuf> = {
+            let mut paths = Vec::new();
+            // Tier 2 extensions
+            let ext_root = repo_root.join("extensions");
+            if let Ok(entries) = std::fs::read_dir(&ext_root) {
+                for entry in entries.flatten() {
+                    let m = entry.path().join("manifest.json");
+                    if m.exists() {
+                        paths.push(m);
+                    }
+                }
+            }
+            // Tier 1 built-in features (exclude create-extension/template)
+            let builtin_root = repo_root.join("asyar-launcher/src/built-in-features");
+            if let Ok(entries) = std::fs::read_dir(&builtin_root) {
+                for entry in entries.flatten() {
+                    let m = entry.path().join("manifest.json");
+                    if m.exists() {
+                        paths.push(m);
+                    }
+                }
+            }
+            paths
+        };
+
+        assert!(
+            manifest_paths.len() >= 5,
+            "expected at least the five extension manifests, found {}",
+            manifest_paths.len()
+        );
+
+        for path in &manifest_paths {
+            let result = read_manifest(path);
+            assert!(
+                result.is_ok(),
+                "manifest at {:?} failed parse/validate: {:?}",
+                path,
+                result.err()
+            );
+        }
+    }
+
+    #[test]
+    fn background_only_extension_with_no_commands_is_allowed() {
+        // Future push-event-only extensions reserve a worker bundle without
+        // any user-invocable commands.
+        let json = r#"{
+            "id": "org.test.bg-only",
+            "name": "BG Only",
+            "version": "1.0.0",
+            "type": "extension",
+            "background": { "main": "dist/worker.js" }
+        }"#;
+        parse(json).expect("background-only extension with no commands should be legal");
+    }
+
+    #[test]
+    fn unsupported_command_mode_is_rejected() {
+        let json = r#"{
+            "id": "org.test.bad-mode",
+            "name": "Bad Mode",
+            "version": "1.0.0",
+            "commands": [
+                { "id": "run", "name": "Run", "mode": "unknown" }
+            ]
+        }"#;
+        let err = parse(json).expect_err("unsupported command mode must fail validation");
+        assert!(format!("{err}").contains("mode"), "got: {err}");
+    }
+
+    #[test]
+    fn mode_absent_defaults_to_view_and_requires_component() {
+        // `mode` defaults to "view" per §4.1. A command with neither mode
+        // nor component is a view command missing its component.
+        let json = r#"{
+            "id": "org.test.default-mode",
+            "name": "Default Mode",
+            "version": "1.0.0",
+            "commands": [
+                { "id": "open", "name": "Open" }
+            ]
+        }"#;
+        let err = parse(json).expect_err("mode absent + component absent must fail validation");
+        assert!(format!("{err}").contains("component"), "got: {err}");
     }
 }

--- a/src-tauri/src/extensions/installer.rs
+++ b/src-tauri/src/extensions/installer.rs
@@ -205,26 +205,30 @@ pub(crate) fn validate_package_structure(
         )));
     }
 
-    let ext_type = manifest.extension_type.as_deref().unwrap_or("");
+    // `type` defaults to `"extension"` when absent. The new schema rejects
+    // legacy `"view"` and `"result"` values at manifest parse time via
+    // `validate_manifest`, so by the time we reach this function the only
+    // surviving values are `"extension"` and `"theme"`.
+    let ext_type = manifest.extension_type.as_deref().unwrap_or("extension");
     match ext_type {
         "theme" => {
             validate_theme_json(extracted_dir)?;
         }
-        "view" | "result" => {
+        "extension" => {
+            // Phase 1 still emits `index.html`; Phase 3 will rename to
+            // `view.html` and additionally require `worker.html` when
+            // `background.main` is declared. Phase 1 therefore checks only
+            // `index.html`.
             if !extracted_dir.join("index.html").exists() {
-                return Err(AppError::Validation(format!(
-                    "Extension type '{}' requires index.html", ext_type
-                )));
+                return Err(AppError::Validation(
+                    "Extension package must include index.html".to_string()
+                ));
             }
         }
-        "" => {
-            return Err(AppError::Validation(
-                "Extension manifest missing 'type' field".to_string()
-            ));
-        }
         other => {
+            // validate_manifest rejects this set, so reaching here is a bug.
             return Err(AppError::Validation(format!(
-                "Unknown extension type '{}' (expected: theme, view, or result)", other
+                "Unknown extension type '{}' (expected: theme or extension)", other
             )));
         }
     }
@@ -656,7 +660,7 @@ mod tests {
 
     #[tokio::test]
     async fn validate_package_structure_theme_valid() {
-        let manifest = r#"{"id":"my-theme","name":"My Theme","version":"1.0.0","type":"theme","commands":[]}"#;
+        let manifest = r#"{"id":"my-theme","name":"My Theme","version":"1.0.0","type":"theme"}"#;
         let theme = r#"{"variables":{"--bg-primary":"red"},"fonts":[]}"#;
         let dest = make_zip_and_extract(&[
             ("manifest.json", manifest.as_bytes()),
@@ -668,7 +672,7 @@ mod tests {
 
     #[tokio::test]
     async fn validate_package_structure_theme_missing_theme_json() {
-        let manifest = r#"{"id":"my-theme","name":"My Theme","version":"1.0.0","type":"theme","commands":[]}"#;
+        let manifest = r#"{"id":"my-theme","name":"My Theme","version":"1.0.0","type":"theme"}"#;
         let dest = make_zip_and_extract(&[
             ("manifest.json", manifest.as_bytes()),
         ]).await.unwrap();
@@ -677,9 +681,17 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// Phase 1 transition: the new schema is in place, but the installer
+    /// still checks for `index.html`. Phase 3 renames the artefact to
+    /// `view.html` and adds a `worker.html` requirement for extensions that
+    /// declare `background.main`; those paths are explicitly out of scope
+    /// here.
     #[tokio::test]
-    async fn validate_package_structure_view_valid() {
-        let manifest = r#"{"id":"my-view","name":"My View","version":"1.0.0","type":"view","commands":[]}"#;
+    async fn validate_package_structure_extension_with_index_html_valid() {
+        let manifest = r#"{
+            "id":"my-ext","name":"My Ext","version":"1.0.0","type":"extension",
+            "commands":[{"id":"open","name":"Open","mode":"view","component":"MainView"}]
+        }"#;
         let dest = make_zip_and_extract(&[
             ("manifest.json", manifest.as_bytes()),
             ("index.html", b"<html/>"),
@@ -689,8 +701,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn validate_package_structure_view_missing_index_html() {
-        let manifest = r#"{"id":"my-view","name":"My View","version":"1.0.0","type":"view","commands":[]}"#;
+    async fn validate_package_structure_extension_missing_index_html() {
+        let manifest = r#"{
+            "id":"my-ext","name":"My Ext","version":"1.0.0","type":"extension",
+            "commands":[{"id":"open","name":"Open","mode":"view","component":"MainView"}]
+        }"#;
         let dest = make_zip_and_extract(&[
             ("manifest.json", manifest.as_bytes()),
         ]).await.unwrap();
@@ -700,9 +715,36 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("index.html"));
     }
 
+    /// Phase 3 deliberately adds a `worker.html` presence requirement for
+    /// extensions declaring `background.main`. Phase 1 must NOT enforce it —
+    /// this test pins that contract so a later phase doesn't quietly drift.
+    #[tokio::test]
+    async fn validate_package_structure_phase1_does_not_require_worker_html() {
+        let manifest = r#"{
+            "id":"my-ext","name":"My Ext","version":"1.0.0","type":"extension",
+            "background": {"main": "dist/worker.js"},
+            "commands":[{"id":"tick","name":"Tick","mode":"background"}]
+        }"#;
+        let dest = make_zip_and_extract(&[
+            ("manifest.json", manifest.as_bytes()),
+            // index.html present; worker.html deliberately absent.
+            ("index.html", b"<html/>"),
+        ]).await.unwrap();
+        let m = crate::extensions::discovery::read_manifest(&dest.path().join("manifest.json")).unwrap();
+        assert!(
+            validate_package_structure(dest.path(), &m).is_ok(),
+            "Phase 1 installer must not require worker.html; that lands in Phase 3"
+        );
+    }
+
     #[tokio::test]
     async fn validate_package_structure_invalid_id_dotdot() {
-        let manifest = r#"{"id":"../evil","name":"Evil","version":"1.0.0","type":"view","commands":[]}"#;
+        // Sneak the bad id past `read_manifest` (validator rejects the
+        // mode/component-less extension otherwise) with a full valid body.
+        let manifest = r#"{
+            "id":"../evil","name":"Evil","version":"1.0.0","type":"extension",
+            "commands":[{"id":"open","name":"Open","mode":"view","component":"MainView"}]
+        }"#;
         let dest = make_zip_and_extract(&[
             ("manifest.json", manifest.as_bytes()),
             ("index.html", b"<html/>"),
@@ -713,28 +755,52 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("ID"));
     }
 
+    /// The new parser's `type` field defaults to `"extension"`, so a manifest
+    /// with no `type` field but a valid view command is legal under Phase 1.
     #[tokio::test]
-    async fn validate_package_structure_missing_type() {
-        let manifest = r#"{"id":"no-type","name":"NoType","version":"1.0.0","commands":[]}"#;
+    async fn validate_package_structure_absent_type_defaults_to_extension() {
+        let manifest = r#"{
+            "id":"no-type","name":"NoType","version":"1.0.0",
+            "commands":[{"id":"open","name":"Open","mode":"view","component":"MainView"}]
+        }"#;
         let dest = make_zip_and_extract(&[
             ("manifest.json", manifest.as_bytes()),
+            ("index.html", b"<html/>"),
         ]).await.unwrap();
         let m = crate::extensions::discovery::read_manifest(&dest.path().join("manifest.json")).unwrap();
-        let result = validate_package_structure(dest.path(), &m);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("type"));
+        assert!(validate_package_structure(dest.path(), &m).is_ok());
     }
 
+    /// Legacy `type: "view"` must be rejected at `read_manifest` time, before
+    /// the package-structure validator ever runs.
     #[tokio::test]
-    async fn validate_package_structure_unknown_type() {
-        let manifest = r#"{"id":"unknown","name":"Unknown","version":"1.0.0","type":"gadget","commands":[]}"#;
+    async fn read_manifest_rejects_legacy_type_view_at_install_time() {
+        let manifest = r#"{
+            "id":"legacy","name":"Legacy","version":"1.0.0","type":"view",
+            "commands":[{"id":"open","name":"Open","mode":"view","component":"MainView"}]
+        }"#;
+        let dest = make_zip_and_extract(&[
+            ("manifest.json", manifest.as_bytes()),
+            ("index.html", b"<html/>"),
+        ]).await.unwrap();
+        let result = crate::extensions::discovery::read_manifest(&dest.path().join("manifest.json"));
+        let err = result.expect_err("legacy type=view must be rejected at install time");
+        assert!(format!("{err}").contains("unsupported type"), "got: {err}");
+    }
+
+    /// Legacy `type: "result"` likewise rejected before install-time
+    /// structural checks.
+    #[tokio::test]
+    async fn read_manifest_rejects_legacy_type_result_at_install_time() {
+        let manifest = r#"{
+            "id":"legacy","name":"Legacy","version":"1.0.0","type":"result"
+        }"#;
         let dest = make_zip_and_extract(&[
             ("manifest.json", manifest.as_bytes()),
         ]).await.unwrap();
-        let m = crate::extensions::discovery::read_manifest(&dest.path().join("manifest.json")).unwrap();
-        let result = validate_package_structure(dest.path(), &m);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("type"));
+        let result = crate::extensions::discovery::read_manifest(&dest.path().join("manifest.json"));
+        let err = result.expect_err("legacy type=result must be rejected at install time");
+        assert!(format!("{err}").contains("unsupported type"), "got: {err}");
     }
 
     #[test]
@@ -784,7 +850,11 @@ mod tests {
             .copied()
             .unwrap_or("other");
         let manifest_json = format!(
-            r#"{{"id":"test.ext","name":"T","version":"1.0.0","description":"d","platforms":["{}"]}}"#,
+            r#"{{
+                "id":"test.ext","name":"T","version":"1.0.0","description":"d",
+                "type":"extension","platforms":["{}"],
+                "commands":[{{"id":"open","name":"Open","mode":"view","component":"MainView"}}]
+            }}"#,
             incompatible_os
         );
 

--- a/src-tauri/src/extensions/mod.rs
+++ b/src-tauri/src/extensions/mod.rs
@@ -177,7 +177,7 @@ pub struct ManifestAction {
 
 /// Mirrors the ExtensionCommand from asyar-sdk
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ExtensionCommand {
     pub id: String,
     pub name: String,
@@ -185,12 +185,18 @@ pub struct ExtensionCommand {
     pub description: String,
     #[serde(default)]
     pub trigger: Option<String>,
+    /// Execution mode. `"view"` commands open the on-demand view iframe and
+    /// render the component named by `component`. `"background"` commands
+    /// execute in the always-on worker context (Phase 2/3). Replaces the
+    /// legacy `resultType` field.
     #[serde(default)]
-    pub result_type: Option<String>,
+    pub mode: Option<String>,
     #[serde(default)]
     pub icon: Option<String>,
+    /// Name of the Svelte component exported by the extension's `view.ts`
+    /// entry. Required iff `mode === "view"`; forbidden otherwise.
     #[serde(default)]
-    pub view: Option<String>,
+    pub component: Option<String>,
     #[serde(default)]
     pub schedule: Option<ScheduleDeclaration>,
     #[serde(default)]
@@ -203,9 +209,19 @@ pub struct ExtensionCommand {
     pub arguments: Option<Vec<CommandArgument>>,
 }
 
+/// Declares the always-on worker bundle for extensions that host background
+/// work (subscriptions, schedules, timers, tray updates). Required when any
+/// command declares `mode: "background"`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BackgroundSpec {
+    /// Path (relative to the extension root) of the compiled worker bundle.
+    pub main: String,
+}
+
 /// Mirrors the ExtensionManifest from asyar-sdk
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ExtensionManifest {
     pub id: String,
     pub name: String,
@@ -214,16 +230,21 @@ pub struct ExtensionManifest {
     pub description: String,
     #[serde(default)]
     pub author: Option<String>,
+    /// Top-level extension kind. Legal values are `"extension"` (default
+    /// when absent) and `"theme"`. The legacy values `"view"` and `"result"`
+    /// are strictly rejected at parse time; per-command `mode` now carries
+    /// the view/background distinction.
     #[serde(rename = "type", default)]
     pub extension_type: Option<String>,
+    /// Worker bundle declaration. Present iff the extension declares at
+    /// least one `mode: "background"` command (or reserves a push-event
+    /// subscription for a future phase).
     #[serde(default)]
-    pub default_view: Option<String>,
+    pub background: Option<BackgroundSpec>,
     #[serde(default)]
     pub searchable: Option<bool>,
     #[serde(default)]
     pub icon: Option<String>,
-    #[serde(default)]
-    pub main: Option<String>,
     #[serde(default)]
     pub commands: Vec<ExtensionCommand>,
     #[serde(default)]
@@ -391,11 +412,13 @@ mod tests {
             "name": name,
             "version": "1.0.0",
             "description": "Test extension",
-            "type": "view",
+            "type": "extension",
             "commands": [{
                 "id": "test-cmd",
                 "name": "Test Command",
-                "description": "A test command"
+                "description": "A test command",
+                "mode": "view",
+                "component": "MainView"
             }]
         });
         fs::write(ext_dir.join("manifest.json"), manifest.to_string()).unwrap();
@@ -422,20 +445,45 @@ mod tests {
             "name": "Full Extension",
             "version": "2.0.0",
             "description": "Full test",
-            "type": "result",
-            "defaultView": "DefaultView",
+            "type": "extension",
+            "background": { "main": "dist/worker.js" },
             "searchable": true,
             "icon": "🔍",
             "permissions": ["clipboard:read", "network"],
-            "commands": []
+            "commands": [
+                { "id": "tick", "name": "Tick", "mode": "background" }
+            ]
         });
         fs::write(ext_dir.join("manifest.json"), manifest.to_string()).unwrap();
-        
+
         let m = discovery::read_manifest(&ext_dir.join("manifest.json")).unwrap();
-        assert_eq!(m.default_view, Some("DefaultView".into()));
+        assert_eq!(m.extension_type.as_deref(), Some("extension"));
+        assert_eq!(m.background.as_ref().unwrap().main, "dist/worker.js");
         assert_eq!(m.searchable, Some(true));
         assert_eq!(m.icon, Some("🔍".into()));
         assert_eq!(m.permissions, Some(vec!["clipboard:read".into(), "network".into()]));
+    }
+
+    /// A single-command manifest body that passes the new schema validator.
+    /// Tests that exercise orthogonal concerns (permission_args, etc.) should
+    /// merge this with their specific fields.
+    fn valid_manifest_fields() -> serde_json::Value {
+        serde_json::json!({
+            "type": "extension",
+            "commands": [
+                { "id": "run", "name": "Run", "mode": "view", "component": "MainView" }
+            ]
+        })
+    }
+
+    /// Merge two JSON objects shallowly (b overrides a).
+    fn merge_json(mut a: serde_json::Value, b: serde_json::Value) -> serde_json::Value {
+        if let (Some(map_a), Some(map_b)) = (a.as_object_mut(), b.as_object()) {
+            for (k, v) in map_b {
+                map_a.insert(k.clone(), v.clone());
+            }
+        }
+        a
     }
 
     #[test]
@@ -443,7 +491,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let ext_dir = tmp.path();
         // Use /tmp as the prefix so validation accepts it regardless of $HOME.
-        let manifest = serde_json::json!({
+        let manifest = merge_json(valid_manifest_fields(), serde_json::json!({
             "id": "test.fs-watch-ext",
             "name": "FS Watch Test",
             "version": "0.1.0",
@@ -451,7 +499,7 @@ mod tests {
             "permissionArgs": {
                 "fs:watch": ["/tmp/asyar-fs-watch/**", "/tmp/asyar-ssh-config"]
             }
-        });
+        }));
         fs::write(ext_dir.join("manifest.json"), manifest.to_string()).unwrap();
 
         let m = discovery::read_manifest(&ext_dir.join("manifest.json")).unwrap();
@@ -466,12 +514,12 @@ mod tests {
     fn rejects_manifest_declaring_fs_watch_without_args() {
         let tmp = TempDir::new().unwrap();
         let ext_dir = tmp.path();
-        let manifest = serde_json::json!({
+        let manifest = merge_json(valid_manifest_fields(), serde_json::json!({
             "id": "bad.ext",
             "name": "Bad",
             "version": "0.1.0",
             "permissions": ["fs:watch"]
-        });
+        }));
         fs::write(ext_dir.join("manifest.json"), manifest.to_string()).unwrap();
         let err = discovery::read_manifest(&ext_dir.join("manifest.json")).unwrap_err();
         assert!(format!("{err}").contains("fs:watch"), "got: {err}");
@@ -481,14 +529,14 @@ mod tests {
     fn rejects_manifest_declaring_fs_watch_args_without_permission() {
         let tmp = TempDir::new().unwrap();
         let ext_dir = tmp.path();
-        let manifest = serde_json::json!({
+        let manifest = merge_json(valid_manifest_fields(), serde_json::json!({
             "id": "bad.ext",
             "name": "Bad",
             "version": "0.1.0",
             "permissionArgs": {
                 "fs:watch": ["/tmp/foo"]
             }
-        });
+        }));
         fs::write(ext_dir.join("manifest.json"), manifest.to_string()).unwrap();
         let err = discovery::read_manifest(&ext_dir.join("manifest.json")).unwrap_err();
         assert!(format!("{err}").contains("fs:watch"), "got: {err}");
@@ -498,13 +546,13 @@ mod tests {
     fn rejects_manifest_with_fs_watch_non_array_value() {
         let tmp = TempDir::new().unwrap();
         let ext_dir = tmp.path();
-        let manifest = serde_json::json!({
+        let manifest = merge_json(valid_manifest_fields(), serde_json::json!({
             "id": "bad.ext",
             "name": "Bad",
             "version": "0.1.0",
             "permissions": ["fs:watch"],
             "permissionArgs": { "fs:watch": "/tmp/foo" }
-        });
+        }));
         fs::write(ext_dir.join("manifest.json"), manifest.to_string()).unwrap();
         let err = discovery::read_manifest(&ext_dir.join("manifest.json")).unwrap_err();
         assert!(format!("{err}").contains("fs:watch"), "got: {err}");
@@ -514,13 +562,13 @@ mod tests {
     fn rejects_manifest_with_fs_watch_pattern_outside_home() {
         let tmp = TempDir::new().unwrap();
         let ext_dir = tmp.path();
-        let manifest = serde_json::json!({
+        let manifest = merge_json(valid_manifest_fields(), serde_json::json!({
             "id": "bad.ext",
             "name": "Bad",
             "version": "0.1.0",
             "permissions": ["fs:watch"],
             "permissionArgs": { "fs:watch": ["/etc/passwd"] }
-        });
+        }));
         fs::write(ext_dir.join("manifest.json"), manifest.to_string()).unwrap();
         let err = discovery::read_manifest(&ext_dir.join("manifest.json")).unwrap_err();
         assert!(format!("{err}").contains("must resolve"), "got: {err}");
@@ -531,16 +579,22 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let ext_dir = tmp.path().join("min-ext");
         fs::create_dir_all(&ext_dir).unwrap();
+        // Minimum valid manifest under the new schema: one background command
+        // plus a background.main bundle path.
         let manifest = serde_json::json!({
             "id": "min-ext",
             "name": "Minimal",
-            "version": "0.1.0"
+            "version": "0.1.0",
+            "background": { "main": "dist/worker.js" },
+            "commands": [
+                { "id": "tick", "name": "Tick", "mode": "background" }
+            ]
         });
         fs::write(ext_dir.join("manifest.json"), manifest.to_string()).unwrap();
-        
+
         let m = discovery::read_manifest(&ext_dir.join("manifest.json")).unwrap();
         assert_eq!(m.id, "min-ext");
-        assert!(m.commands.is_empty());
+        assert_eq!(m.commands.len(), 1);
         assert!(m.permissions.is_none());
     }
 
@@ -653,10 +707,9 @@ mod tests {
                 description: String::new(),
                 author: None,
                 extension_type: None,
-                default_view: None,
+                background: None,
                 searchable: None,
                 icon: None,
-                main: None,
                 commands: vec![],
                 permissions: None,
                 permission_args: None,
@@ -680,7 +733,7 @@ mod tests {
             "id": "check-deploys",
             "name": "Check Deployments",
             "description": "Checks deploy status",
-            "resultType": "no-view",
+            "mode": "background",
             "schedule": { "intervalSeconds": 300 }
         }"#;
         let cmd: ExtensionCommand = serde_json::from_str(json).unwrap();

--- a/src/built-in-features/ai-chat/manifest.json
+++ b/src/built-in-features/ai-chat/manifest.json
@@ -6,8 +6,7 @@
   "description": "Chat with AI directly from the launcher",
   "author": "Core",
   "searchable": true,
-  "type": "view",
-  "defaultView": "ChatView",
+  "type": "extension",
   "actions": [
     {
       "id": "new-chat",
@@ -38,7 +37,6 @@
       "name": "AI Chat",
       "icon": "icon:ai-chat",
       "description": "Open AI conversation",
-      "resultType": "view",
       "actions": [
         {
           "id": "ask-about-selection",
@@ -47,14 +45,17 @@
           "icon": "✂️",
           "category": "AI Chat"
         }
-      ]
+      ],
+      "mode": "view",
+      "component": "ChatView"
     },
     {
       "id": "ai-settings",
       "name": "AI Settings",
       "icon": "icon:settings",
       "description": "Configure AI provider and model",
-      "resultType": "view"
+      "mode": "view",
+      "component": "ChatView"
     }
   ]
 }

--- a/src/built-in-features/calculator/manifest.json
+++ b/src/built-in-features/calculator/manifest.json
@@ -4,7 +4,7 @@
   "icon": "icon:calculator",
   "version": "1.0.0",
   "description": "Perform math expressions, unit conversions, currency conversion, and date/time calculations inline.",
-  "type": "result",
+  "type": "extension",
   "commands": [],
   "searchable": true,
   "preferences": [

--- a/src/built-in-features/clipboard-history/manifest.json
+++ b/src/built-in-features/clipboard-history/manifest.json
@@ -3,9 +3,7 @@
   "id": "clipboard-history",
   "version": "1.0.0",
   "description": "Manage and access your clipboard history",
-  "type": "view",
-  "defaultView": "DefaultView",
-  "main": "index.es.js",
+  "type": "extension",
   "searchable": true,
   "icon": "icon:clipboard",
   "actions": [
@@ -23,8 +21,9 @@
       "name": "Show Clipboard History",
       "description": "Show clipboard history",
       "trigger": "clip",
-      "resultType": "view",
-      "icon": "icon:clipboard"
+      "icon": "icon:clipboard",
+      "mode": "view",
+      "component": "DefaultView"
     }
   ]
 }

--- a/src/built-in-features/create-extension/manifest.json
+++ b/src/built-in-features/create-extension/manifest.json
@@ -6,15 +6,15 @@
   "description": "Scaffold new Asyar extensions",
   "author": "Core",
   "searchable": true,
-  "type": "view",
-  "defaultView": "DefaultView",
+  "type": "extension",
   "commands": [
     {
       "id": "open",
       "name": "Create Extension",
       "icon": "icon:dev-tools",
       "description": "Scaffold a new Asyar extension for development",
-      "resultType": "view"
+      "mode": "view",
+      "component": "DefaultView"
     }
   ]
 }

--- a/src/built-in-features/portals/manifest.json
+++ b/src/built-in-features/portals/manifest.json
@@ -6,22 +6,23 @@
   "description": "Save URLs as named, searchable shortcuts",
   "author": "Core",
   "searchable": true,
-  "type": "view",
-  "defaultView": "DefaultView",
+  "type": "extension",
   "commands": [
     {
       "id": "open-portals",
       "name": "Open Portals",
       "icon": "icon:globe",
       "description": "Manage your saved portals",
-      "resultType": "view"
+      "mode": "view",
+      "component": "DefaultView"
     },
     {
       "id": "new-portal",
       "name": "New Portal",
       "icon": "icon:plus",
       "description": "Add a new portal URL shortcut",
-      "resultType": "view"
+      "mode": "view",
+      "component": "DefaultView"
     }
   ]
 }

--- a/src/built-in-features/quit/manifest.json
+++ b/src/built-in-features/quit/manifest.json
@@ -4,7 +4,7 @@
   "icon": "icon:power",
   "version": "1.0.0",
   "description": "Quit the Asyar application",
-  "type": "result",
+  "type": "extension",
   "searchable": true,
   "commands": [
     {
@@ -12,7 +12,10 @@
       "name": "Quit Asyar",
       "icon": "icon:power",
       "description": "Quit the Asyar application",
-      "resultType": "no-view"
+      "mode": "background"
     }
-  ]
+  ],
+  "background": {
+    "main": "dist/worker.js"
+  }
 }

--- a/src/built-in-features/settings/manifest.json
+++ b/src/built-in-features/settings/manifest.json
@@ -4,7 +4,7 @@
   "icon": "icon:settings",
   "version": "1.0.0",
   "description": "Open application settings",
-  "type": "result",
+  "type": "extension",
   "searchable": true,
   "commands": [
     {
@@ -12,7 +12,10 @@
       "name": "Settings",
       "icon": "icon:settings",
       "description": "Open application settings",
-      "resultType": "no-view"
+      "mode": "background"
     }
-  ]
+  ],
+  "background": {
+    "main": "dist/worker.js"
+  }
 }

--- a/src/built-in-features/shortcuts/manifest.json
+++ b/src/built-in-features/shortcuts/manifest.json
@@ -5,8 +5,7 @@
   "description": "Global user shortcuts for applications and commands",
   "version": "1.0.0",
   "author": "Asyar",
-  "type": "view",
-  "defaultView": "DefaultView",
+  "type": "extension",
   "searchable": true,
   "commands": [
     {
@@ -15,7 +14,8 @@
       "icon": "icon:keyboard",
       "trigger": "shortcuts",
       "description": "Manage assigned global shortcuts",
-      "resultType": "view"
+      "mode": "view",
+      "component": "DefaultView"
     }
   ]
 }

--- a/src/built-in-features/snippets/manifest.json
+++ b/src/built-in-features/snippets/manifest.json
@@ -5,8 +5,7 @@
   "description": "Text expansion — type a keyword, get the full text",
   "version": "1.0.0",
   "author": "Asyar",
-  "type": "view",
-  "defaultView": "DefaultView",
+  "type": "extension",
   "searchable": true,
   "commands": [
     {
@@ -15,7 +14,6 @@
       "icon": "icon:snippets",
       "trigger": "snippets",
       "description": "Manage text expansion snippets",
-      "resultType": "view",
       "actions": [
         {
           "id": "add",
@@ -25,7 +23,9 @@
           "shortcut": "⌘N",
           "category": "Snippets"
         }
-      ]
+      ],
+      "mode": "view",
+      "component": "DefaultView"
     }
   ]
 }

--- a/src/built-in-features/store/manifest.json
+++ b/src/built-in-features/store/manifest.json
@@ -5,26 +5,17 @@
   "version": "1.0.0",
   "author": "Asyar",
   "icon": "icon:store",
-  "type": "view",
+  "type": "extension",
   "searchable": true,
-  "entry": "index.ts",
-  "main": "index.es.js",
   "commands": [
     {
       "id": "browse",
       "name": "Browse Extension Store",
       "trigger": "store",
       "description": "Find and install new extensions",
-      "category": "Asyar",
-      "keywords": [
-        "store",
-        "extensions",
-        "browse",
-        "install",
-        "add",
-        "find"
-      ],
-      "icon": "icon:store"
+      "icon": "icon:store",
+      "mode": "view",
+      "component": "__TBD__"
     }
   ]
 }

--- a/src/built-in-features/window-management/manifest.json
+++ b/src/built-in-features/window-management/manifest.json
@@ -3,29 +3,162 @@
   "name": "Window Management",
   "version": "1.0.0",
   "description": "Resize and reposition the frontmost window using layout presets",
-  "type": "view",
-  "defaultView": "ManageView",
+  "type": "extension",
   "searchable": true,
   "icon": "icon:store",
-  "permissions": ["window:manage", "storage:read", "storage:write"],
+  "permissions": [
+    "window:manage",
+    "storage:read",
+    "storage:write"
+  ],
   "commands": [
-    { "id": "left-half",           "name": "Left Half",            "description": "Left 50% of screen",             "trigger": "left half window",           "resultType": "no-view", "icon": "icon:store" },
-    { "id": "right-half",          "name": "Right Half",           "description": "Right 50% of screen",            "trigger": "right half window",          "resultType": "no-view", "icon": "icon:store" },
-    { "id": "top-half",            "name": "Top Half",             "description": "Top 50% of screen",              "trigger": "top half window",            "resultType": "no-view", "icon": "icon:store" },
-    { "id": "bottom-half",         "name": "Bottom Half",          "description": "Bottom 50% of screen",           "trigger": "bottom half window",         "resultType": "no-view", "icon": "icon:store" },
-    { "id": "top-left-quarter",    "name": "Top Left Quarter",     "description": "Top-left 25% of screen",         "trigger": "top left quarter window",    "resultType": "no-view", "icon": "icon:store" },
-    { "id": "top-right-quarter",   "name": "Top Right Quarter",    "description": "Top-right 25% of screen",        "trigger": "top right quarter window",   "resultType": "no-view", "icon": "icon:store" },
-    { "id": "bottom-left-quarter", "name": "Bottom Left Quarter",  "description": "Bottom-left 25% of screen",      "trigger": "bottom left quarter window", "resultType": "no-view", "icon": "icon:store" },
-    { "id": "bottom-right-quarter","name": "Bottom Right Quarter", "description": "Bottom-right 25% of screen",     "trigger": "bottom right quarter",       "resultType": "no-view", "icon": "icon:store" },
-    { "id": "left-third",          "name": "Left Third",           "description": "Left 33% of screen",             "trigger": "left third window",          "resultType": "no-view", "icon": "icon:store" },
-    { "id": "center-third",        "name": "Center Third",         "description": "Center 33% of screen",           "trigger": "center third window",        "resultType": "no-view", "icon": "icon:store" },
-    { "id": "right-third",         "name": "Right Third",          "description": "Right 33% of screen",            "trigger": "right third window",         "resultType": "no-view", "icon": "icon:store" },
-    { "id": "left-two-thirds",     "name": "Left Two Thirds",      "description": "Left 66% of screen",             "trigger": "left two thirds window",     "resultType": "no-view", "icon": "icon:store" },
-    { "id": "right-two-thirds",    "name": "Right Two Thirds",     "description": "Right 66% of screen",            "trigger": "right two thirds window",    "resultType": "no-view", "icon": "icon:store" },
-    { "id": "center",              "name": "Center",               "description": "Centered, 80% × 80% of screen",  "trigger": "center window",              "resultType": "no-view", "icon": "icon:store" },
-    { "id": "almost-maximize",     "name": "Almost Maximize",      "description": "Centered, 90% × 90% of screen",  "trigger": "almost maximize window",     "resultType": "no-view", "icon": "icon:store" },
-    { "id": "maximize",            "name": "Maximize",             "description": "Fill the entire screen (fullscreen)", "trigger": "maximize fullscreen window", "resultType": "no-view", "icon": "icon:store" },
-    { "id": "restore",             "name": "Restore Previous Bounds", "description": "Undo the last applied window layout", "trigger": "restore window undo",   "resultType": "no-view", "icon": "icon:refresh" },
-    { "id": "manage-layouts",      "name": "Manage Window Layouts", "description": "View, add, and delete custom window layouts", "trigger": "manage window layouts", "resultType": "view", "view": "ManageView", "icon": "icon:settings" }
-  ]
+    {
+      "id": "left-half",
+      "name": "Left Half",
+      "description": "Left 50% of screen",
+      "trigger": "left half window",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "right-half",
+      "name": "Right Half",
+      "description": "Right 50% of screen",
+      "trigger": "right half window",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "top-half",
+      "name": "Top Half",
+      "description": "Top 50% of screen",
+      "trigger": "top half window",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "bottom-half",
+      "name": "Bottom Half",
+      "description": "Bottom 50% of screen",
+      "trigger": "bottom half window",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "top-left-quarter",
+      "name": "Top Left Quarter",
+      "description": "Top-left 25% of screen",
+      "trigger": "top left quarter window",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "top-right-quarter",
+      "name": "Top Right Quarter",
+      "description": "Top-right 25% of screen",
+      "trigger": "top right quarter window",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "bottom-left-quarter",
+      "name": "Bottom Left Quarter",
+      "description": "Bottom-left 25% of screen",
+      "trigger": "bottom left quarter window",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "bottom-right-quarter",
+      "name": "Bottom Right Quarter",
+      "description": "Bottom-right 25% of screen",
+      "trigger": "bottom right quarter",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "left-third",
+      "name": "Left Third",
+      "description": "Left 33% of screen",
+      "trigger": "left third window",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "center-third",
+      "name": "Center Third",
+      "description": "Center 33% of screen",
+      "trigger": "center third window",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "right-third",
+      "name": "Right Third",
+      "description": "Right 33% of screen",
+      "trigger": "right third window",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "left-two-thirds",
+      "name": "Left Two Thirds",
+      "description": "Left 66% of screen",
+      "trigger": "left two thirds window",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "right-two-thirds",
+      "name": "Right Two Thirds",
+      "description": "Right 66% of screen",
+      "trigger": "right two thirds window",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "center",
+      "name": "Center",
+      "description": "Centered, 80% × 80% of screen",
+      "trigger": "center window",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "almost-maximize",
+      "name": "Almost Maximize",
+      "description": "Centered, 90% × 90% of screen",
+      "trigger": "almost maximize window",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "maximize",
+      "name": "Maximize",
+      "description": "Fill the entire screen (fullscreen)",
+      "trigger": "maximize fullscreen window",
+      "icon": "icon:store",
+      "mode": "background"
+    },
+    {
+      "id": "restore",
+      "name": "Restore Previous Bounds",
+      "description": "Undo the last applied window layout",
+      "trigger": "restore window undo",
+      "icon": "icon:refresh",
+      "mode": "background"
+    },
+    {
+      "id": "manage-layouts",
+      "name": "Manage Window Layouts",
+      "description": "View, add, and delete custom window layouts",
+      "trigger": "manage window layouts",
+      "icon": "icon:settings",
+      "mode": "view",
+      "component": "ManageView"
+    }
+  ],
+  "background": {
+    "main": "dist/worker.js"
+  }
 }

--- a/src/routes/settings/settingsHandlers.test.ts
+++ b/src/routes/settings/settingsHandlers.test.ts
@@ -29,7 +29,7 @@ describe('SettingsHandler.loadExtensions', () => {
         isBuiltIn: false,
         title: 'Pomodoro',
         enabled: true,
-        type: 'view',
+        type: 'extension',
         commands: [
           { id: 'cmd1', name: 'Start Timer', description: 'Starts the timer', trigger: 'pomo start' },
         ],

--- a/src/routes/settings/tabs/ExtensionsTab.svelte
+++ b/src/routes/settings/tabs/ExtensionsTab.svelte
@@ -127,8 +127,7 @@
   const FILTERS: { id: ExtensionFilter; label: string }[] = [
     { id: 'all', label: 'All' },
     { id: 'commands', label: 'Commands' },
-    { id: 'view', label: 'View' },
-    { id: 'result', label: 'Result' },
+    { id: 'extension', label: 'Extensions' },
     { id: 'theme', label: 'Theme' },
   ];
 </script>

--- a/src/routes/settings/tabs/extensionFilters.test.ts
+++ b/src/routes/settings/tabs/extensionFilters.test.ts
@@ -13,13 +13,16 @@ function makeExt(
   };
 }
 
+// After the Tier 2 worker/view split there are only two extension types:
+// "extension" (everything with commands) and "theme". The per-command
+// view/background distinction is filtered elsewhere.
 const extensions: ExtensionItem[] = [
   makeExt('Catppuccin', 'theme'),
-  makeExt('Pomodoro Timer', 'view', [
+  makeExt('Pomodoro Timer', 'extension', [
     { id: 'c1', name: 'Start Timer', trigger: 'pomo start' },
     { id: 'c2', name: 'Stop Timer', trigger: 'pomo stop' },
   ]),
-  makeExt('GitHub', 'result', [
+  makeExt('GitHub', 'extension', [
     { id: 'c3', name: 'Search Repos', trigger: 'gh repos' },
   ]),
 ];
@@ -64,16 +67,10 @@ describe('filterExtensions', () => {
   });
 
   describe('type filters', () => {
-    it('filter view returns only view extensions', () => {
-      const result = filterExtensions(extensions, '', 'view');
-      expect(result).toHaveLength(1);
-      expect(result[0].title).toBe('Pomodoro Timer');
-    });
-
-    it('filter result returns only result extensions', () => {
-      const result = filterExtensions(extensions, '', 'result');
-      expect(result).toHaveLength(1);
-      expect(result[0].title).toBe('GitHub');
+    it('filter extension returns only type=extension rows', () => {
+      const result = filterExtensions(extensions, '', 'extension');
+      expect(result).toHaveLength(2);
+      expect(result.map((r) => r.title).sort()).toEqual(['GitHub', 'Pomodoro Timer']);
     });
 
     it('filter theme returns only theme extensions', () => {
@@ -90,8 +87,8 @@ describe('filterExtensions', () => {
 
   describe('combined filter + query', () => {
     it('applies both type filter and query', () => {
-      expect(filterExtensions(extensions, 'github', 'result')).toHaveLength(1);
-      expect(filterExtensions(extensions, 'pomo', 'result')).toHaveLength(0);
+      expect(filterExtensions(extensions, 'github', 'extension')).toHaveLength(1);
+      expect(filterExtensions(extensions, 'zzz', 'extension')).toHaveLength(0);
     });
   });
 });

--- a/src/routes/settings/tabs/extensionFilters.ts
+++ b/src/routes/settings/tabs/extensionFilters.ts
@@ -1,6 +1,13 @@
 import type { ExtensionItem } from '../settingsHandlers.svelte';
 
-export type ExtensionFilter = 'all' | 'commands' | 'view' | 'result' | 'theme';
+/**
+ * Settings-page filter categories. After the Tier 2 worker/view split the
+ * legacy `'view'` and `'result'` extension types collapsed into a single
+ * `'extension'` type; the view/background distinction now lives on
+ * individual commands. `'extension'` keeps only type=extension rows,
+ * `'theme'` keeps only type=theme rows.
+ */
+export type ExtensionFilter = 'all' | 'commands' | 'extension' | 'theme';
 
 export function filterExtensions(
   extensions: ExtensionItem[],
@@ -9,8 +16,7 @@ export function filterExtensions(
 ): ExtensionItem[] {
   let result = extensions;
 
-  if (filter === 'view') result = result.filter(e => e.type === 'view');
-  else if (filter === 'result') result = result.filter(e => e.type === 'result');
+  if (filter === 'extension') result = result.filter(e => e.type === 'extension' || !e.type);
   else if (filter === 'theme') result = result.filter(e => e.type === 'theme');
   else if (filter === 'commands') result = result.filter(e => (e.commands?.length ?? 0) > 0);
 
@@ -20,7 +26,7 @@ export function filterExtensions(
   return result.filter(ext => {
     if (ext.title.toLowerCase().includes(q)) return true;
     return ext.commands?.some(
-      cmd => cmd.name.toLowerCase().includes(q) || cmd.trigger.toLowerCase().includes(q),
+      cmd => cmd.name.toLowerCase().includes(q) || (cmd.trigger ?? '').toLowerCase().includes(q),
     ) ?? false;
   });
 }

--- a/src/services/deeplink/deeplinkService.svelte.ts
+++ b/src/services/deeplink/deeplinkService.svelte.ts
@@ -60,12 +60,14 @@ export class DeeplinkService {
         return;
       }
 
-      // 6. Determine execution mode based on resultType
-      const isView = command.resultType === 'view' || manifest.type === 'view';
+      // 6. Determine execution mode based on the command's `mode`. After the
+      // Tier 2 worker/view split there is no manifest-level view/result type;
+      // the view/background distinction lives on each command.
+      const isView = command.mode === 'view';
 
       if (isView) {
         await this.deps.showWindow();
-        const viewPath = `${extensionId}/${manifest.defaultView || commandId}`;
+        const viewPath = `${extensionId}/${command.component ?? commandId}`;
         this.deps.navigateToView(viewPath);
       }
 

--- a/src/services/deeplink/deeplinkService.test.ts
+++ b/src/services/deeplink/deeplinkService.test.ts
@@ -25,29 +25,32 @@ function makeDeps(overrides?: Partial<DeeplinkDeps>): DeeplinkDeps {
   }
 }
 
-/** A minimal manifest with one no-view command. */
+/**
+ * A minimal manifest under the Tier 2 worker/view split schema.
+ * `mode` drives view/background routing (was `resultType` pre-refactor).
+ * `component` replaces the per-manifest `defaultView`.
+ */
 function makeManifest(overrides?: {
   commandId?: string
-  resultType?: string
-  defaultView?: string
-  extensionType?: string
+  mode?: 'view' | 'background'
+  component?: string
 }) {
   const commandId = overrides?.commandId ?? 'run'
-  const resultType = overrides?.resultType ?? 'no-view'
+  const mode = overrides?.mode ?? 'background'
   return {
     id: 'com.example.ext',
     name: 'Test Extension',
     version: '1.0.0',
     description: '',
-    type: overrides?.extensionType ?? 'result',
-    defaultView: overrides?.defaultView,
+    type: 'extension' as const,
     commands: [
       {
         id: commandId,
         name: 'Run',
         description: '',
         trigger: 'run',
-        resultType,
+        mode,
+        component: overrides?.component,
       },
     ],
   }
@@ -104,8 +107,8 @@ describe('DeeplinkService.handleExtensionDeeplink', () => {
 
   it('shows window and navigates for view commands', async () => {
     const manifest = makeManifest({
-      resultType: 'view',
-      defaultView: 'DefaultView',
+      mode: 'view',
+      component: 'MainView',
     })
     vi.mocked(deps.getManifestById).mockReturnValue(manifest)
     vi.mocked(deps.isExtensionEnabled).mockReturnValue(true)
@@ -119,19 +122,17 @@ describe('DeeplinkService.handleExtensionDeeplink', () => {
     })
 
     expect(deps.showWindow).toHaveBeenCalled()
-    expect(deps.navigateToView).toHaveBeenCalledWith('com.example.ext/DefaultView')
+    expect(deps.navigateToView).toHaveBeenCalledWith('com.example.ext/MainView')
   })
 
-  it('shows window for view-type extension even when command resultType is no-view', async () => {
-    const manifest = makeManifest({
-      extensionType: 'view',
-      resultType: 'no-view',
-      defaultView: 'MainView',
-    })
+  it('falls back to commandId when mode=view command has no component', async () => {
+    // component is required by the Rust validator, but the TS layer must
+    // not panic if a fixture lacks it. Falls back to commandId.
+    const manifest = makeManifest({ mode: 'view', component: undefined })
     vi.mocked(deps.getManifestById).mockReturnValue(manifest)
     vi.mocked(deps.isExtensionEnabled).mockReturnValue(true)
     vi.mocked(deps.hasCommand).mockReturnValue(true)
-    vi.mocked(deps.executeCommand).mockResolvedValue({ type: 'no-view' })
+    vi.mocked(deps.executeCommand).mockResolvedValue({ type: 'view' })
 
     await service.handleExtensionDeeplink({
       extensionId: 'com.example.ext',
@@ -139,8 +140,7 @@ describe('DeeplinkService.handleExtensionDeeplink', () => {
       args: {},
     })
 
-    expect(deps.showWindow).toHaveBeenCalled()
-    expect(deps.navigateToView).toHaveBeenCalledWith('com.example.ext/MainView')
+    expect(deps.navigateToView).toHaveBeenCalledWith('com.example.ext/run')
   })
 
   // ── Validation: extension not found ──────────────────────────────────
@@ -292,15 +292,16 @@ describe('DeeplinkService.handleExtensionDeeplink', () => {
       name: 'Store',
       version: '1.0.0',
       description: '',
-      type: 'view' as const,
-      defaultView: undefined,
+      type: 'extension' as const,
       commands: [
         {
           id: 'browse',
           name: 'Browse Extension Store',
           description: '',
           trigger: 'store',
-          resultType: undefined,
+          // Store is a view command; its component drives the nav path.
+          mode: 'view' as const,
+          component: 'BrowseView',
         },
       ],
     }

--- a/src/services/extension/ExtensionLoader.test.ts
+++ b/src/services/extension/ExtensionLoader.test.ts
@@ -276,7 +276,7 @@ describe('ExtensionLoader Tier 2 no-view handler routes through dispatcher', () 
       vi.fn(),
     )
     ;(loader as any).allLoadedCommands = [{
-      cmd: { id: 'run', name: 'Run', resultType: 'no-view' },
+      cmd: { id: 'run', name: 'Run', mode: 'background' },
       manifest: { id: 'ext.a', commands: [] },
       isBuiltIn: false,
     }]

--- a/src/services/extension/ExtensionLoader.ts
+++ b/src/services/extension/ExtensionLoader.ts
@@ -220,8 +220,8 @@ export class ExtensionLoader {
         if (!module) {
           // Tier 2 extensions (iframes) don't have a JS module instance
           if (!isBuiltIn) {
-            if (cmd.resultType === 'no-view') {
-              // no-view Tier 2 command: send execute message to iframe
+            if (cmd.mode === 'background') {
+              // background Tier 2 command: send execute message to iframe
               const handler = {
                 execute: async (args?: Record<string, any>) => {
                   await dispatch({
@@ -236,10 +236,13 @@ export class ExtensionLoader {
               commandService.registerCommand(fullObjectId, handler, manifest.id);
               commandService.setShortCommandId(fullObjectId, shortCmdId);
             } else {
-              // view Tier 2 command: navigate to view (existing behavior)
+              // view Tier 2 command: navigate to the component the manifest
+              // declares for this command. Phase 3 swaps this for the new
+              // dual-iframe registry; until then, navigating by component
+              // name preserves existing behaviour.
               const handler = {
-                execute: async (args?: Record<string, any>) => {
-                  const viewName = (cmd as any).view || manifest.defaultView || 'DefaultView';
+                execute: async (_args?: Record<string, any>) => {
+                  const viewName = cmd.component ?? cmd.id;
                   navigateToView(`${manifest.id}/${viewName}`);
                 },
               };
@@ -266,7 +269,7 @@ export class ExtensionLoader {
               if (isBuiltIn) {
                 return await extensionInstance.executeCommand(shortCmdId, args);
               } else {
-                const viewName = (cmd as any).view || manifest.defaultView || 'DefaultView';
+                const viewName = cmd.component ?? cmd.id;
                 navigateToView(`${manifest.id}/${viewName}`);
               }
             } catch (execError) {
@@ -380,7 +383,10 @@ export class ExtensionLoader {
           name: cmd.name,
           extension: manifest.id,
           trigger: cmd.trigger || cmd.name,
-          type: cmd.resultType || manifest.type,
+          // Rust search index reads this as the command's execution style.
+          // After the schema change, `cmd.mode` is the authoritative field;
+          // fall back to manifest.type (which is `"extension"` or `"theme"`).
+          type: cmd.mode || manifest.type,
           icon: cmd.icon ?? manifest.icon ?? null,
         }));
 

--- a/src/services/extension/extensionSearchAggregator.ts
+++ b/src/services/extension/extensionSearchAggregator.ts
@@ -92,7 +92,13 @@ export class ExtensionSearchAggregator {
                   extensionId: id,
                   // Create a host-side action since functions can't be serialized
                   action: () => {
-                    const viewPath = r.viewPath || `${id}/${manifest.defaultView || 'DefaultView'}`;
+                    // Prefer the extension-returned viewPath. Otherwise fall
+                    // back to the first mode=view command's component (the
+                    // new-schema replacement for the old manifest.defaultView).
+                    const firstViewComponent = manifest.commands?.find(
+                      (c: any) => c.mode === 'view' && typeof c.component === 'string' && c.component.length > 0,
+                    )?.component;
+                    const viewPath = r.viewPath || `${id}/${firstViewComponent ?? 'DefaultView'}`;
                     this.navigateToView(viewPath);
                   }
                 }));

--- a/src/services/extension/extensionStateManager.svelte.ts
+++ b/src/services/extension/extensionStateManager.svelte.ts
@@ -106,8 +106,15 @@ export class ExtensionStateManager {
               .join(" ") || "",
           type: manifest.type,
           action: () => {
-            if (manifest.type === "view" && manifest.defaultView) {
-              navigateToView(`${manifest.id}/${manifest.defaultView}`);
+            // After the Tier 2 worker/view split, auto-navigate on enable
+            // keys off the first command whose mode is `"view"`. The old
+            // top-level `defaultView` is gone; the per-command `component`
+            // field is now authoritative.
+            const firstViewCmd = manifest.commands?.find(
+              (c: any) => c.mode === "view" && typeof c.component === "string" && c.component.length > 0,
+            );
+            if (firstViewCmd) {
+              navigateToView(`${manifest.id}/${firstViewCmd.component}`);
             } else {
               logService.info(
                 `Default action triggered for non-view/commandless extension: ${manifest.id}`


### PR DESCRIPTION
Redefine the manifest `type` field to "extension" | "theme" (rejecting
legacy "view" and "result"), add top-level `background.main`, add
per-command `mode` ("view" | "background") with a `component` field for
views. Remove `defaultView`, top-level `main`, and per-command
`resultType`. Enforce unknown-field rejection via
serde(deny_unknown_fields). Installer branches on `type` for theme vs
extension validation; old "view"/"result" values are install-time errors.

Frontend theme recognition is updated to drop branches on the removed
"view"/"result" values; `type === 'theme'` keeps working.

Schema-only phase: runtime dispatch and iframe lifecycle are unchanged.