### PR TITLE
feat: add launcher-brokered extension state store + view→worker RPC

### DIFF
--- a/src-tauri/src/commands/extension_state.rs
+++ b/src-tauri/src/commands/extension_state.rs
@@ -1,0 +1,430 @@
+//! Tauri command surface for the launcher-brokered state store + RPC primitive.
+//!
+//! Wire namespace: `state:*`. Five state commands and three RPC commands.
+//! All are thin wrappers around [`crate::extensions::extension_state`] and
+//! [`crate::extensions::extension_runtime`]; the inner functions take
+//! injectable seams so tests can drive them without a live `AppHandle`.
+//!
+//! ## extensionId scoping
+//!
+//! Every command receives `extensionId` as a named parameter from the
+//! frontend `ExtensionIpcRouter`, which auto-injects it from the calling
+//! iframe's verified origin (the `INJECTS_EXTENSION_ID` set adds `state`
+//! alongside `storage`/`cache`/`preferences`/etc.). Extensions never claim
+//! their own id — same pattern as today's `storage:*`. No `PERMISSION_MAP`
+//! entries are added; per-extension scoping is enforced by injection, not
+//! by manifest permissions, mirroring `storage:*`'s rationale.
+
+use crate::error::AppError;
+use crate::extensions::extension_runtime::{
+    ExtensionRuntimeManager, MessageKind, PendingMessage, TriggerSource,
+    types::ContextRole,
+};
+use crate::extensions::extension_state::{
+    ExtensionStateService, RpcReplyPayload, SubscriptionId,
+};
+use serde_json::Value;
+use std::sync::Arc;
+use std::time::Instant;
+use tauri::State;
+
+// ── Pure inner functions (testable without AppHandle) ────────────────────
+
+pub(crate) fn state_get_inner(
+    svc: &ExtensionStateService,
+    extension_id: &str,
+    key: &str,
+) -> Result<Option<Value>, AppError> {
+    svc.get(extension_id, key)
+}
+
+pub(crate) fn state_set_inner(
+    svc: &ExtensionStateService,
+    extension_id: &str,
+    key: &str,
+    value: Value,
+    now_ms: u64,
+) -> Result<(), AppError> {
+    svc.set(extension_id, key, value, now_ms)
+}
+
+pub(crate) fn state_subscribe_inner(
+    svc: &ExtensionStateService,
+    extension_id: String,
+    key: String,
+    role: ContextRole,
+) -> Result<SubscriptionId, AppError> {
+    Ok(svc.subscribe(extension_id, key, role))
+}
+
+pub(crate) fn state_unsubscribe_inner(
+    svc: &ExtensionStateService,
+    subscription_id: SubscriptionId,
+) -> Result<(), AppError> {
+    svc.unsubscribe(subscription_id)
+}
+
+pub(crate) fn state_clear_inner(
+    svc: &ExtensionStateService,
+    extension_id: &str,
+) -> Result<u64, AppError> {
+    svc.clear(extension_id)
+}
+
+/// View → worker: enqueue an `__rpc__` envelope into the worker mailbox so
+/// the request survives Dormant/Mounting and lands when the worker reaches
+/// Ready. `MessageKind::Action` keeps the existing wire+drain path intact;
+/// the worker-side SDK detects `__rpc__` payloads and routes to onRequest
+/// handlers instead of the user's action dispatcher.
+pub(crate) fn state_rpc_request_inner(
+    mgr: &ExtensionRuntimeManager,
+    extension_id: &str,
+    handler_id: String,
+    correlation_id: String,
+    payload: Value,
+    now: Instant,
+) -> Result<(), AppError> {
+    mgr.enqueue_worker(
+        extension_id,
+        PendingMessage {
+            kind: MessageKind::Action,
+            payload: serde_json::json!({
+                "__rpc__": "request",
+                "id": handler_id,
+                "correlationId": correlation_id,
+                "payload": payload,
+            }),
+            enqueued_at: now,
+            source: TriggerSource::Invoke,
+        },
+        now,
+    );
+    Ok(())
+}
+
+/// View → worker: ask the worker-side SDK to abort the in-flight handler
+/// matching `correlation_id`. Same envelope mechanism as request — Action
+/// kind, `__rpc__` discriminator. Worker-side SDK looks up the in-flight
+/// AbortController and fires `.abort()`; handlers that ignore the signal
+/// produce a detectable leak (their late reply is silently dropped view-side).
+pub(crate) fn state_rpc_abort_inner(
+    mgr: &ExtensionRuntimeManager,
+    extension_id: &str,
+    correlation_id: String,
+    now: Instant,
+) -> Result<(), AppError> {
+    mgr.enqueue_worker(
+        extension_id,
+        PendingMessage {
+            kind: MessageKind::Action,
+            payload: serde_json::json!({
+                "__rpc__": "abort",
+                "correlationId": correlation_id,
+            }),
+            enqueued_at: now,
+            source: TriggerSource::Invoke,
+        },
+        now,
+    );
+    Ok(())
+}
+
+/// Worker → view: relay the reply via the launcher emitter. The view-side
+/// push bridge picks it up off the `asyar:state-rpc-reply` Tauri event and
+/// posts it into the view iframe; the SDK matches on `correlationId`.
+pub(crate) fn state_rpc_reply_inner(
+    svc: &ExtensionStateService,
+    extension_id: String,
+    correlation_id: String,
+    result: Option<Value>,
+    error: Option<String>,
+) -> Result<(), AppError> {
+    svc.relay_rpc_reply(RpcReplyPayload {
+        extension_id,
+        correlation_id,
+        result,
+        error,
+    });
+    Ok(())
+}
+
+// ── Tauri command wrappers ───────────────────────────────────────────────
+
+#[tauri::command]
+pub fn state_get(
+    extension_id: String,
+    key: String,
+    svc: State<'_, Arc<ExtensionStateService>>,
+) -> Result<Option<Value>, AppError> {
+    state_get_inner(&svc, &extension_id, &key)
+}
+
+#[tauri::command]
+pub fn state_set(
+    extension_id: String,
+    key: String,
+    value: Value,
+    svc: State<'_, Arc<ExtensionStateService>>,
+) -> Result<(), AppError> {
+    state_set_inner(&svc, &extension_id, &key, value, crate::shell::now_millis())
+}
+
+#[tauri::command]
+pub fn state_subscribe(
+    extension_id: String,
+    key: String,
+    role: ContextRole,
+    svc: State<'_, Arc<ExtensionStateService>>,
+) -> Result<SubscriptionId, AppError> {
+    state_subscribe_inner(&svc, extension_id, key, role)
+}
+
+#[tauri::command]
+pub fn state_unsubscribe(
+    subscription_id: SubscriptionId,
+    svc: State<'_, Arc<ExtensionStateService>>,
+) -> Result<(), AppError> {
+    state_unsubscribe_inner(&svc, subscription_id)
+}
+
+#[tauri::command]
+pub fn state_clear(
+    extension_id: String,
+    svc: State<'_, Arc<ExtensionStateService>>,
+) -> Result<(), AppError> {
+    state_clear_inner(&svc, &extension_id).map(|_| ())
+}
+
+#[tauri::command]
+pub fn state_rpc_request(
+    extension_id: String,
+    id: String,
+    correlation_id: String,
+    payload: Value,
+    mgr: State<'_, Arc<ExtensionRuntimeManager>>,
+) -> Result<(), AppError> {
+    state_rpc_request_inner(&mgr, &extension_id, id, correlation_id, payload, Instant::now())
+}
+
+#[tauri::command]
+pub fn state_rpc_abort(
+    extension_id: String,
+    correlation_id: String,
+    mgr: State<'_, Arc<ExtensionRuntimeManager>>,
+) -> Result<(), AppError> {
+    state_rpc_abort_inner(&mgr, &extension_id, correlation_id, Instant::now())
+}
+
+#[tauri::command]
+pub fn state_rpc_reply(
+    extension_id: String,
+    correlation_id: String,
+    result: Option<Value>,
+    error: Option<String>,
+    svc: State<'_, Arc<ExtensionStateService>>,
+) -> Result<(), AppError> {
+    state_rpc_reply_inner(&svc, extension_id, correlation_id, result, error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extensions::extension_runtime::{
+        DispatchOutcome, RuntimeConfig,
+    };
+    use crate::extensions::extension_state::RecordingStateEmitter;
+    use crate::storage::extension_state as store;
+    use rusqlite::Connection;
+    use std::sync::Mutex;
+
+    fn fresh_svc_with_emitter() -> (Arc<ExtensionStateService>, Arc<RecordingStateEmitter>) {
+        let conn = Connection::open_in_memory().unwrap();
+        store::init_table(&conn).unwrap();
+        let svc = Arc::new(ExtensionStateService::new(Arc::new(Mutex::new(conn))));
+        let emitter: Arc<RecordingStateEmitter> = Arc::new(RecordingStateEmitter::default());
+        svc.set_emitter(Box::new(Arc::clone(&emitter)));
+        (svc, emitter)
+    }
+
+    // ── State commands ─────────────────────────────────────────────────────
+
+    #[test]
+    fn state_set_then_get_round_trips() {
+        let (svc, _) = fresh_svc_with_emitter();
+        state_set_inner(&svc, "ext.a", "k", serde_json::json!({ "n": 1 }), 0).unwrap();
+        let v = state_get_inner(&svc, "ext.a", "k").unwrap();
+        assert_eq!(v, Some(serde_json::json!({ "n": 1 })));
+    }
+
+    #[test]
+    fn state_subscribe_returns_unique_id_then_unsubscribe_clears_it() {
+        let (svc, emitter) = fresh_svc_with_emitter();
+        let id =
+            state_subscribe_inner(&svc, "ext.a".into(), "k".into(), ContextRole::View).unwrap();
+        state_set_inner(&svc, "ext.a", "k", serde_json::json!(1), 0).unwrap();
+        assert_eq!(emitter.changed().len(), 1);
+
+        state_unsubscribe_inner(&svc, id).unwrap();
+        state_set_inner(&svc, "ext.a", "k", serde_json::json!(2), 0).unwrap();
+        assert_eq!(
+            emitter.changed().len(),
+            1,
+            "second set must not fire after unsubscribe"
+        );
+    }
+
+    #[test]
+    fn state_clear_removes_rows_and_subscriptions() {
+        let (svc, emitter) = fresh_svc_with_emitter();
+        state_subscribe_inner(&svc, "ext.a".into(), "k".into(), ContextRole::View).unwrap();
+        state_set_inner(&svc, "ext.a", "k", serde_json::json!(1), 0).unwrap();
+        emitter.state_changed.lock().unwrap().clear();
+
+        state_clear_inner(&svc, "ext.a").unwrap();
+        assert_eq!(state_get_inner(&svc, "ext.a", "k").unwrap(), None);
+
+        state_set_inner(&svc, "ext.a", "k", serde_json::json!(2), 0).unwrap();
+        assert!(emitter.changed().is_empty(), "subscriptions dropped on clear");
+    }
+
+    // ── RPC reply routing ──────────────────────────────────────────────────
+
+    #[test]
+    fn state_rpc_reply_relays_through_emitter() {
+        let (svc, emitter) = fresh_svc_with_emitter();
+        state_rpc_reply_inner(
+            &svc,
+            "ext.a".into(),
+            "cor-1".into(),
+            Some(serde_json::json!({ "ok": true })),
+            None,
+        )
+        .unwrap();
+        let replies = emitter.replies();
+        assert_eq!(replies.len(), 1);
+        assert_eq!(replies[0].extension_id, "ext.a");
+        assert_eq!(replies[0].correlation_id, "cor-1");
+        assert_eq!(replies[0].result, Some(serde_json::json!({ "ok": true })));
+    }
+
+    #[test]
+    fn state_rpc_reply_with_unknown_correlation_id_emits_anyway_for_view_to_filter() {
+        // Rust does not track in-flight correlation ids — it is a pure
+        // relay. The view-side SDK is the source of truth for "did I ask
+        // for this?" because it has the pending-reply table. A reply with
+        // a bogus correlationId reaches the view, view drops it silently.
+        let (svc, emitter) = fresh_svc_with_emitter();
+        state_rpc_reply_inner(
+            &svc,
+            "ext.a".into(),
+            "stale".into(),
+            Some(serde_json::json!(null)),
+            None,
+        )
+        .unwrap();
+        assert_eq!(emitter.replies().len(), 1, "Rust always relays; view filters");
+    }
+
+    // ── RPC request enqueuing into the worker mailbox ──────────────────────
+
+    #[test]
+    fn rpc_request_enqueues_into_worker_mailbox_with_envelope() {
+        let mgr = ExtensionRuntimeManager::new(RuntimeConfig::default());
+        let now = Instant::now();
+        state_rpc_request_inner(
+            &mgr,
+            "ext.a",
+            "start".into(),
+            "cor-1".into(),
+            serde_json::json!({ "minutes": 25 }),
+            now,
+        )
+        .unwrap();
+        // The worker context should now be Mounting with the envelope queued.
+        let worker = mgr.worker.lock().unwrap();
+        assert_eq!(worker.mailbox_len("ext.a"), 1, "envelope queued in mailbox");
+    }
+
+    #[test]
+    fn rpc_request_payload_carries_envelope_keys() {
+        // Round-trip: enqueue, drain on ready-ack, inspect drained payload.
+        let mgr = ExtensionRuntimeManager::new(RuntimeConfig::default());
+        let now = Instant::now();
+        state_rpc_request_inner(
+            &mgr,
+            "ext.a",
+            "start".into(),
+            "cor-1".into(),
+            serde_json::json!({ "x": 1 }),
+            now,
+        )
+        .unwrap();
+        // Find the Mounting token so we can ack readiness and drain.
+        let token = {
+            let worker = mgr.worker.lock().unwrap();
+            match worker.snapshot_entries().into_iter().find(|e| e.extension_id == "ext.a") {
+                Some(_) => 1u64, // first mount token starts at 1 per ContextMachine::new
+                None => panic!("expected entry"),
+            }
+        };
+        let drained = mgr.on_ready_ack("ext.a", token, ContextRole::Worker, now);
+        assert_eq!(drained.len(), 1);
+        let env = &drained[0].payload;
+        assert_eq!(env["__rpc__"], "request");
+        assert_eq!(env["id"], "start");
+        assert_eq!(env["correlationId"], "cor-1");
+        assert_eq!(env["payload"], serde_json::json!({ "x": 1 }));
+        // Source must be Invoke so the runtime treats this as background
+        // (not user-facing) for pending/degraded UX accounting.
+        assert!(matches!(drained[0].source, TriggerSource::Invoke));
+    }
+
+    #[test]
+    fn rpc_abort_enqueues_abort_envelope() {
+        let mgr = ExtensionRuntimeManager::new(RuntimeConfig::default());
+        let now = Instant::now();
+        // Seed: first a request to put the worker into Mounting.
+        state_rpc_request_inner(
+            &mgr,
+            "ext.a",
+            "start".into(),
+            "cor-1".into(),
+            serde_json::json!({}),
+            now,
+        )
+        .unwrap();
+        // Then abort.
+        state_rpc_abort_inner(&mgr, "ext.a", "cor-1".into(), now).unwrap();
+
+        let token = 1u64;
+        let drained = mgr.on_ready_ack("ext.a", token, ContextRole::Worker, now);
+        assert_eq!(drained.len(), 2);
+        let abort = drained.iter().find(|m| m.payload["__rpc__"] == "abort").unwrap();
+        assert_eq!(abort.payload["correlationId"], "cor-1");
+    }
+
+    // ── Sanity: rpc-request on unknown ext still returns NeedsMount ───────
+
+    #[test]
+    fn rpc_request_on_unknown_ext_returns_needs_mount() {
+        let mgr = ExtensionRuntimeManager::new(RuntimeConfig::default());
+        let now = Instant::now();
+        // The runtime doesn't know whether the extension is real — it just
+        // tracks state per id. The IpcRouter (frontend) already gates on
+        // registry membership before reaching this command, so a "rogue"
+        // request never gets here in production. This test pins the
+        // runtime's behaviour for a previously-unseen id.
+        state_rpc_request_inner(&mgr, "ext.unknown", "x".into(), "c".into(), serde_json::json!({}), now)
+            .unwrap();
+        let worker = mgr.worker.lock().unwrap();
+        let snap: Vec<_> = worker
+            .snapshot_entries()
+            .into_iter()
+            .filter(|e| e.extension_id == "ext.unknown")
+            .collect();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].state, "mounting");
+        // Suppress unused warning on import path.
+        let _ = DispatchOutcome::MountingWaitForReady;
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -24,6 +24,7 @@ pub mod app_events;
 pub mod application_index;
 pub mod timers;
 pub mod extension_runtime;
+pub mod extension_state;
 pub mod fs_watcher;
 
 pub use app::*;

--- a/src-tauri/src/extensions/extension_state/mod.rs
+++ b/src-tauri/src/extensions/extension_state/mod.rs
@@ -1,0 +1,558 @@
+//! Launcher-brokered durable state store + RPC primitive for Tier 2 extensions.
+//!
+//! The view context reads + subscribes; the worker context writes; both
+//! share the same `(extension_id, key) -> JSON` namespace. State survives
+//! launcher restart because the SQLite write happens in `set`. RPC calls
+//! flow view → worker via the runtime's mailbox; replies flow worker → view
+//! via a Tauri broadcast event matched by `correlationId` in the view-side
+//! SDK.
+//!
+//! Persistence lives in [`crate::storage::extension_state`]; this module
+//! owns the in-memory subscription registry and the event-emission glue.
+//! Subscription filtering and fan-out are Rust-side per the rust-first
+//! skill — the SDK proxy receives only events it asked for.
+
+use crate::error::AppError;
+use crate::extensions::extension_runtime::types::ContextRole;
+use crate::storage::extension_state as store;
+use rusqlite::Connection;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+pub type SubscriptionId = u64;
+
+/// One row in the in-memory subscription registry. The launcher fans out
+/// `state:changed` to the matching `(extension_id, key, role)` subscribers
+/// only — never globally — so the SDK proxy on the receiving side does not
+/// have to filter.
+#[derive(Debug, Clone)]
+pub struct Subscription {
+    pub extension_id: String,
+    pub key: String,
+    pub role: ContextRole,
+}
+
+/// Wire shape for the `state:changed` push delivered to one iframe.
+/// Includes `role` so the frontend push bridge can target the correct iframe
+/// (`iframe[data-extension-id="..."][data-role="worker|view"]`).
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct StateChangedPayload {
+    pub extension_id: String,
+    pub key: String,
+    pub value: Value,
+    pub role: ContextRole,
+}
+
+/// Wire shape for the worker → view RPC reply broadcast. The view-side
+/// SDK matches on `correlation_id`; replies for unknown correlation ids are
+/// dropped silently.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcReplyPayload {
+    pub extension_id: String,
+    pub correlation_id: String,
+    /// Present on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    /// Present on failure (handler threw or returned a rejected promise).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Pluggable emission seam. Production wires this to a Tauri `AppHandle`
+/// via [`TauriStateEmitter`]; tests substitute [`RecordingStateEmitter`] to
+/// assert exactly what would have been broadcast.
+pub trait StateEventEmitter: Send + Sync {
+    fn emit_state_changed(&self, payload: &StateChangedPayload);
+    fn emit_rpc_reply(&self, payload: &RpcReplyPayload);
+}
+
+pub struct ExtensionStateService {
+    data_store: Arc<Mutex<Connection>>,
+    subscriptions: Mutex<HashMap<SubscriptionId, Subscription>>,
+    next_id: AtomicU64,
+    emitter: Mutex<Option<Box<dyn StateEventEmitter>>>,
+}
+
+impl ExtensionStateService {
+    pub fn new(data_store: Arc<Mutex<Connection>>) -> Self {
+        Self {
+            data_store,
+            subscriptions: Mutex::new(HashMap::new()),
+            next_id: AtomicU64::new(1),
+            emitter: Mutex::new(None),
+        }
+    }
+
+    /// Install the broadcast emitter. Production wiring happens in
+    /// `setup_app` once the `AppHandle` is available; tests can replace it
+    /// in-line.
+    pub fn set_emitter(&self, emitter: Box<dyn StateEventEmitter>) {
+        *self.emitter.lock().expect("state emitter mutex poisoned") = Some(emitter);
+    }
+
+    pub fn get(&self, extension_id: &str, key: &str) -> Result<Option<Value>, AppError> {
+        let conn = self.data_store.lock().map_err(|_| AppError::Lock)?;
+        store::get(&conn, extension_id, key)
+    }
+
+    /// Persist `(extension_id, key) = value` and broadcast `state:changed`
+    /// to every distinct role that has at least one subscription on the
+    /// pair. The dedup keeps push traffic minimal: a single `set` that
+    /// matches ten worker-side subscribers fires one event, and the SDK
+    /// proxy demultiplexes to each registered handler in-process.
+    pub fn set(
+        &self,
+        extension_id: &str,
+        key: &str,
+        value: Value,
+        now_ms: u64,
+    ) -> Result<(), AppError> {
+        {
+            let conn = self.data_store.lock().map_err(|_| AppError::Lock)?;
+            store::set(&conn, extension_id, key, &value, now_ms)?;
+        }
+
+        let target_roles: Vec<ContextRole> = {
+            let subs = self.subscriptions.lock().expect("subscriptions mutex poisoned");
+            let mut roles: HashSet<ContextRole> = HashSet::new();
+            for s in subs.values() {
+                if s.extension_id == extension_id && s.key == key {
+                    roles.insert(s.role);
+                }
+            }
+            roles.into_iter().collect()
+        };
+
+        if target_roles.is_empty() {
+            return Ok(());
+        }
+
+        let emitter_guard = self.emitter.lock().expect("state emitter mutex poisoned");
+        if let Some(emitter) = emitter_guard.as_ref() {
+            for role in target_roles {
+                emitter.emit_state_changed(&StateChangedPayload {
+                    extension_id: extension_id.to_string(),
+                    key: key.to_string(),
+                    value: value.clone(),
+                    role,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn subscribe(
+        &self,
+        extension_id: String,
+        key: String,
+        role: ContextRole,
+    ) -> SubscriptionId {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let mut subs = self.subscriptions.lock().expect("subscriptions mutex poisoned");
+        subs.insert(
+            id,
+            Subscription {
+                extension_id,
+                key,
+                role,
+            },
+        );
+        id
+    }
+
+    pub fn unsubscribe(&self, id: SubscriptionId) -> Result<(), AppError> {
+        let mut subs = self.subscriptions.lock().expect("subscriptions mutex poisoned");
+        subs.remove(&id);
+        // Returning Ok even if the id was unknown matches the SDK contract:
+        // unsubscribe is idempotent so view-side `pagehide` cleanup never
+        // surfaces "no such subscription" errors when a subscription was
+        // already torn down by the launcher (e.g. during uninstall).
+        Ok(())
+    }
+
+    /// Delete every persisted row for `extension_id` and drop every active
+    /// subscription owned by that extension. Called by `lifecycle::uninstall`
+    /// after the runtime's `notify_extension_removed` synchronously tears
+    /// down both context machines (see Phase 5 §4d).
+    pub fn clear(&self, extension_id: &str) -> Result<u64, AppError> {
+        let row_count = {
+            let conn = self.data_store.lock().map_err(|_| AppError::Lock)?;
+            store::clear(&conn, extension_id)?
+        };
+        let mut subs = self.subscriptions.lock().expect("subscriptions mutex poisoned");
+        subs.retain(|_, s| s.extension_id != extension_id);
+        Ok(row_count)
+    }
+
+    /// Relay a worker → view RPC reply. The Tauri command handler delegates
+    /// here so tests can assert routing without a live `AppHandle`.
+    pub fn relay_rpc_reply(&self, payload: RpcReplyPayload) {
+        let emitter_guard = self.emitter.lock().expect("state emitter mutex poisoned");
+        if let Some(emitter) = emitter_guard.as_ref() {
+            emitter.emit_rpc_reply(&payload);
+        }
+    }
+
+    #[cfg(test)]
+    fn subscription_count(&self) -> usize {
+        self.subscriptions.lock().unwrap().len()
+    }
+}
+
+/// Tauri-backed emitter. One instance per service registration.
+pub struct TauriStateEmitter {
+    pub app: tauri::AppHandle,
+}
+
+impl StateEventEmitter for TauriStateEmitter {
+    fn emit_state_changed(&self, payload: &StateChangedPayload) {
+        use tauri::Emitter;
+        if let Err(e) = self.app.emit("asyar:state-changed", payload) {
+            log::warn!("[extension_state] emit state-changed failed: {e}");
+        }
+    }
+
+    fn emit_rpc_reply(&self, payload: &RpcReplyPayload) {
+        use tauri::Emitter;
+        if let Err(e) = self.app.emit("asyar:state-rpc-reply", payload) {
+            log::warn!("[extension_state] emit rpc-reply failed: {e}");
+        }
+    }
+}
+
+/// Test double — captures emissions in order so tests can assert exactly
+/// what would have flowed onto the Tauri event channel.
+#[derive(Default)]
+pub struct RecordingStateEmitter {
+    pub state_changed: Mutex<Vec<StateChangedPayload>>,
+    pub rpc_replies: Mutex<Vec<RpcReplyPayload>>,
+}
+
+impl RecordingStateEmitter {
+    pub fn changed(&self) -> Vec<StateChangedPayload> {
+        self.state_changed.lock().unwrap().clone()
+    }
+    pub fn replies(&self) -> Vec<RpcReplyPayload> {
+        self.rpc_replies.lock().unwrap().clone()
+    }
+}
+
+impl StateEventEmitter for RecordingStateEmitter {
+    fn emit_state_changed(&self, payload: &StateChangedPayload) {
+        self.state_changed.lock().unwrap().push(payload.clone());
+    }
+    fn emit_rpc_reply(&self, payload: &RpcReplyPayload) {
+        self.rpc_replies.lock().unwrap().push(payload.clone());
+    }
+}
+
+impl<T: StateEventEmitter + ?Sized> StateEventEmitter for Arc<T> {
+    fn emit_state_changed(&self, payload: &StateChangedPayload) {
+        (**self).emit_state_changed(payload);
+    }
+    fn emit_rpc_reply(&self, payload: &RpcReplyPayload) {
+        (**self).emit_rpc_reply(payload);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::extension_state as store;
+    use rusqlite::Connection;
+
+    fn fresh_conn() -> Arc<Mutex<Connection>> {
+        let conn = Connection::open_in_memory().unwrap();
+        store::init_table(&conn).unwrap();
+        Arc::new(Mutex::new(conn))
+    }
+
+    fn svc_with_emitter() -> (ExtensionStateService, Arc<RecordingStateEmitter>) {
+        let svc = ExtensionStateService::new(fresh_conn());
+        let emitter: Arc<RecordingStateEmitter> = Arc::new(RecordingStateEmitter::default());
+        svc.set_emitter(Box::new(Arc::clone(&emitter)));
+        (svc, emitter)
+    }
+
+    // ── Persistence ────────────────────────────────────────────────────────
+
+    #[test]
+    fn get_returns_none_for_unseen_key() {
+        let (svc, _) = svc_with_emitter();
+        assert!(svc.get("ext.a", "missing").unwrap().is_none());
+    }
+
+    #[test]
+    fn set_then_get_round_trips() {
+        let (svc, _) = svc_with_emitter();
+        svc.set("ext.a", "k", serde_json::json!({ "x": 1 }), 0).unwrap();
+        assert_eq!(
+            svc.get("ext.a", "k").unwrap(),
+            Some(serde_json::json!({ "x": 1 }))
+        );
+    }
+
+    #[test]
+    fn set_persists_across_service_restart() {
+        // Mirrors "running the launcher twice" — the underlying SQLite
+        // connection is shared, the service instance is recreated.
+        let conn = fresh_conn();
+        let svc1 = ExtensionStateService::new(Arc::clone(&conn));
+        svc1.set("ext.a", "timer", serde_json::json!({ "running": true }), 0).unwrap();
+
+        // Drop & recreate the service against the same DB.
+        drop(svc1);
+        let svc2 = ExtensionStateService::new(Arc::clone(&conn));
+        assert_eq!(
+            svc2.get("ext.a", "timer").unwrap(),
+            Some(serde_json::json!({ "running": true })),
+            "value must survive service restart against the same DB",
+        );
+    }
+
+    #[test]
+    fn clear_deletes_all_keys_for_one_extension_only() {
+        let (svc, _) = svc_with_emitter();
+        svc.set("ext.a", "k1", serde_json::json!(1), 0).unwrap();
+        svc.set("ext.a", "k2", serde_json::json!(2), 0).unwrap();
+        svc.set("ext.b", "k1", serde_json::json!("safe"), 0).unwrap();
+
+        let removed = svc.clear("ext.a").unwrap();
+        assert_eq!(removed, 2);
+        assert!(svc.get("ext.a", "k1").unwrap().is_none());
+        assert!(svc.get("ext.a", "k2").unwrap().is_none());
+        assert_eq!(
+            svc.get("ext.b", "k1").unwrap(),
+            Some(serde_json::json!("safe"))
+        );
+    }
+
+    // ── Subscriptions & fan-out ────────────────────────────────────────────
+
+    #[test]
+    fn subscribe_returns_unique_ids() {
+        let (svc, _) = svc_with_emitter();
+        let id1 = svc.subscribe("ext.a".into(), "k".into(), ContextRole::View);
+        let id2 = svc.subscribe("ext.a".into(), "k".into(), ContextRole::View);
+        assert_ne!(id1, id2, "subscription ids must be unique even for identical (ext, key, role)");
+    }
+
+    #[test]
+    fn set_fires_state_changed_to_matching_subscriber() {
+        let (svc, emitter) = svc_with_emitter();
+        let _id = svc.subscribe("ext.a".into(), "timer".into(), ContextRole::View);
+        svc.set("ext.a", "timer", serde_json::json!({ "secs": 1 }), 0)
+            .unwrap();
+        let events = emitter.changed();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].extension_id, "ext.a");
+        assert_eq!(events[0].key, "timer");
+        assert_eq!(events[0].role, ContextRole::View);
+        assert_eq!(events[0].value, serde_json::json!({ "secs": 1 }));
+    }
+
+    #[test]
+    fn set_does_not_fire_to_subscribers_of_different_key() {
+        let (svc, emitter) = svc_with_emitter();
+        svc.subscribe("ext.a".into(), "other".into(), ContextRole::View);
+        svc.set("ext.a", "timer", serde_json::json!(1), 0).unwrap();
+        assert!(emitter.changed().is_empty(), "different key must not fire");
+    }
+
+    #[test]
+    fn set_does_not_fire_to_subscribers_of_different_extension() {
+        let (svc, emitter) = svc_with_emitter();
+        svc.subscribe("ext.b".into(), "timer".into(), ContextRole::View);
+        svc.set("ext.a", "timer", serde_json::json!(1), 0).unwrap();
+        assert!(
+            emitter.changed().is_empty(),
+            "subscriber on a different extension must not fire"
+        );
+    }
+
+    #[test]
+    fn set_emits_once_per_distinct_role_even_with_multiple_subscriptions() {
+        // Two view subscribers + one worker subscriber on the same (ext,
+        // key) → one push to view, one push to worker. The SDK proxy
+        // demultiplexes within the iframe.
+        let (svc, emitter) = svc_with_emitter();
+        svc.subscribe("ext.a".into(), "timer".into(), ContextRole::View);
+        svc.subscribe("ext.a".into(), "timer".into(), ContextRole::View);
+        svc.subscribe("ext.a".into(), "timer".into(), ContextRole::Worker);
+
+        svc.set("ext.a", "timer", serde_json::json!({ "secs": 5 }), 0)
+            .unwrap();
+        let events = emitter.changed();
+        assert_eq!(events.len(), 2, "one event per distinct role");
+
+        let roles: HashSet<ContextRole> = events.iter().map(|e| e.role).collect();
+        assert!(roles.contains(&ContextRole::View));
+        assert!(roles.contains(&ContextRole::Worker));
+    }
+
+    #[test]
+    fn set_with_no_subscribers_emits_nothing() {
+        let (svc, emitter) = svc_with_emitter();
+        svc.set("ext.a", "k", serde_json::json!(1), 0).unwrap();
+        assert!(emitter.changed().is_empty(), "no subscribers, no broadcast");
+        // But the value IS persisted.
+        assert_eq!(svc.get("ext.a", "k").unwrap(), Some(serde_json::json!(1)));
+    }
+
+    #[test]
+    fn unsubscribe_stops_future_state_changed() {
+        let (svc, emitter) = svc_with_emitter();
+        let id = svc.subscribe("ext.a".into(), "k".into(), ContextRole::View);
+        svc.set("ext.a", "k", serde_json::json!(1), 0).unwrap();
+        svc.unsubscribe(id).unwrap();
+        svc.set("ext.a", "k", serde_json::json!(2), 0).unwrap();
+
+        let events = emitter.changed();
+        assert_eq!(events.len(), 1, "second set must not fire after unsubscribe");
+        assert_eq!(events[0].value, serde_json::json!(1));
+    }
+
+    #[test]
+    fn unsubscribe_unknown_id_is_idempotent() {
+        let (svc, _) = svc_with_emitter();
+        // No subscription was ever issued — unsubscribe of a fabricated id
+        // is a noop, not an error. View-side pagehide cleanup hits this
+        // path when the launcher cleared subs first (uninstall race).
+        svc.unsubscribe(9999).unwrap();
+    }
+
+    #[test]
+    fn clear_drops_subscriptions_for_the_extension() {
+        let (svc, emitter) = svc_with_emitter();
+        svc.subscribe("ext.a".into(), "k".into(), ContextRole::View);
+        svc.subscribe("ext.b".into(), "k".into(), ContextRole::View);
+        assert_eq!(svc.subscription_count(), 2);
+
+        svc.clear("ext.a").unwrap();
+        assert_eq!(svc.subscription_count(), 1, "ext.a subscription must be dropped");
+
+        // Subsequent set on ext.a does not fire.
+        svc.set("ext.a", "k", serde_json::json!(1), 0).unwrap();
+        assert!(emitter.changed().is_empty());
+
+        // ext.b still receives.
+        svc.set("ext.b", "k", serde_json::json!(2), 0).unwrap();
+        assert_eq!(emitter.changed().len(), 1);
+    }
+
+    // ── RPC reply relay ────────────────────────────────────────────────────
+
+    #[test]
+    fn relay_rpc_reply_emits_through_emitter() {
+        let (svc, emitter) = svc_with_emitter();
+        svc.relay_rpc_reply(RpcReplyPayload {
+            extension_id: "ext.a".into(),
+            correlation_id: "abc-123".into(),
+            result: Some(serde_json::json!({ "ok": true })),
+            error: None,
+        });
+        let replies = emitter.replies();
+        assert_eq!(replies.len(), 1);
+        assert_eq!(replies[0].correlation_id, "abc-123");
+        assert_eq!(replies[0].result, Some(serde_json::json!({ "ok": true })));
+        assert!(replies[0].error.is_none());
+    }
+
+    #[test]
+    fn relay_rpc_reply_with_error_emits_error_field() {
+        let (svc, emitter) = svc_with_emitter();
+        svc.relay_rpc_reply(RpcReplyPayload {
+            extension_id: "ext.a".into(),
+            correlation_id: "abc-123".into(),
+            result: None,
+            error: Some("handler threw".into()),
+        });
+        let replies = emitter.replies();
+        assert_eq!(replies[0].error.as_deref(), Some("handler threw"));
+    }
+
+    #[test]
+    fn rpc_reply_payload_serializes_result_omits_error_when_absent() {
+        // Wire shape contract — view-side SDK matches reply on
+        // `correlationId`; presence/absence of `error` decides resolve vs
+        // reject. `serde(skip_serializing_if = "Option::is_none")` keeps
+        // the JSON shape clean.
+        let p = RpcReplyPayload {
+            extension_id: "ext.a".into(),
+            correlation_id: "c1".into(),
+            result: Some(serde_json::json!({ "v": 1 })),
+            error: None,
+        };
+        let json = serde_json::to_value(&p).unwrap();
+        assert_eq!(json["correlationId"], "c1");
+        assert_eq!(json["result"], serde_json::json!({ "v": 1 }));
+        assert!(json.get("error").is_none(), "absent error must not appear in JSON");
+    }
+
+    #[test]
+    fn state_changed_payload_serializes_role_as_camel_case() {
+        let p = StateChangedPayload {
+            extension_id: "ext.a".into(),
+            key: "k".into(),
+            value: serde_json::json!(1),
+            role: ContextRole::Worker,
+        };
+        let json = serde_json::to_value(&p).unwrap();
+        assert_eq!(json["role"], "worker");
+        assert_eq!(json["extensionId"], "ext.a");
+    }
+
+    // ── Uninstall ordering: state:clear runs after teardown ────────────────
+
+    #[test]
+    fn clear_after_runtime_teardown_drops_state_and_subs_in_one_step() {
+        // Mirrors the lifecycle::uninstall sequence: the runtime's
+        // `notify_extension_removed` runs first (synchronously tears down
+        // both context machines), then `extension_state::clear` runs. After
+        // both, no rows survive and no subscriptions remain.
+        use crate::extensions::extension_runtime::{ExtensionRuntimeManager, RuntimeConfig};
+
+        let mgr = ExtensionRuntimeManager::new(RuntimeConfig::default());
+        let (svc, emitter) = svc_with_emitter();
+
+        // Seed: extension has state and subscriptions.
+        svc.subscribe("ext.a".into(), "timer".into(), ContextRole::View);
+        svc.subscribe("ext.a".into(), "timer".into(), ContextRole::Worker);
+        svc.set("ext.a", "timer", serde_json::json!({ "secs": 7 }), 0)
+            .unwrap();
+        // Sanity: the seed `set` fanned out to both roles.
+        assert_eq!(emitter.changed().len(), 2, "seed set fans out to both roles");
+        emitter.state_changed.lock().unwrap().clear();
+
+        // Step 1 — runtime teardown of both contexts. Synchronous; no acks.
+        let (worker_had, view_had) = mgr.tear_down_both("ext.a");
+        // No state machines were seeded in this test, so `had` is false —
+        // the teardown is still a noop precondition that must not panic.
+        assert!(!worker_had && !view_had);
+
+        // Step 2 — state:clear. Drops rows AND subscriptions.
+        let removed = svc.clear("ext.a").unwrap();
+        assert_eq!(removed, 1, "one row deleted");
+        assert!(svc.get("ext.a", "timer").unwrap().is_none());
+        assert_eq!(svc.subscription_count(), 0, "subs dropped on clear");
+
+        // Step 3 — a late `set` from a "dying" worker would no-op for
+        // fan-out (no subs left) and still write the row only because the
+        // store layer doesn't gate on registry membership. The IpcRouter
+        // gates on registry membership before reaching this service, so a
+        // real late call is rejected upstream — assert the local invariant
+        // that fan-out doesn't fire after clear.
+        svc.set("ext.a", "timer", serde_json::json!({ "secs": 99 }), 0)
+            .unwrap();
+        assert!(
+            emitter.changed().is_empty(),
+            "no subscribers after clear → no fan-out"
+        );
+    }
+}

--- a/src-tauri/src/extensions/lifecycle.rs
+++ b/src-tauri/src/extensions/lifecycle.rs
@@ -315,6 +315,22 @@ pub(crate) fn uninstall(
         );
     }
 
+    // Drop launcher-brokered extension state AFTER both context machines
+    // are torn down (Phase 5 §4d). `tear_down_both` above is synchronous,
+    // so by the time we reach here no new dispatch can route to the old
+    // mailbox; a late `state:set` from a dying iframe is rejected upstream
+    // by the IpcRouter (the registry no longer knows the extension), so
+    // this clear cannot race a repopulating write.
+    if let Some(state_svc) = app_handle.try_state::<std::sync::Arc<crate::extensions::extension_state::ExtensionStateService>>() {
+        match state_svc.clear(extension_id) {
+            Ok(n) if n > 0 => {
+                info!("Cleared {n} extension_state row(s) for extension '{extension_id}'")
+            }
+            Ok(_) => {}
+            Err(e) => warn!("Failed to clear extension_state for '{extension_id}': {e}"),
+        }
+    }
+
     info!("Extension '{}' uninstalled successfully (directory + settings + registry + storage)", extension_id);
     Ok(())
 }

--- a/src-tauri/src/extensions/mod.rs
+++ b/src-tauri/src/extensions/mod.rs
@@ -7,6 +7,7 @@ pub mod installer;
 pub mod lifecycle;
 pub mod headless;
 pub mod extension_runtime;
+pub mod extension_state;
 pub mod updater;
 pub mod scheduler;
 pub mod update_scheduler;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -190,6 +190,14 @@ pub fn run() {
             commands::extension_runtime::iframe_unmount_ack,
             commands::extension_runtime::iframe_mount_timeout_reported,
             commands::extension_runtime::get_extension_runtime_snapshot,
+            commands::extension_state::state_get,
+            commands::extension_state::state_set,
+            commands::extension_state::state_subscribe,
+            commands::extension_state::state_unsubscribe,
+            commands::extension_state::state_clear,
+            commands::extension_state::state_rpc_request,
+            commands::extension_state::state_rpc_abort,
+            commands::extension_state::state_rpc_reply,
             commands::fs_watcher::fs_watch_create,
             commands::fs_watcher::fs_watch_dispose,
             search_engine::commands::index_item,
@@ -505,6 +513,32 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // `conn_arc()`. Must be built before the backlog scan and the live
     // scheduler so both can see the same rows.
     let timer_registry = timers::TimerRegistry::new(data_store.conn_arc());
+
+    // Launcher-brokered extension state store + RPC primitive (Phase 5).
+    // Shares the DataStore SQLite connection via `conn_arc()` so writes
+    // land in the same `asyar_data.db` file as every other launcher table.
+    // The Tauri-backed emitter is installed immediately so the first
+    // `state:set` of the boot can fan out cleanly. Logs the database file
+    // path so the boot log evidences the SQLite location.
+    let extension_state_service = std::sync::Arc::new(
+        crate::extensions::extension_state::ExtensionStateService::new(data_store.conn_arc()),
+    );
+    extension_state_service.set_emitter(Box::new(
+        crate::extensions::extension_state::TauriStateEmitter {
+            app: app.handle().clone(),
+        },
+    ));
+    {
+        use tauri::Manager;
+        match app.handle().path().app_data_dir() {
+            Ok(dir) => log::info!(
+                "[extension_state] using SQLite database at {}",
+                dir.join("asyar_data.db").display()
+            ),
+            Err(e) => log::warn!("[extension_state] could not resolve app_data_dir: {e}"),
+        }
+    }
+    app.manage(std::sync::Arc::clone(&extension_state_service));
 
     app.manage(data_store);
 

--- a/src-tauri/src/storage/extension_state.rs
+++ b/src-tauri/src/storage/extension_state.rs
@@ -1,0 +1,178 @@
+//! SQLite persistence primitives for the launcher-brokered extension state
+//! store. Matches the `extension_kv` table shape but stores JSON values and
+//! tracks `updated_at` for future diagnostics.
+//!
+//! This module owns only the row-level CRUD. The in-memory subscription
+//! registry, fan-out, and RPC routing live in
+//! [`crate::extensions::extension_state`] — the two are split so the
+//! persistence layer stays trivially unit-testable without spinning up any
+//! subscriber machinery.
+
+use crate::error::AppError;
+use rusqlite::{params, Connection};
+use serde_json::Value;
+
+pub fn init_table(conn: &Connection) -> Result<(), AppError> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS extension_state (
+            extension_id TEXT NOT NULL,
+            key TEXT NOT NULL,
+            value_json TEXT NOT NULL,
+            updated_at INTEGER NOT NULL,
+            PRIMARY KEY (extension_id, key)
+        );
+        CREATE INDEX IF NOT EXISTS idx_ext_state_ext_id
+            ON extension_state(extension_id);",
+    )
+    .map_err(|e| AppError::Database(format!("Failed to init extension_state table: {e}")))?;
+    Ok(())
+}
+
+/// Fetch the latest value for `(extension_id, key)`. Returns `None` when no
+/// row exists. The stored JSON is parsed on read — rows written by `set` are
+/// guaranteed to be valid JSON, so parse failure here indicates an external
+/// mutation and is surfaced as a `Database` error rather than `None`.
+pub fn get(
+    conn: &Connection,
+    extension_id: &str,
+    key: &str,
+) -> Result<Option<Value>, AppError> {
+    let row = conn.query_row(
+        "SELECT value_json FROM extension_state WHERE extension_id = ?1 AND key = ?2",
+        params![extension_id, key],
+        |row| row.get::<_, String>(0),
+    );
+    match row {
+        Ok(json) => {
+            let v: Value = serde_json::from_str(&json)
+                .map_err(|e| AppError::Database(format!("Corrupt extension_state JSON: {e}")))?;
+            Ok(Some(v))
+        }
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(AppError::Database(format!("Failed to get extension_state: {e}"))),
+    }
+}
+
+/// Upsert the row for `(extension_id, key)`. `now_ms` is the caller-supplied
+/// wall clock so tests can pin time and production code can use
+/// `shell::now_millis()` for consistency with timers / cache.
+pub fn set(
+    conn: &Connection,
+    extension_id: &str,
+    key: &str,
+    value: &Value,
+    now_ms: u64,
+) -> Result<(), AppError> {
+    let json = serde_json::to_string(value)
+        .map_err(|e| AppError::Database(format!("Failed to serialise extension_state: {e}")))?;
+    conn.execute(
+        "INSERT OR REPLACE INTO extension_state (extension_id, key, value_json, updated_at)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![extension_id, key, json, now_ms],
+    )
+    .map_err(|e| AppError::Database(format!("Failed to set extension_state: {e}")))?;
+    Ok(())
+}
+
+/// Delete all rows for `extension_id`. Returns the number of rows deleted so
+/// uninstall / disable can log a one-line summary.
+pub fn clear(conn: &Connection, extension_id: &str) -> Result<u64, AppError> {
+    let count = conn
+        .execute(
+            "DELETE FROM extension_state WHERE extension_id = ?1",
+            params![extension_id],
+        )
+        .map_err(|e| AppError::Database(format!("Failed to clear extension_state: {e}")))?;
+    Ok(count as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        init_table(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn get_returns_none_for_unseen_key() {
+        let conn = setup();
+        assert!(get(&conn, "ext.a", "missing").unwrap().is_none());
+    }
+
+    #[test]
+    fn set_then_get_round_trips_the_value() {
+        let conn = setup();
+        let v = serde_json::json!({ "seconds": 42, "running": true });
+        set(&conn, "ext.a", "timer", &v, 10).unwrap();
+        assert_eq!(get(&conn, "ext.a", "timer").unwrap(), Some(v));
+    }
+
+    #[test]
+    fn set_upserts_and_keeps_the_latest_value() {
+        let conn = setup();
+        set(&conn, "ext.a", "k", &serde_json::json!(1), 10).unwrap();
+        set(&conn, "ext.a", "k", &serde_json::json!(2), 20).unwrap();
+        assert_eq!(get(&conn, "ext.a", "k").unwrap(), Some(serde_json::json!(2)));
+    }
+
+    #[test]
+    fn clear_deletes_all_keys_for_the_extension_only() {
+        let conn = setup();
+        set(&conn, "ext.a", "k1", &serde_json::json!("v1"), 10).unwrap();
+        set(&conn, "ext.a", "k2", &serde_json::json!("v2"), 10).unwrap();
+        set(&conn, "ext.b", "k1", &serde_json::json!("other"), 10).unwrap();
+
+        assert_eq!(clear(&conn, "ext.a").unwrap(), 2);
+        assert!(get(&conn, "ext.a", "k1").unwrap().is_none());
+        assert!(get(&conn, "ext.a", "k2").unwrap().is_none());
+        // ext.b survives
+        assert_eq!(
+            get(&conn, "ext.b", "k1").unwrap(),
+            Some(serde_json::json!("other"))
+        );
+    }
+
+    #[test]
+    fn init_table_is_idempotent() {
+        // Guards "running the launcher twice does not error" — mirrors the
+        // DataStore::initialize path which calls each module's init_table on
+        // every boot. A reachable `CREATE TABLE IF NOT EXISTS` should no-op
+        // the second time; any row written in between must still be there.
+        let conn = Connection::open_in_memory().unwrap();
+        init_table(&conn).unwrap();
+        set(&conn, "ext.a", "k", &serde_json::json!("v"), 10).unwrap();
+        init_table(&conn).unwrap();
+        assert_eq!(
+            get(&conn, "ext.a", "k").unwrap(),
+            Some(serde_json::json!("v"))
+        );
+    }
+
+    #[test]
+    fn set_persists_null_and_scalar_values() {
+        let conn = setup();
+        set(&conn, "ext.a", "null", &serde_json::Value::Null, 0).unwrap();
+        assert_eq!(get(&conn, "ext.a", "null").unwrap(), Some(serde_json::Value::Null));
+
+        set(&conn, "ext.a", "num", &serde_json::json!(2.5), 0).unwrap();
+        assert_eq!(get(&conn, "ext.a", "num").unwrap(), Some(serde_json::json!(2.5)));
+    }
+
+    #[test]
+    fn isolation_between_extensions_same_key() {
+        let conn = setup();
+        set(&conn, "ext.a", "shared", &serde_json::json!("a"), 0).unwrap();
+        set(&conn, "ext.b", "shared", &serde_json::json!("b"), 0).unwrap();
+        assert_eq!(
+            get(&conn, "ext.a", "shared").unwrap(),
+            Some(serde_json::json!("a"))
+        );
+        assert_eq!(
+            get(&conn, "ext.b", "shared").unwrap(),
+            Some(serde_json::json!("b"))
+        );
+    }
+}

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -4,6 +4,7 @@ pub mod commands;
 pub mod extension_cache;
 pub mod extension_kv;
 pub mod extension_preferences;
+pub mod extension_state;
 pub mod shell;
 pub mod shortcuts;
 pub mod snippets;
@@ -48,6 +49,7 @@ impl DataStore {
         extension_kv::init_table(&conn)?;
         extension_preferences::init_table(&conn)?;
         extension_cache::init_table(&conn)?;
+        extension_state::init_table(&conn)?;
         shell::init_table(&conn)?;
         timers::init_table(&conn)?;
         command_arg_defaults::init_table(&conn)?;
@@ -80,6 +82,7 @@ pub fn create_test_store() -> DataStore {
     shortcuts::init_table(&conn).unwrap();
     extension_kv::init_table(&conn).unwrap();
     extension_preferences::init_table(&conn).unwrap();
+    extension_state::init_table(&conn).unwrap();
     shell::init_table(&conn).unwrap();
     timers::init_table(&conn).unwrap();
     command_arg_defaults::init_table(&conn).unwrap();

--- a/src/services/appInitializer.ts
+++ b/src/services/appInitializer.ts
@@ -34,6 +34,8 @@ import { systemEventsBridge } from './systemEvents/systemEventsBridge.svelte';
 import { appEventsBridge } from './appEvents/appEventsBridge.svelte';
 import { indexEventsBridge } from './applicationIndex/indexEventsBridge.svelte';
 import { fsWatcherBridge } from './fsWatcher/fsWatcherBridge.svelte';
+import { stateChangedBridge } from './extensionState/stateChangedBridge.svelte';
+import { rpcReplyBridge } from './extensionState/rpcReplyBridge.svelte';
 import { initScanPathsSync } from './application/scanPathsSync.svelte';
 import { trayClickBridge } from './statusBar/trayClickBridge.svelte';
 import { viewRegistry } from './extension/viewRegistry.svelte';
@@ -155,6 +157,14 @@ export const appInitializer = {
         });
         trayClickBridge.init().catch((err: any) => {
           logService.warn(`trayClickBridge init failed: ${err}`);
+        });
+        // Phase 5: extension state push + RPC reply. Must be ready before
+        // any `dispatch()` can race the first `state:set` or `request()`.
+        stateChangedBridge.init().catch((err: any) => {
+          logService.warn(`stateChangedBridge init failed: ${err}`);
+        });
+        rpcReplyBridge.init().catch((err: any) => {
+          logService.warn(`rpcReplyBridge init failed: ${err}`);
         });
       }
 

--- a/src/services/extension/ExtensionIpcRouter.ts
+++ b/src/services/extension/ExtensionIpcRouter.ts
@@ -34,7 +34,7 @@ export const ALLOWED_EXTENSION_INVOKE_COMMANDS = new Set(Object.keys(EXTENSION_I
  * its first argument instead of the extension ID — a silent, hard-to-debug bug.
  */
 export const INJECTS_EXTENSION_ID = new Set<Namespace>([
-  'storage', 'ai', 'oauth', 'shell', 'interop', 'cache', 'preferences', 'notifications', 'power', 'systemEvents', 'appEvents', 'timers',
+  'storage', 'ai', 'oauth', 'shell', 'interop', 'cache', 'preferences', 'notifications', 'power', 'systemEvents', 'appEvents', 'timers', 'state',
 ] as const satisfies readonly Namespace[]);
 
 /**

--- a/src/services/extension/buildServiceRegistry.ts
+++ b/src/services/extension/buildServiceRegistry.ts
@@ -29,6 +29,7 @@ import { appEventsService } from '../appEvents/appEventsService';
 import { applicationIndexService } from '../applicationIndex/applicationIndexService';
 import { timerService } from '../timers/timerService';
 import { fsWatcherService } from '../fsWatcher/fsWatcherService';
+import { extensionStateService } from '../extensionState/extensionStateService';
 
 export function buildServiceRegistry(deps: {
   extensionManager: IExtensionManager;
@@ -93,5 +94,6 @@ export function buildServiceRegistry(deps: {
     applicationIndex: applicationIndexService,
     timers: timerService,
     fsWatcher: fsWatcherService,
+    state: extensionStateService,
   });
 }

--- a/src/services/extensionState/extensionStateService.ts
+++ b/src/services/extensionState/extensionStateService.ts
@@ -1,0 +1,66 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * Host-side thin wrapper over the Rust `state_*` Tauri commands.
+ *
+ * The `ExtensionIpcRouter` auto-injects the caller's `extensionId` as the
+ * first arg (see `INJECTS_EXTENSION_ID` — `'state'` is added alongside
+ * `'storage'`/`'cache'`/etc.), so extensions never claim their own id. The
+ * router also flattens the SDK proxy's payload object into positional args,
+ * so the proxy sending `{ key }` lands here as `key: string`.
+ */
+export const extensionStateService = {
+  async get(extensionId: string, key: string): Promise<unknown> {
+    return invoke<unknown>('state_get', { extensionId, key });
+  },
+
+  async set(extensionId: string, key: string, value: unknown): Promise<void> {
+    return invoke<void>('state_set', { extensionId, key, value });
+  },
+
+  async subscribe(extensionId: string, key: string, role: 'worker' | 'view'): Promise<number> {
+    return invoke<number>('state_subscribe', { extensionId, key, role });
+  },
+
+  async unsubscribe(extensionId: string, subscriptionId: number): Promise<void> {
+    // `subscriptionId` is the only arg Rust needs; extensionId is injected
+    // by the router but Rust doesn't require it — pass it anyway so the
+    // router's extensionId-first injection stays uniform with the other
+    // state methods (matches the `storage`/`cache` convention even where
+    // Rust would be fine with less).
+    void extensionId;
+    return invoke<void>('state_unsubscribe', { subscriptionId });
+  },
+
+  async rpcRequest(
+    extensionId: string,
+    id: string,
+    correlationId: string,
+    payload: unknown,
+  ): Promise<void> {
+    return invoke<void>('state_rpc_request', {
+      extensionId,
+      id,
+      correlationId,
+      payload,
+    });
+  },
+
+  async rpcAbort(extensionId: string, correlationId: string): Promise<void> {
+    return invoke<void>('state_rpc_abort', { extensionId, correlationId });
+  },
+
+  async rpcReply(
+    extensionId: string,
+    correlationId: string,
+    result?: unknown,
+    error?: string,
+  ): Promise<void> {
+    return invoke<void>('state_rpc_reply', {
+      extensionId,
+      correlationId,
+      result: result ?? null,
+      error: error ?? null,
+    });
+  },
+};

--- a/src/services/extensionState/rpcReplyBridge.svelte.ts
+++ b/src/services/extensionState/rpcReplyBridge.svelte.ts
@@ -1,0 +1,61 @@
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { logService } from '../log/logService';
+import { getExtensionFrameOrigin } from '../../lib/ipc/extensionOrigin';
+
+/**
+ * Bridges Rust-relayed worker → view RPC replies to the calling view
+ * iframe. The Rust `state_rpc_reply` command emits `asyar:state-rpc-reply`
+ * with `{extensionId, correlationId, result, error}`; the view-side SDK
+ * matches the correlationId against its pending-reply table and
+ * resolves/rejects accordingly.
+ *
+ * Only the view iframe receives replies — RPC direction is view→worker→view,
+ * never worker→worker. Stale replies (view moved on / pagehide fired)
+ * arrive to a view that no longer has the correlationId pending; the SDK
+ * drops them silently.
+ */
+interface RpcReplyEnvelope {
+  extensionId: string;
+  correlationId: string;
+  result?: unknown;
+  error?: string;
+}
+
+export interface PushBridge {
+  init(): Promise<void>;
+  dispose(): void;
+}
+
+class RpcReplyBridge implements PushBridge {
+  private unlisten: UnlistenFn | null = null;
+
+  async init(): Promise<void> {
+    if (this.unlisten) return;
+    this.unlisten = await listen<RpcReplyEnvelope>('asyar:state-rpc-reply', (msg) => {
+      const { extensionId, correlationId, result, error } = msg.payload;
+      const iframe = document.querySelector(
+        `iframe[data-extension-id="${extensionId}"][data-role="view"]`,
+      ) as HTMLIFrameElement | null;
+      if (!iframe?.contentWindow) {
+        logService.debug(
+          `[rpcReplyBridge] no view iframe for ${extensionId}; reply ${correlationId} dropped`,
+        );
+        return;
+      }
+      iframe.contentWindow.postMessage(
+        {
+          type: 'asyar:event:state:rpc-reply:push',
+          payload: { correlationId, result, error },
+        },
+        getExtensionFrameOrigin(extensionId),
+      );
+    });
+  }
+
+  dispose(): void {
+    this.unlisten?.();
+    this.unlisten = null;
+  }
+}
+
+export const rpcReplyBridge = new RpcReplyBridge();

--- a/src/services/extensionState/stateChangedBridge.svelte.ts
+++ b/src/services/extensionState/stateChangedBridge.svelte.ts
@@ -1,0 +1,62 @@
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { logService } from '../log/logService';
+import { getExtensionFrameOrigin } from '../../lib/ipc/extensionOrigin';
+
+/**
+ * Bridges Rust-emitted `asyar:state-changed` Tauri events to the matching
+ * role-specific iframe for each subscribing extension. Unlike the other
+ * push bridges (system-event / app-event / index-event), state:changed
+ * events are **role-scoped** — Rust dedupes by `(extensionId, key, role)`
+ * and emits at most one event per role per set, so each event payload
+ * carries a `role` field and this bridge targets
+ * `iframe[data-extension-id="..."][data-role="worker|view"]`.
+ *
+ * Drops silently if the target iframe is absent (worker might be in the
+ * middle of remount; a subsequent set will re-fire once both sides are
+ * ready again).
+ */
+interface StateChangedEnvelope {
+  extensionId: string;
+  key: string;
+  value: unknown;
+  role: 'worker' | 'view';
+}
+
+export interface PushBridge {
+  init(): Promise<void>;
+  dispose(): void;
+}
+
+class StateChangedBridge implements PushBridge {
+  private unlisten: UnlistenFn | null = null;
+
+  async init(): Promise<void> {
+    if (this.unlisten) return;
+    this.unlisten = await listen<StateChangedEnvelope>('asyar:state-changed', (msg) => {
+      const { extensionId, key, value, role } = msg.payload;
+      const iframe = document.querySelector(
+        `iframe[data-extension-id="${extensionId}"][data-role="${role}"]`,
+      ) as HTMLIFrameElement | null;
+      if (!iframe?.contentWindow) {
+        logService.debug(
+          `[stateChangedBridge] no ${role} iframe for ${extensionId}; state:changed for ${key} dropped`,
+        );
+        return;
+      }
+      iframe.contentWindow.postMessage(
+        {
+          type: 'asyar:event:state:changed:push',
+          payload: { extensionId, key, value, role },
+        },
+        getExtensionFrameOrigin(extensionId),
+      );
+    });
+  }
+
+  dispose(): void {
+    this.unlisten?.();
+    this.unlisten = null;
+  }
+}
+
+export const stateChangedBridge = new StateChangedBridge();


### PR DESCRIPTION
SQLite-backed (extension_state in asyar_data.db) with role-scoped
state:changed fan-out, RPC envelope routed via worker mailbox, and
state:clear ordered after runtime teardown on uninstall.