### PR TITLE
refactor(sdk-consumers)!: migrate to asyar-sdk/contracts; retire data-role DOM read

### DIFF
--- a/src/built-in-features/ai-chat/index.test.ts
+++ b/src/built-in-features/ai-chat/index.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ActionContext } from 'asyar-sdk';
+import { ActionContext } from 'asyar-sdk/contracts';
 
 // Mocks MUST be defined BEFORE imports of the module under test
-vi.mock('asyar-sdk', () => ({
+vi.mock('asyar-sdk/contracts', () => ({
   ActionContext: {
     EXTENSION_VIEW: 'EXTENSION_VIEW',
   },

--- a/src/built-in-features/ai-chat/index.ts
+++ b/src/built-in-features/ai-chat/index.ts
@@ -1,5 +1,5 @@
-import type { Extension, ExtensionContext, IExtensionManager } from 'asyar-sdk';
-import { ActionContext } from 'asyar-sdk';
+import type { Extension, ExtensionContext, IExtensionManager } from 'asyar-sdk/contracts';
+import { ActionContext } from 'asyar-sdk/contracts';
 import ChatView from './ChatView.svelte';
 import HistoryView from './HistoryView.svelte';
 import { contextModeService } from '../../services/context/contextModeService.svelte';

--- a/src/built-in-features/calculator/index.ts
+++ b/src/built-in-features/calculator/index.ts
@@ -4,7 +4,7 @@ import type {
   ExtensionResult,
   ILogService,
   INotificationService,
-} from "asyar-sdk";
+} from "asyar-sdk/contracts";
 
 import { evaluateMath } from "./engine/math";
 import { evaluateUnitExpression } from "./engine/units";

--- a/src/built-in-features/clipboard-history/DefaultView.svelte
+++ b/src/built-in-features/clipboard-history/DefaultView.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { clipboardViewState } from "./state.svelte";
   import { fetchRawHtml } from "./urlFetcher";
-  import { stripRtf, type ClipboardHistoryItem } from "asyar-sdk";
+  import { stripRtf, type ClipboardHistoryItem } from "asyar-sdk/contracts";
   import { readFile } from "@tauri-apps/plugin-fs";
   import { revealItemInDir } from "@tauri-apps/plugin-opener";
   import { marked } from "marked";

--- a/src/built-in-features/clipboard-history/index.test.ts
+++ b/src/built-in-features/clipboard-history/index.test.ts
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { ClipboardItemType } from 'asyar-sdk'
+import { ClipboardItemType } from 'asyar-sdk/contracts'
 import extension from './index'
 import { clipboardViewState } from './state.svelte'
 

--- a/src/built-in-features/clipboard-history/index.ts
+++ b/src/built-in-features/clipboard-history/index.ts
@@ -18,8 +18,8 @@ import {
   type ClipboardHistoryItem,
   ActionContext,
   ClipboardItemType,
-} from "asyar-sdk";
-import type { ExtensionAction, IActionService } from "asyar-sdk";
+} from "asyar-sdk/contracts";
+import type { ExtensionAction, IActionService } from "asyar-sdk/contracts";
 import { snippetUiState } from '../snippets/snippetUiState.svelte';
 
 // Define static results for clipboard extension

--- a/src/built-in-features/clipboard-history/state.svelte.ts
+++ b/src/built-in-features/clipboard-history/state.svelte.ts
@@ -8,7 +8,7 @@ import {
   SearchEngine,
   stripHtml,
   stripRtf,
-} from "asyar-sdk";
+} from "asyar-sdk/contracts";
 
 
 export class ClipboardViewStateClass {

--- a/src/built-in-features/clipboard-history/urlFetcher.ts
+++ b/src/built-in-features/clipboard-history/urlFetcher.ts
@@ -1,4 +1,4 @@
-import type { INetworkService } from "asyar-sdk";
+import type { INetworkService } from "asyar-sdk/contracts";
 
 const cache = new Map<string, { html: string; timestamp: number }>();
 const rawCache = new Map<string, { html: string; timestamp: number }>();

--- a/src/built-in-features/create-extension/CreateExtensionView.svelte
+++ b/src/built-in-features/create-extension/CreateExtensionView.svelte
@@ -85,7 +85,7 @@
       }, 1500);
 
       try {
-        const { ExtensionManagerProxy } = await import("asyar-sdk");
+        const { ExtensionManagerProxy } = await import("asyar-sdk/contracts");
         await new ExtensionManagerProxy().reloadExtensions();
       } catch (err) {
         logService.error(`Failed to trigger reload: ${err}`);

--- a/src/built-in-features/create-extension/index.ts
+++ b/src/built-in-features/create-extension/index.ts
@@ -1,4 +1,4 @@
-import type { Extension, ExtensionContext, IExtensionManager } from "asyar-sdk";
+import type { Extension, ExtensionContext, IExtensionManager } from "asyar-sdk/contracts";
 import DefaultView from "./CreateExtensionView.svelte";
 
 class CreateExtension implements Extension {

--- a/src/built-in-features/portals/index.svelte.ts
+++ b/src/built-in-features/portals/index.svelte.ts
@@ -1,11 +1,11 @@
-import type { Extension, ExtensionContext, IExtensionManager } from 'asyar-sdk';
+import type { Extension, ExtensionContext, IExtensionManager } from 'asyar-sdk/contracts';
 import DefaultView from './DefaultView.svelte';
 import { portalStore, type Portal } from './portalStore.svelte';
 import { invoke } from '@tauri-apps/api/core';
 import { searchService } from '../../services/search/SearchService';
 import { commandService } from '../../services/extension/commandService.svelte';
 import { actionService } from '../../services/action/actionService.svelte';
-import { ActionContext } from 'asyar-sdk';
+import { ActionContext } from 'asyar-sdk/contracts';
 import { contextModeService } from '../../services/context/contextModeService.svelte';
 import { resolveTemplate, PLACEHOLDERS } from '../../lib/placeholders';
 

--- a/src/built-in-features/quit/index.ts
+++ b/src/built-in-features/quit/index.ts
@@ -1,4 +1,4 @@
-import type { Extension, ExtensionContext } from 'asyar-sdk';
+import type { Extension, ExtensionContext } from 'asyar-sdk/contracts';
 import { quitApp, setFocusLock } from '../../lib/ipc/commands';
 import { feedbackService } from '../../services/feedback/feedbackService.svelte';
 

--- a/src/built-in-features/settings/index.ts
+++ b/src/built-in-features/settings/index.ts
@@ -1,4 +1,4 @@
-import type { Extension, ExtensionContext } from 'asyar-sdk';
+import type { Extension, ExtensionContext } from 'asyar-sdk/contracts';
 import { showSettingsWindow } from '../../lib/ipc/commands';
 
 class SettingsExtension implements Extension {

--- a/src/built-in-features/shortcuts/index.ts
+++ b/src/built-in-features/shortcuts/index.ts
@@ -1,5 +1,5 @@
-import type { Extension, ExtensionContext, IExtensionManager } from 'asyar-sdk';
-import { ActionContext } from 'asyar-sdk';
+import type { Extension, ExtensionContext, IExtensionManager } from 'asyar-sdk/contracts';
+import { ActionContext } from 'asyar-sdk/contracts';
 // @ts-ignore
 import DefaultView from './DefaultView.svelte';
 import { actionService } from '../../services/action/actionService.svelte';

--- a/src/built-in-features/snippets/index.ts
+++ b/src/built-in-features/snippets/index.ts
@@ -1,9 +1,9 @@
-import type { Extension, ExtensionContext, IExtensionManager } from 'asyar-sdk';
+import type { Extension, ExtensionContext, IExtensionManager } from 'asyar-sdk/contracts';
 // @ts-ignore
 import DefaultView from './DefaultView.svelte';
 import { snippetStore } from './snippetStore.svelte';
 import { snippetService } from './snippetService';
-import { ActionContext } from 'asyar-sdk';
+import { ActionContext } from 'asyar-sdk/contracts';
 import { actionService } from '../../services/action/actionService.svelte';
 import { snippetUiState } from './snippetUiState.svelte';
 import { snippetViewState } from './snippetViewState.svelte';

--- a/src/built-in-features/snippets/snippetService.test.ts
+++ b/src/built-in-features/snippets/snippetService.test.ts
@@ -45,7 +45,7 @@ vi.mock('../../services/log/logService', () => ({
   logService: { warn: mockWarn }
 }))
 
-import { ClipboardItemType } from 'asyar-sdk'
+import { ClipboardItemType } from 'asyar-sdk/contracts'
 import { selectionService } from '../../services/selection/selectionService'
 import { clipboardHistoryService } from '../../services/clipboard/clipboardHistoryService'
 import { snippetService } from './snippetService'

--- a/src/built-in-features/snippets/snippetViewState.svelte.ts
+++ b/src/built-in-features/snippets/snippetViewState.svelte.ts
@@ -1,5 +1,5 @@
 import { snippetStore, type Snippet } from './snippetStore.svelte';
-import { SearchEngine } from 'asyar-sdk';
+import { SearchEngine } from 'asyar-sdk/contracts';
 
 export type SnippetEditMode = 'view' | 'edit' | 'create';
 

--- a/src/built-in-features/store/index.svelte.ts
+++ b/src/built-in-features/store/index.svelte.ts
@@ -7,7 +7,7 @@ import type {
   ILogService,
   INotificationService,
   ExtensionAction,
-} from "asyar-sdk";
+} from "asyar-sdk/contracts";
 // Import the placeholder and the initializer function
 import { storeViewState, initializeStore } from "./state.svelte";
 import * as commands from "../../lib/ipc/commands";

--- a/src/built-in-features/store/state.svelte.ts
+++ b/src/built-in-features/store/state.svelte.ts
@@ -1,4 +1,4 @@
-import { SearchEngine, type ILogService, type IExtensionManager } from 'asyar-sdk';
+import { SearchEngine, type ILogService, type IExtensionManager } from 'asyar-sdk/contracts';
 import type { AvailableUpdate } from '../../types/ExtensionUpdate';
 
 // Re-define ApiExtension here or import if possible (avoiding circular deps)

--- a/src/built-in-features/window-management/ManageView.svelte
+++ b/src/built-in-features/window-management/ManageView.svelte
@@ -5,8 +5,8 @@
   import { windowManagementService } from '../../services/windowManagement/windowManagementService'
   import { feedbackService } from '../../services/feedback/feedbackService.svelte'
   import { actionService } from '../../services/action/actionService.svelte'
-  import type { IStorageService } from 'asyar-sdk'
-  import { ActionContext } from 'asyar-sdk'
+  import type { IStorageService } from 'asyar-sdk/contracts'
+  import { ActionContext } from 'asyar-sdk/contracts'
 
   interface Props {
     store?: IStorageService

--- a/src/built-in-features/window-management/index.test.ts
+++ b/src/built-in-features/window-management/index.test.ts
@@ -40,7 +40,7 @@ import extension from './index'
 import { windowManagementService } from '../../services/windowManagement/windowManagementService'
 import { feedbackService } from '../../services/feedback/feedbackService.svelte'
 import { windowManagementState } from './state.svelte'
-import type { ExtensionContext } from 'asyar-sdk'
+import type { ExtensionContext } from 'asyar-sdk/contracts'
 
 function makeContext(): ExtensionContext {
   return {

--- a/src/built-in-features/window-management/index.ts
+++ b/src/built-in-features/window-management/index.ts
@@ -12,7 +12,7 @@ import {
   type IStorageService,
   type IExtensionManager,
   ActionContext,
-} from 'asyar-sdk'
+} from 'asyar-sdk/contracts'
 
 class WindowManagementExtension implements Extension {
   onUnload: any

--- a/src/built-in-features/window-management/state.svelte.test.ts
+++ b/src/built-in-features/window-management/state.svelte.test.ts
@@ -7,7 +7,7 @@ vi.mock('../../services/log/logService', () => ({
 }))
 
 import { WindowManagementState } from './state.svelte'
-import type { IStorageService } from 'asyar-sdk'
+import type { IStorageService } from 'asyar-sdk/contracts'
 import type { WindowBounds } from '../../lib/ipc/commands'
 
 function makeStoreMock(data: Record<string, string> = {}): IStorageService {

--- a/src/built-in-features/window-management/state.svelte.ts
+++ b/src/built-in-features/window-management/state.svelte.ts
@@ -1,5 +1,5 @@
 import { logService } from '../../services/log/logService'
-import type { IStorageService } from 'asyar-sdk'
+import type { IStorageService } from 'asyar-sdk/contracts'
 import type { WindowBounds } from '../../lib/ipc/commands'
 
 export interface CustomLayout {

--- a/src/components/extension/ExtensionIframe.svelte
+++ b/src/components/extension/ExtensionIframe.svelte
@@ -2,7 +2,7 @@
   import { logService as logger } from '../../services/log/logService';
   import { extensionIframeManager } from '../../services/extension/extensionIframeManager.svelte';
   import { viewRegistry } from '../../services/extension/viewRegistry.svelte';
-  import type { ExtensionManifest } from 'asyar-sdk';
+  import type { ExtensionManifest } from 'asyar-sdk/contracts';
   import { collectThemeVariables } from '../../lib/themeVariables';
   import { buildFontFaceCSS } from '../../lib/themeFonts';
 

--- a/src/components/extension/ExtensionViewContainer.svelte
+++ b/src/components/extension/ExtensionViewContainer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import ExtensionIframe from './ExtensionIframe.svelte';
   import { isBuiltInFeature } from '../../services/extension/extensionDiscovery';
-  import type { ExtensionManifest } from 'asyar-sdk';
+  import type { ExtensionManifest } from 'asyar-sdk/contracts';
 
   interface Props {
     activeView: string;

--- a/src/components/layout/BottomActionBar.svelte
+++ b/src/components/layout/BottomActionBar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { actionService, type ApplicationAction } from '../../services/action/actionService.svelte';
   import type { SearchResult } from '../../services/search/interfaces/SearchResult';
-  import type { ExtensionManifest } from 'asyar-sdk';
+  import type { ExtensionManifest } from 'asyar-sdk/contracts';
   import { viewManager } from '../../services/extension/viewManager.svelte';
   import { searchStores } from '../../services/search/stores/search.svelte';
   import extensionManager from '../../services/extension/extensionManager.svelte';

--- a/src/components/layout/InformationPanel.svelte
+++ b/src/components/layout/InformationPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { SearchResult } from '../../services/search/interfaces/SearchResult';
-  import type { ExtensionManifest } from 'asyar-sdk';
+  import type { ExtensionManifest } from 'asyar-sdk/contracts';
   import { logService } from '../../services/log/logService';
   import { viewManager } from '../../services/extension/viewManager.svelte';
   import { isIconImage, isBuiltInIcon, getBuiltInIconName } from '../../lib/iconUtils';

--- a/src/components/layout/actionFilter.test.ts
+++ b/src/components/layout/actionFilter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { filterActions } from './actionFilter'
 import type { ApplicationAction } from '../../services/action/actionService.svelte'
-import { ActionContext } from 'asyar-sdk'
+import { ActionContext } from 'asyar-sdk/contracts'
 
 function makeAction(id: string, label: string, description = ''): ApplicationAction {
   return { id, label, description, context: ActionContext.EXTENSION_VIEW, execute: vi.fn() }

--- a/src/components/search/CommandArgInput.svelte
+++ b/src/components/search/CommandArgInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { tick } from 'svelte';
-  import type { CommandArgument } from 'asyar-sdk';
+  import type { CommandArgument } from 'asyar-sdk/contracts';
 
   let {
     arg,

--- a/src/components/settings/ExtensionDetailPanel.svelte
+++ b/src/components/settings/ExtensionDetailPanel.svelte
@@ -3,7 +3,7 @@
   import Toggle from '../base/Toggle.svelte';
   import ExtensionPreferencesForm from './ExtensionPreferencesForm.svelte';
   import type { ExtensionItem } from '../../routes/settings/settingsHandlers.svelte';
-  import type { ExtensionCommand } from 'asyar-sdk';
+  import type { ExtensionCommand } from 'asyar-sdk/contracts';
   import { extensionPreferencesService } from '../../services/extension/extensionPreferencesService.svelte';
 
   let {

--- a/src/components/settings/ExtensionPreferencesForm.svelte
+++ b/src/components/settings/ExtensionPreferencesForm.svelte
@@ -2,7 +2,7 @@
   import Input from '../base/Input.svelte';
   import Checkbox from '../base/Checkbox.svelte';
   import SettingsFormRow from './SettingsFormRow.svelte';
-  import type { PreferenceDeclaration } from 'asyar-sdk';
+  import type { PreferenceDeclaration } from 'asyar-sdk/contracts';
 
   interface Props {
     preferences: PreferenceDeclaration[];

--- a/src/components/settings/RequiredPreferencesDialog.svelte
+++ b/src/components/settings/RequiredPreferencesDialog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { PreferenceDeclaration } from 'asyar-sdk';
+  import type { PreferenceDeclaration } from 'asyar-sdk/contracts';
   import ExtensionPreferencesForm from './ExtensionPreferencesForm.svelte';
 
   interface Props {

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -1,4 +1,4 @@
-import { ICON_DATA } from 'asyar-sdk';
+import { ICON_DATA } from 'asyar-sdk/contracts';
 
 /**
  * SVG path data for built-in Asyar icons.

--- a/src/lib/launcher/selectionEffects.svelte.ts
+++ b/src/lib/launcher/selectionEffects.svelte.ts
@@ -1,6 +1,6 @@
 import { searchStores } from '../../services/search/stores/search.svelte';
 import { actionService } from '../../services/action/actionService.svelte';
-import { ActionContext } from 'asyar-sdk';
+import { ActionContext } from 'asyar-sdk/contracts';
 import { buildMappedItems } from '../searchResultMapper';
 import type { ItemShortcut } from '../../built-in-features/shortcuts/shortcutStore.svelte';
 import type { LauncherState } from './launcherState.svelte';

--- a/src/routes/settings/settingsHandlers.svelte.ts
+++ b/src/routes/settings/settingsHandlers.svelte.ts
@@ -9,7 +9,7 @@ import { feedbackService } from '../../services/feedback/feedbackService.svelte'
 import type { AppSettings } from '../../services/settings/types/AppSettingsType';
 import { logService } from '../../services/log/logService';
 import type { CompatibilityStatus } from '../../types/CompatibilityStatus';
-import type { ExtensionCommand, PreferenceDeclaration } from 'asyar-sdk';
+import type { ExtensionCommand, PreferenceDeclaration } from 'asyar-sdk/contracts';
 
 // Define interface for extension items with enabled status
 export interface ExtensionItem {

--- a/src/routes/settings/tabs/ExtensionsTab.svelte
+++ b/src/routes/settings/tabs/ExtensionsTab.svelte
@@ -15,7 +15,7 @@
   } from '../../../lib/ipc/commands';
   import ShellTrustManager from '../../../components/settings/ShellTrustManager.svelte';
   import { filterExtensions, type ExtensionFilter } from './extensionFilters';
-  import type { ExtensionCommand } from 'asyar-sdk';
+  import type { ExtensionCommand } from 'asyar-sdk/contracts';
 
   let { handler }: { handler: SettingsHandler } = $props();
 

--- a/src/services/action/actionService.nonMacos.test.ts
+++ b/src/services/action/actionService.nonMacos.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { ActionContext } from 'asyar-sdk'
+import { ActionContext } from 'asyar-sdk/contracts'
 
 vi.mock('../log/logService', () => ({
   logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },

--- a/src/services/action/actionService.svelte.ts
+++ b/src/services/action/actionService.svelte.ts
@@ -1,6 +1,6 @@
 import { logService } from "../log/logService";
-import type { ExtensionAction, IActionService } from "asyar-sdk";
-import { ActionContext } from "asyar-sdk";
+import type { ExtensionAction, IActionService } from "asyar-sdk/contracts";
+import { ActionContext } from "asyar-sdk/contracts";
 import * as commands from "../../lib/ipc/commands";
 import { searchService } from "../search/SearchService";
 import { searchOrchestrator } from "../search/searchOrchestrator.svelte";

--- a/src/services/action/actionService.test.ts
+++ b/src/services/action/actionService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ActionService, type ApplicationAction } from './actionService.svelte'
-import { ActionContext } from 'asyar-sdk'
+import { ActionContext } from 'asyar-sdk/contracts'
 
 vi.mock('../log/logService', () => ({
   logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },

--- a/src/services/action/actionService.windows.test.ts
+++ b/src/services/action/actionService.windows.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { ActionContext } from 'asyar-sdk'
+import { ActionContext } from 'asyar-sdk/contracts'
 
 vi.mock('../log/logService', () => ({
   logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },

--- a/src/services/application/applicationService.ts
+++ b/src/services/application/applicationService.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { settingsService } from '../settings/settingsService.svelte';
-import type { FrontmostApplication } from 'asyar-sdk';
+import type { FrontmostApplication } from 'asyar-sdk/contracts';
 
 /**
  * One row of Library-scope data matched to an installed application by the

--- a/src/services/clipboard/clipboardHistoryService.test.ts
+++ b/src/services/clipboard/clipboardHistoryService.test.ts
@@ -60,7 +60,7 @@ vi.mock('./stores/clipboardHistoryStore.svelte', () => ({
 vi.mock('uuid', () => ({ v4: vi.fn(() => 'test-uuid') }))
 
 import { ClipboardHistoryService } from './clipboardHistoryService'
-import { ClipboardItemType, type ClipboardHistoryItem } from 'asyar-sdk'
+import { ClipboardItemType, type ClipboardHistoryItem } from 'asyar-sdk/contracts'
 
 function getInstance(): ClipboardHistoryService {
   return new ClipboardHistoryService()

--- a/src/services/clipboard/clipboardHistoryService.ts
+++ b/src/services/clipboard/clipboardHistoryService.ts
@@ -21,7 +21,7 @@ import {
   type IClipboardHistoryService,
   type ClipboardSourceApp,
   type FrontmostApplication,
-} from "asyar-sdk";
+} from "asyar-sdk/contracts";
 
 /**
  * Service for managing clipboard history

--- a/src/services/clipboard/stores/clipboardHistoryStore.svelte.ts
+++ b/src/services/clipboard/stores/clipboardHistoryStore.svelte.ts
@@ -1,5 +1,5 @@
 import { logService } from "../../log/logService";
-import type { ClipboardHistoryItem } from "asyar-sdk";
+import type { ClipboardHistoryItem } from "asyar-sdk/contracts";
 import {
   clipboardGetAll,
   clipboardToggleFavorite,

--- a/src/services/deeplink/deeplinkService.svelte.ts
+++ b/src/services/deeplink/deeplinkService.svelte.ts
@@ -1,6 +1,6 @@
 import { listen } from '@tauri-apps/api/event';
 import { logService } from '../log/logService';
-import type { ExtensionManifest, ExtensionCommand } from 'asyar-sdk';
+import type { ExtensionManifest, ExtensionCommand } from 'asyar-sdk/contracts';
 
 export interface DeeplinkDeps {
   getManifestById: (id: string) => ExtensionManifest | undefined;

--- a/src/services/extension/ExtensionIpcRouter.test.ts
+++ b/src/services/extension/ExtensionIpcRouter.test.ts
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { messageBroker } from 'asyar-sdk';
+import { messageBroker } from 'asyar-sdk/contracts';
 
 vi.mock('../log/logService', () => ({
   logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },

--- a/src/services/extension/ExtensionIpcRouter.ts
+++ b/src/services/extension/ExtensionIpcRouter.ts
@@ -4,7 +4,7 @@ import { envService } from "../envService";
 import { extensionIframeManager } from './extensionIframeManager.svelte';
 import { extensionPreferencesService } from './extensionPreferencesService.svelte';
 import { streamDispatcher } from './streamDispatcher.svelte';
-import { messageBroker, type Namespace } from 'asyar-sdk';
+import { messageBroker, type Namespace } from 'asyar-sdk/contracts';
 import type { ServiceRegistry } from './defineServiceRegistry';
 import type { ExtendedManifest } from '../../types/ExtendedManifest';
 

--- a/src/services/extension/ExtensionLoader.test.ts
+++ b/src/services/extension/ExtensionLoader.test.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ExtensionLoader } from './ExtensionLoader'
-import { ActionContext } from 'asyar-sdk'
+import { ActionContext } from 'asyar-sdk/contracts'
 
 // ---------- hoisted mocks ----------
 

--- a/src/services/extension/ExtensionLoader.ts
+++ b/src/services/extension/ExtensionLoader.ts
@@ -1,5 +1,5 @@
-import { ExtensionBridge, ActionContext } from "asyar-sdk";
-import type { Extension, ExtensionManifest, ExtensionCommand } from "asyar-sdk";
+import { ExtensionBridge, ActionContext } from "asyar-sdk/contracts";
+import type { Extension, ExtensionManifest, ExtensionCommand } from "asyar-sdk/contracts";
 import type { ExtendedManifest } from '../../types/ExtendedManifest';
 import { logService } from "../log/logService";
 import { extensionLoaderService } from "../extensionLoaderService";

--- a/src/services/extension/__tests__/injectionSets.test.ts
+++ b/src/services/extension/__tests__/injectionSets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { NAMESPACES } from 'asyar-sdk';
+import { NAMESPACES } from 'asyar-sdk/contracts';
 import {
   INJECTS_EXTENSION_ID,
   ALWAYS_INJECTS_CALLER_ID,

--- a/src/services/extension/__tests__/registryNoClassNameKeys.test.ts
+++ b/src/services/extension/__tests__/registryNoClassNameKeys.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { NAMESPACES } from 'asyar-sdk';
+import { NAMESPACES } from 'asyar-sdk/contracts';
 
 describe('serviceRegistry anti-reflection guard', () => {
   it('contains no class-name-shaped entries (ends with Service/Manager, or PascalCase)', () => {

--- a/src/services/extension/buildServiceRegistry.test.ts
+++ b/src/services/extension/buildServiceRegistry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { NAMESPACES } from 'asyar-sdk';
+import { NAMESPACES } from 'asyar-sdk/contracts';
 
 // Mock all service dependencies BEFORE importing the module under test
 vi.mock('../log/logService', () => ({

--- a/src/services/extension/buildServiceRegistry.ts
+++ b/src/services/extension/buildServiceRegistry.ts
@@ -1,5 +1,5 @@
 import { defineServiceRegistry, type ServiceRegistry } from './defineServiceRegistry';
-import type { IExtensionManager } from 'asyar-sdk';
+import type { IExtensionManager } from 'asyar-sdk/contracts';
 import type { ExtendedManifest } from '../../types/ExtendedManifest';
 import { logService } from '../log/logService';
 import { settingsService } from '../settings/settingsService.svelte';

--- a/src/services/extension/commandService.svelte.ts
+++ b/src/services/extension/commandService.svelte.ts
@@ -1,4 +1,4 @@
-import type { CommandHandler, ICommandService } from "asyar-sdk";
+import type { CommandHandler, ICommandService } from "asyar-sdk/contracts";
 import type { ExtensionManager } from './extensionManager.svelte';
 import { logService } from "../log/logService";
 import { extensionPreferencesService } from "./extensionPreferencesService.svelte";

--- a/src/services/extension/defineServiceRegistry.ts
+++ b/src/services/extension/defineServiceRegistry.ts
@@ -1,4 +1,4 @@
-import type { Namespace } from 'asyar-sdk';
+import type { Namespace } from 'asyar-sdk/contracts';
 
 export type ServiceRegistry = Record<Namespace, unknown>;
 

--- a/src/services/extension/extensionDiscovery.ts
+++ b/src/services/extension/extensionDiscovery.ts
@@ -1,5 +1,5 @@
 import { logService } from "../log/logService";
-import type { ExtensionManifest } from "asyar-sdk";
+import type { ExtensionManifest } from "asyar-sdk/contracts";
 
 // Import both regular and built-in features
 export const extensionContext = import.meta.glob("../../extensions/*/manifest.json");

--- a/src/services/extension/extensionManager.cycle.test.ts
+++ b/src/services/extension/extensionManager.cycle.test.ts
@@ -56,7 +56,7 @@ vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }))
 vi.mock('@tauri-apps/api/path', () => ({ resourceDir: vi.fn(), appDataDir: vi.fn(), join: vi.fn() }))
 vi.mock('@tauri-apps/plugin-fs', () => ({ exists: vi.fn(), readDir: vi.fn(), remove: vi.fn() }))
 vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }))
-vi.mock('asyar-sdk', () => ({
+vi.mock('asyar-sdk/contracts', () => ({
   extensionBridge: {
     registerManifest: vi.fn(),
     registerExtensionImplementation: vi.fn(),

--- a/src/services/extension/extensionManager.svelte.ts
+++ b/src/services/extension/extensionManager.svelte.ts
@@ -6,11 +6,11 @@ import type {
   ExtensionResult,
   IExtensionManager,
   ExtensionCommand,
-} from "asyar-sdk";
+} from "asyar-sdk/contracts";
 
 import type { ExtendedManifest } from '../../types/ExtendedManifest';
 import { isBuiltInFeature } from "./extensionDiscovery";
-import { extensionBridge, type ExtensionBridge } from "asyar-sdk";
+import { extensionBridge, type ExtensionBridge } from "asyar-sdk/contracts";
 import { logService } from "../log/logService";
 import { actionService } from "../action/actionService.svelte";
 
@@ -373,7 +373,7 @@ export class ExtensionManager implements IExtensionManager {
     commandName: string;
     isBuiltIn: boolean;
     icon?: string;
-    args: import('asyar-sdk').CommandArgument[];
+    args: import('asyar-sdk/contracts').CommandArgument[];
   } | null {
     if (!commandObjectId.startsWith('cmd_')) return null;
     const rest = commandObjectId.slice(4);
@@ -389,7 +389,7 @@ export class ExtensionManager implements IExtensionManager {
         commandName: cmd.name,
         isBuiltIn: isBuiltInFeature(manifest.id),
         icon: (cmd as { icon?: string }).icon ?? (manifest as { icon?: string }).icon,
-        args: (cmd as { arguments?: import('asyar-sdk').CommandArgument[] }).arguments ?? [],
+        args: (cmd as { arguments?: import('asyar-sdk/contracts').CommandArgument[] }).arguments ?? [],
       };
     }
     return null;

--- a/src/services/extension/extensionManager.test.ts
+++ b/src/services/extension/extensionManager.test.ts
@@ -42,7 +42,7 @@ vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
 vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }))
 vi.mock('@tauri-apps/plugin-fs', () => ({ exists: vi.fn(), readDir: vi.fn(), remove: vi.fn() }))
 vi.mock('@tauri-apps/api/path', () => ({ join: vi.fn(), resourceDir: vi.fn(), appDataDir: vi.fn() }))
-vi.mock('asyar-sdk', () => ({
+vi.mock('asyar-sdk/contracts', () => ({
   extensionBridge: {
     registerManifest: vi.fn(),
     registerExtensionImplementation: vi.fn(),

--- a/src/services/extension/extensionPreferencesService.svelte.ts
+++ b/src/services/extension/extensionPreferencesService.svelte.ts
@@ -3,7 +3,7 @@ import {
   extensionPreferencesSet,
   extensionPreferencesReset,
 } from '../../lib/ipc/commands';
-import type { PreferenceDeclaration } from 'asyar-sdk';
+import type { PreferenceDeclaration } from 'asyar-sdk/contracts';
 import { extensionIframeManager } from './extensionIframeManager.svelte';
 
 export interface PreferenceBundle {

--- a/src/services/extension/extensionReadinessListener.test.ts
+++ b/src/services/extension/extensionReadinessListener.test.ts
@@ -12,13 +12,15 @@ vi.mock('../log/logService', () => ({
 
 import { iframeReadyAck } from '../../lib/ipc/iframeLifecycleCommands';
 import { post } from './extensionDelivery';
+import { logService } from '../log/logService';
 import { extensionReadinessListener } from './extensionReadinessListener';
 
-function makeIframe(id: string, token: string, role?: string) {
+function makeIframe(id: string, token: string) {
   const iframe = document.createElement('iframe');
   iframe.setAttribute('data-extension-id', id);
   iframe.setAttribute('data-mount-token', token);
-  if (role !== undefined) iframe.setAttribute('data-role', role);
+  // NB: data-role is intentionally NOT read by the listener anymore.
+  // role is carried in the asyar:extension:loaded event payload by the SDK.
   Object.defineProperty(iframe, 'contentWindow', {
     value: { postMessage: vi.fn() } as any,
     configurable: true,
@@ -27,7 +29,7 @@ function makeIframe(id: string, token: string, role?: string) {
   return iframe;
 }
 
-describe('extensionReadinessListener', () => {
+describe('extensionReadinessListener — reads role from asyar:extension:loaded payload', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     document.body.replaceChildren();
@@ -35,14 +37,14 @@ describe('extensionReadinessListener', () => {
     extensionReadinessListener.init();
   });
 
-  it('on asyar:extension:loaded from a known iframe, calls iframeReadyAck with role and posts drained messages', async () => {
-    const iframe = makeIframe('ext.a', '7', 'view');
+  it('acks with role=view when payload.role === "view"', async () => {
+    const iframe = makeIframe('ext.a', '7');
     vi.mocked(iframeReadyAck).mockResolvedValueOnce([
-      { kind: 'command', payload: { commandId: 'x' }, source: 'search' },
+      { kind: 'command', payload: { commandId: 'x' }, source: 'search' } as any,
     ]);
 
     const event = new MessageEvent('message', {
-      data: { type: 'asyar:extension:loaded', extensionId: 'ext.a' },
+      data: { type: 'asyar:extension:loaded', extensionId: 'ext.a', role: 'view' },
       source: iframe.contentWindow as any,
     });
     window.dispatchEvent(event);
@@ -53,12 +55,12 @@ describe('extensionReadinessListener', () => {
     expect(post).toHaveBeenCalledTimes(1);
   });
 
-  it('on asyar:extension:loaded from worker iframe, calls iframeReadyAck with role=worker', async () => {
-    const iframe = makeIframe('ext.a', '3', 'worker');
+  it('acks with role=worker when payload.role === "worker"', async () => {
+    const iframe = makeIframe('ext.a', '3');
     vi.mocked(iframeReadyAck).mockResolvedValueOnce([]);
 
     const event = new MessageEvent('message', {
-      data: { type: 'asyar:extension:loaded', extensionId: 'ext.a' },
+      data: { type: 'asyar:extension:loaded', extensionId: 'ext.a', role: 'worker' },
       source: iframe.contentWindow as any,
     });
     window.dispatchEvent(event);
@@ -68,8 +70,8 @@ describe('extensionReadinessListener', () => {
     expect(iframeReadyAck).toHaveBeenCalledWith('ext.a', 3, 'worker');
   });
 
-  it('logs error and skips ack when iframe has no data-role (hard error)', async () => {
-    const iframe = makeIframe('ext.a', '7'); // no data-role
+  it('hard-errors and skips ack when payload.role is absent', async () => {
+    const iframe = makeIframe('ext.a', '7');
     vi.mocked(iframeReadyAck).mockResolvedValueOnce([]);
 
     const event = new MessageEvent('message', {
@@ -81,6 +83,23 @@ describe('extensionReadinessListener', () => {
     await Promise.resolve();
 
     expect(iframeReadyAck).not.toHaveBeenCalled();
+    expect(logService.error).toHaveBeenCalled();
+  });
+
+  it('hard-errors and skips ack when payload.role is unknown', async () => {
+    const iframe = makeIframe('ext.a', '7');
+    vi.mocked(iframeReadyAck).mockResolvedValueOnce([]);
+
+    const event = new MessageEvent('message', {
+      data: { type: 'asyar:extension:loaded', extensionId: 'ext.a', role: 'garbage' },
+      source: iframe.contentWindow as any,
+    });
+    window.dispatchEvent(event);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(iframeReadyAck).not.toHaveBeenCalled();
+    expect(logService.error).toHaveBeenCalled();
   });
 
   it('ignores messages whose iframe has no data-mount-token', async () => {
@@ -93,7 +112,7 @@ describe('extensionReadinessListener', () => {
     document.body.appendChild(iframe);
 
     const event = new MessageEvent('message', {
-      data: { type: 'asyar:extension:loaded', extensionId: 'ext.a' },
+      data: { type: 'asyar:extension:loaded', extensionId: 'ext.a', role: 'view' },
       source: iframe.contentWindow as any,
     });
     window.dispatchEvent(event);

--- a/src/services/extension/extensionReadinessListener.ts
+++ b/src/services/extension/extensionReadinessListener.ts
@@ -43,14 +43,18 @@ class ExtensionReadinessListener {
     const mountToken = Number(mountTokenStr);
     if (!Number.isFinite(mountToken)) return;
 
-    const roleAttr = iframe.getAttribute('data-role');
-    if (roleAttr !== 'view' && roleAttr !== 'worker') {
+    // Role is authoritative from the SDK-emitted payload (Phase 4).
+    // The iframe's data-role DOM attribute is retained for the dev
+    // inspector (Phase 7) but is not read here — the listener trusts the
+    // sender's self-declared role via postMessage.
+    const payloadRole = (data as { role?: unknown }).role;
+    if (payloadRole !== 'view' && payloadRole !== 'worker') {
       logService.error(
-        `[readiness] iframe for ${extensionId} has no valid data-role (got: ${String(roleAttr)})`,
+        `[readiness] asyar:extension:loaded from ${extensionId} has no valid role in payload (got: ${String(payloadRole)})`,
       );
       return;
     }
-    const role: 'view' | 'worker' = roleAttr;
+    const role: 'view' | 'worker' = payloadRole;
 
     let drained: IpcPendingMessage[];
     try {

--- a/src/services/extension/extensionSearchAggregator.ts
+++ b/src/services/extension/extensionSearchAggregator.ts
@@ -1,4 +1,4 @@
-import type { Extension, ExtensionResult, ExtensionManifest } from "asyar-sdk";
+import type { Extension, ExtensionResult, ExtensionManifest } from "asyar-sdk/contracts";
 import { logService } from "../log/logService";
 import { extensionIframeManager } from './extensionIframeManager.svelte';
 import { settingsService } from "../settings/settingsService.svelte";

--- a/src/services/extension/preferencesPromptStore.svelte.ts
+++ b/src/services/extension/preferencesPromptStore.svelte.ts
@@ -1,4 +1,4 @@
-import type { PreferenceDeclaration } from 'asyar-sdk';
+import type { PreferenceDeclaration } from 'asyar-sdk/contracts';
 
 /**
  * Reactive store for the "required preferences" modal. The commandService

--- a/src/services/extension/viewManager.svelte.ts
+++ b/src/services/extension/viewManager.svelte.ts
@@ -1,7 +1,7 @@
 import { logService } from '../log/logService';
 import { searchStores } from '../search/stores/search.svelte';
 import { extensionIframeManager } from './extensionIframeManager.svelte';
-import type { ExtensionManifest, Extension } from 'asyar-sdk';
+import type { ExtensionManifest, Extension } from 'asyar-sdk/contracts';
 
 // Internal state for navigation stack
 interface NavigationState {

--- a/src/services/extension/viewManager.test.ts
+++ b/src/services/extension/viewManager.test.ts
@@ -20,7 +20,7 @@ vi.mock('./extensionIframeManager.svelte', () => ({
 import { viewManager } from './viewManager.svelte'
 import { searchStores } from '../search/stores/search.svelte'
 import { extensionIframeManager } from './extensionIframeManager.svelte'
-import type { ExtensionManifest } from 'asyar-sdk'
+import type { ExtensionManifest } from 'asyar-sdk/contracts'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/src/services/extensionLoaderService.ts
+++ b/src/services/extensionLoaderService.ts
@@ -1,5 +1,5 @@
 import { logService } from "./log/logService";
-import type { ExtensionManifest } from "asyar-sdk";
+import type { ExtensionManifest } from "asyar-sdk/contracts";
 import { isBuiltInFeature } from "./extension/extensionDiscovery";
 import { discoverExtensions as discoverExtensionsIpc, getExtension as getExtensionIpc } from "../lib/ipc/commands";
 

--- a/src/services/feedback/feedbackService.svelte.ts
+++ b/src/services/feedback/feedbackService.svelte.ts
@@ -3,7 +3,7 @@ import type {
   ShowToastOptions,
   ConfirmAlertOptions,
   ToastStyle,
-} from "asyar-sdk";
+} from "asyar-sdk/contracts";
 import * as commands from "../../lib/ipc/commands";
 
 interface ActiveToast {

--- a/src/services/log/logService.ts
+++ b/src/services/log/logService.ts
@@ -1,5 +1,5 @@
 import { info, error, debug, attachConsole } from "@tauri-apps/plugin-log";
-import type { ILogService } from "asyar-sdk";
+import type { ILogService } from "asyar-sdk/contracts";
 
 /**
  * Color codes for terminal output

--- a/src/services/notification/notificationService.ts
+++ b/src/services/notification/notificationService.ts
@@ -7,7 +7,7 @@ import {
 import type {
   NotificationAction,
   NotificationOptions,
-} from "asyar-sdk";
+} from "asyar-sdk/contracts";
 
 /**
  * Host-side notification service. All real work happens in Rust —

--- a/src/services/power/powerService.ts
+++ b/src/services/power/powerService.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { KeepAwakeOptions, ActiveInhibitor } from 'asyar-sdk';
+import type { KeepAwakeOptions, ActiveInhibitor } from 'asyar-sdk/contracts';
 
 /**
  * Host-side thin wrapper over the Rust `power_*` Tauri commands.

--- a/src/services/profile/providers/clipboardSyncProvider.ts
+++ b/src/services/profile/providers/clipboardSyncProvider.ts
@@ -1,5 +1,5 @@
 import { clipboardHistoryStore } from '../../clipboard/stores/clipboardHistoryStore.svelte';
-import { stripHtml, stripRtf, type ClipboardHistoryItem } from 'asyar-sdk';
+import { stripHtml, stripRtf, type ClipboardHistoryItem } from 'asyar-sdk/contracts';
 import type { ISyncProvider, SyncProviderData, BinaryAsset, ImportPreview, ImportResult, DataSummary, ConflictStrategy } from '../types';
 
 export class ClipboardSyncProvider implements ISyncProvider {

--- a/src/services/search/commandArgumentsService.svelte.ts
+++ b/src/services/search/commandArgumentsService.svelte.ts
@@ -1,4 +1,4 @@
-import type { CommandArgument } from 'asyar-sdk';
+import type { CommandArgument } from 'asyar-sdk/contracts';
 import { logService } from '../log/logService';
 import {
   commandArgDefaultsGet,

--- a/src/services/search/commandArgumentsService.test.ts
+++ b/src/services/search/commandArgumentsService.test.ts
@@ -14,7 +14,7 @@ vi.mock('../../lib/ipc/commandArgDefaultsCommands', () => ({
 }))
 
 import { CommandArgumentsService } from './commandArgumentsService.svelte'
-import type { CommandArgument } from 'asyar-sdk'
+import type { CommandArgument } from 'asyar-sdk/contracts'
 
 function makeDeps(opts: {
   args: CommandArgument[]

--- a/src/services/search/searchOrchestrator.svelte.ts
+++ b/src/services/search/searchOrchestrator.svelte.ts
@@ -6,7 +6,7 @@ import { searchService } from './SearchService';
 import { contextModeService } from '../context/contextModeService.svelte';
 import { logService } from '../log/logService';
 import type { SearchResult } from './interfaces/SearchResult';
-import type { ExtensionResult } from 'asyar-sdk';
+import type { ExtensionResult } from 'asyar-sdk/contracts';
 import { getCachedTopItems, setCachedTopItems, invalidateTopItemsCache } from './topItemsCache';
 import * as commands from '../../lib/ipc/commands';
 import { envService } from '../envService';

--- a/src/services/selection/selectionService.ts
+++ b/src/services/selection/selectionService.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { ISelectionService, SelectionError, SelectionErrorCode } from 'asyar-sdk';
+import type { ISelectionService, SelectionError, SelectionErrorCode } from 'asyar-sdk/contracts';
 import { logService } from '../log/logService';
 
 export class SelectionService implements ISelectionService {

--- a/src/services/timers/timerService.ts
+++ b/src/services/timers/timerService.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { ScheduleTimerOptions, TimerDescriptor } from 'asyar-sdk';
+import type { ScheduleTimerOptions, TimerDescriptor } from 'asyar-sdk/contracts';
 import { logService } from '../log/logService';
 
 /**

--- a/src/types/ExtendedManifest.ts
+++ b/src/types/ExtendedManifest.ts
@@ -1,4 +1,4 @@
-import type { ExtensionManifest } from 'asyar-sdk';
+import type { ExtensionManifest } from 'asyar-sdk/contracts';
 
 /**
  * Extended manifest type that includes fields not yet in the SDK's

--- a/src/types/ExtensionRecord.ts
+++ b/src/types/ExtensionRecord.ts
@@ -1,4 +1,4 @@
-import type { ExtensionManifest } from 'asyar-sdk';
+import type { ExtensionManifest } from 'asyar-sdk/contracts';
 import type { CompatibilityStatus } from './CompatibilityStatus';
 
 export interface ExtensionRecord {


### PR DESCRIPTION
Phase 4 of the Tier 2 worker/view split lands the SDK's three-subpath
shape. The default `asyar-sdk` export is gone; this change moves every
launcher import site onto the neutral `asyar-sdk/contracts` entry
(launcher-safe, no role assertion, no DOM requirement).