### PR TITLE
fix(extension-runtime): auto-mount worker iframe on enable and relaunch

### DIFF
--- a/src-tauri/src/commands/extension_runtime.rs
+++ b/src-tauri/src/commands/extension_runtime.rs
@@ -177,6 +177,53 @@ pub fn get_extension_runtime_snapshot(
     get_extension_runtime_snapshot_inner(&mgr)
 }
 
+/// Phase 2.1 always-on worker auto-mount. Called by the enable path
+/// (`lifecycle::set_enabled` when `enabled=true`) and the post-discovery
+/// restoration loop so that extensions with `background.main` get their
+/// worker iframe spawned without waiting for a user dispatch.
+///
+/// Returns `true` when an `EVENT_MOUNT` was emitted. No-op when the extension
+/// has no background entrypoint, or when the worker context is already
+/// Mounting/Ready/Degraded (idempotent).
+pub(crate) fn auto_mount_worker_inner(
+    mgr: &ExtensionRuntimeManager,
+    emitter: &dyn EventEmitter,
+    has_background_main: bool,
+    extension_id: String,
+    now: Instant,
+) -> bool {
+    if !has_background_main {
+        return false;
+    }
+    match mgr.ensure_worker_mounted(&extension_id, now) {
+        Some(mount_token) => {
+            emit_typed(
+                emitter,
+                EVENT_MOUNT,
+                &serde_json::json!({
+                    "extensionId": extension_id,
+                    "mountToken": mount_token,
+                    "role": ContextRole::Worker,
+                }),
+            );
+            true
+        }
+        None => false,
+    }
+}
+
+/// Tauri wrapper for `auto_mount_worker_inner` — builds a `TauriEventEmitter`
+/// from the supplied `AppHandle`. Call from the enable / restoration paths.
+pub fn auto_mount_worker(
+    mgr: &Arc<ExtensionRuntimeManager>,
+    app: &AppHandle,
+    has_background_main: bool,
+    extension_id: String,
+) -> bool {
+    let emitter = TauriEventEmitter { app: app.clone() };
+    auto_mount_worker_inner(mgr, &emitter, has_background_main, extension_id, Instant::now())
+}
+
 pub(crate) fn notify_extension_removed_inner(
     mgr: &ExtensionRuntimeManager,
     emitter: &dyn EventEmitter,
@@ -398,5 +445,111 @@ mod tests {
         let last = events.last().unwrap();
         assert_eq!(last.0, EVENT_UNMOUNT);
         assert_eq!(last.1["reason"], "uninstall");
+    }
+
+    // ── auto_mount_worker_inner (Phase 2.1 always-on worker hotfix) ───────────
+    // Shared helper used by the enable path (lifecycle::set_enabled) and the
+    // app-startup / post-discovery restoration loop. Gates on `has_background_main`
+    // so callers can safely pass every extension in the registry.
+
+    #[test]
+    fn auto_mount_worker_inner_emits_mount_with_role_worker_when_bg_main_and_dormant() {
+        let mgr = mgr();
+        let emitter = RecordingEmitter::default();
+        let did_emit = auto_mount_worker_inner(
+            &mgr,
+            &emitter,
+            true, // has_background_main
+            "ext.a".into(),
+            Instant::now(),
+        );
+        assert!(did_emit, "dormant worker with bg.main must emit");
+        let events = emitter.events();
+        assert_eq!(events.len(), 1, "exactly one mount event");
+        assert_eq!(events[0].0, EVENT_MOUNT);
+        assert_eq!(events[0].1["extensionId"], "ext.a");
+        assert_eq!(events[0].1["role"], "worker");
+        assert!(events[0].1["mountToken"].is_number());
+    }
+
+    #[test]
+    fn auto_mount_worker_inner_emits_nothing_when_bg_main_is_false() {
+        let mgr = mgr();
+        let emitter = RecordingEmitter::default();
+        let did_emit = auto_mount_worker_inner(
+            &mgr,
+            &emitter,
+            false, // no background.main
+            "ext.a".into(),
+            Instant::now(),
+        );
+        assert!(!did_emit);
+        assert!(emitter.events().is_empty(), "no emit when extension has no background");
+        // Worker machine is unchanged (still has no state for ext.a).
+        assert!(mgr.worker.lock().unwrap().state("ext.a").is_none());
+    }
+
+    #[test]
+    fn auto_mount_worker_inner_called_per_extension_in_mixed_list_emits_once() {
+        // Simulates the post-discovery restoration loop: iterate enabled
+        // extensions, skip those without background.main. Two extensions,
+        // one with bg.main and one without — exactly one mount emit, and
+        // it carries role: worker.
+        let mgr = mgr();
+        let emitter = RecordingEmitter::default();
+        let now = Instant::now();
+
+        let enabled: Vec<(&str, bool)> = vec![
+            ("ext.bg", true),   // background worker extension
+            ("ext.view", false), // view-only extension
+        ];
+        let mut emit_count = 0;
+        for (id, has_bg) in enabled {
+            if auto_mount_worker_inner(&mgr, &emitter, has_bg, id.to_string(), now) {
+                emit_count += 1;
+            }
+        }
+        assert_eq!(emit_count, 1, "only the bg.main extension triggers an emit");
+        let events = emitter.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].1["extensionId"], "ext.bg");
+        assert_eq!(events[0].1["role"], "worker");
+    }
+
+    #[test]
+    fn auto_mount_worker_inner_then_notify_extension_removed_tears_down_worker_context() {
+        // Enable path emits a mount → frontend would spawn an iframe.
+        // Disable path then calls notify_extension_removed → worker context
+        // must be torn down so no leak, and the next enable gets a fresh token.
+        let mgr = mgr();
+        let emitter = RecordingEmitter::default();
+        let now = Instant::now();
+
+        auto_mount_worker_inner(&mgr, &emitter, true, "ext.a".into(), now);
+        assert!(matches!(
+            mgr.worker.lock().unwrap().state("ext.a"),
+            Some(LifecycleState::Mounting { .. })
+        ));
+
+        notify_extension_removed_inner(&mgr, &emitter, "ext.a".into()).unwrap();
+        assert!(
+            mgr.worker.lock().unwrap().state("ext.a").is_none(),
+            "disable must tear down worker context"
+        );
+        assert!(
+            mgr.view.lock().unwrap().state("ext.a").is_none(),
+            "disable tears down view context too (tear_down_both)"
+        );
+
+        // Re-enabling after teardown must produce a fresh token (not reuse stale one).
+        let events_before = emitter.events().len();
+        auto_mount_worker_inner(&mgr, &emitter, true, "ext.a".into(), now);
+        let events_after = emitter.events();
+        assert_eq!(
+            events_after.len(),
+            events_before + 1,
+            "re-enable must emit a new mount event"
+        );
+        assert_eq!(events_after.last().unwrap().1["role"], "worker");
     }
 }

--- a/src-tauri/src/commands/extensions.rs
+++ b/src-tauri/src/commands/extensions.rs
@@ -4,7 +4,7 @@ use crate::error::AppError;
 use crate::extensions::{self, ExtensionRegistryState, ExtensionRecord, ThemeDefinition, headless::HeadlessRegistry};
 use crate::extensions::scheduler::{self, SchedulerState, ScheduledTaskInfo};
 use std::collections::HashMap;
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 
 #[tauri::command]
 pub async fn check_path_exists(path: String) -> bool {
@@ -83,6 +83,42 @@ pub async fn discover_extensions(
     let result = extensions::lifecycle::discover_all(&app_handle, &registry)?;
     // Restart all scheduled tasks based on updated registry
     scheduler::start_all_tasks(&app_handle, &registry, &scheduler)?;
+
+    // Phase 2.1 always-on worker restoration: for every enabled extension that
+    // declares `background.main`, drive its worker context Dormant → Mounting
+    // and emit EVENT_MOUNT. This is the relaunch equivalent of set_enabled's
+    // enable-path mount — without it, workers would only materialise on the
+    // first scheduled / search-triggered dispatch.
+    //
+    // This runs inside `discover_extensions` (a frontend-invoked Tauri command)
+    // rather than `setup_app` because the registry is populated here, and by
+    // the time the frontend calls this command its Tauri event listeners are
+    // installed — no listener-readiness race.
+    if let Some(mgr) = app_handle.try_state::<std::sync::Arc<
+        crate::extensions::extension_runtime::ExtensionRuntimeManager,
+    >>()
+    {
+        for record in &result {
+            if !record.enabled {
+                continue;
+            }
+            let has_bg = record
+                .manifest
+                .background
+                .as_ref()
+                .map(|b| !b.main.trim().is_empty())
+                .unwrap_or(false);
+            if has_bg {
+                crate::commands::extension_runtime::auto_mount_worker(
+                    &mgr,
+                    &app_handle,
+                    true,
+                    record.manifest.id.clone(),
+                );
+            }
+        }
+    }
+
     Ok(result)
 }
 

--- a/src-tauri/src/extensions/extension_runtime/context.rs
+++ b/src-tauri/src/extensions/extension_runtime/context.rs
@@ -223,6 +223,33 @@ impl ContextMachine {
         out
     }
 
+    /// Drives an extension from Dormant (or absent state) into Mounting without
+    /// enqueueing a message. Returns `Some(mount_token)` when a fresh mount must
+    /// be announced to the frontend, or `None` if the machine is already
+    /// Mounting, Ready, or Degraded (no new emit needed).
+    ///
+    /// Used by the always-on worker auto-mount path so that enabling an
+    /// extension with `background.main` materialises its worker iframe before
+    /// any dispatch arrives. Subsequent dispatches still go through `enqueue`
+    /// and land in the mailbox while Mounting finishes its ready handshake.
+    pub fn transition_dormant_to_mounting(&mut self, ext: &str, now: Instant) -> Option<u64> {
+        let state = self.states.entry(ext.to_string()).or_default();
+        match state {
+            LifecycleState::Dormant => {
+                let token = self.next_mount_token;
+                self.next_mount_token += 1;
+                *state = LifecycleState::Mounting {
+                    since: now,
+                    mount_token: token,
+                };
+                Some(token)
+            }
+            LifecycleState::Mounting { .. }
+            | LifecycleState::Ready { .. }
+            | LifecycleState::Degraded { .. } => None,
+        }
+    }
+
     pub fn on_extension_removed(&mut self, ext: &str) -> bool {
         let had = self.states.remove(ext).is_some();
         self.mailboxes.remove(ext);
@@ -619,5 +646,72 @@ mod tests {
         assert_eq!(snap.len(), 1);
         assert_eq!(snap[0].role, ContextRole::Worker);
         assert_eq!(snap[0].state, "mounting");
+    }
+
+    // ── transition_dormant_to_mounting ─────────────────────────────────────────
+    // Used by the "always-on worker" auto-mount hotfix: lets callers drive a
+    // fresh Mounting transition without enqueueing a message, so the frontend
+    // gets a mount event and the worker iframe materialises before any
+    // dispatch arrives.
+
+    #[test]
+    fn transition_dormant_to_mounting_on_dormant_returns_some_and_transitions_state() {
+        let mut m = worker_machine();
+        let now = Instant::now();
+        let token = m
+            .transition_dormant_to_mounting("ext.a", now)
+            .expect("dormant (or absent) extension must transition and yield a token");
+        assert!(matches!(
+            m.state("ext.a"),
+            Some(LifecycleState::Mounting { mount_token, .. }) if *mount_token == token
+        ));
+        // Pure transition: no message enqueued.
+        assert_eq!(m.mailbox_len("ext.a"), 0);
+    }
+
+    #[test]
+    fn transition_dormant_to_mounting_on_non_dormant_states_returns_none() {
+        // Mounting: already announced, no re-emit.
+        let mut m = worker_machine();
+        let now = Instant::now();
+        let initial = m
+            .transition_dormant_to_mounting("ext.a", now)
+            .expect("initial transition from Dormant must yield a token");
+        let again = m.transition_dormant_to_mounting("ext.a", now);
+        assert!(
+            again.is_none(),
+            "second call while Mounting must be a no-op"
+        );
+        // Token didn't change, state still Mounting with the original token.
+        match m.state("ext.a") {
+            Some(LifecycleState::Mounting { mount_token, .. }) => {
+                assert_eq!(*mount_token, initial);
+            }
+            other => panic!("expected Mounting, got {other:?}"),
+        }
+
+        // Ready: worker already handshaked, no re-emit.
+        let mut m = worker_machine();
+        let now = Instant::now();
+        let token = m.transition_dormant_to_mounting("ext.a", now).unwrap();
+        m.on_ready_ack("ext.a", token, now);
+        assert!(m.transition_dormant_to_mounting("ext.a", now).is_none());
+        assert!(matches!(m.state("ext.a"), Some(LifecycleState::Ready { .. })));
+
+        // Degraded: cooldown owns retry timing; caller must not force remount.
+        let mut m = worker_machine();
+        let t0 = Instant::now();
+        for i in 0..3 {
+            let o = m.enqueue(
+                "ext.a",
+                msg(MessageKind::Command, TriggerSource::Timer),
+                t0 + Duration::from_secs(i),
+            );
+            if let DispatchOutcome::NeedsMount { mount_token } = o {
+                m.on_mount_timeout("ext.a", mount_token, t0 + Duration::from_secs(i + 1));
+            }
+        }
+        assert!(matches!(m.state("ext.a"), Some(LifecycleState::Degraded { .. })));
+        assert!(m.transition_dormant_to_mounting("ext.a", t0).is_none());
     }
 }

--- a/src-tauri/src/extensions/extension_runtime/manager.rs
+++ b/src-tauri/src/extensions/extension_runtime/manager.rs
@@ -57,6 +57,25 @@ impl ExtensionRuntimeManager {
         }
     }
 
+    /// Drives the worker context from Dormant → Mounting for `ext` if it is
+    /// currently Dormant (or has no state). Idempotent: returns `None` if the
+    /// worker is already Mounting, Ready, or Degraded (no emit needed).
+    /// Returns `Some(mount_token)` when a fresh mount must be announced to the
+    /// frontend.
+    ///
+    /// Phase 2.1 "always-on worker" hotfix: enabling an extension with
+    /// `background.main` (or restoring state on launcher start) must make the
+    /// worker iframe materialise before any command dispatch. The caller emits
+    /// `EVENT_MOUNT` with role: worker using the returned token; subsequent
+    /// dispatches still go through `enqueue_worker` and land in the mailbox
+    /// while the mount finishes its ready handshake.
+    pub fn ensure_worker_mounted(&self, ext: &str, now: Instant) -> Option<u64> {
+        self.worker
+            .lock()
+            .unwrap()
+            .transition_dormant_to_mounting(ext, now)
+    }
+
     /// Removes an extension from both machines independently.
     /// Returns `(worker_had, view_had)` — `true` if that machine had active state.
     pub fn tear_down_both(&self, ext: &str) -> (bool, bool) {
@@ -270,5 +289,42 @@ mod tests {
         let entry = snap.iter().find(|e| e.extension_id == "ext.a").unwrap();
         let json = serde_json::to_value(entry).unwrap();
         assert_eq!(json["role"], "worker");
+    }
+
+    // ── ensure_worker_mounted (always-on worker auto-mount) ────────────────────
+
+    #[test]
+    fn ensure_worker_mounted_transitions_worker_not_view_and_is_idempotent() {
+        let mgr = mgr();
+        let now = Instant::now();
+
+        // First call: worker is Dormant (no state yet) → Mounting, returns Some(token).
+        let token = mgr
+            .ensure_worker_mounted("ext.a", now)
+            .expect("dormant worker must transition and yield a token");
+
+        // Worker machine is now Mounting with that token; view machine untouched.
+        {
+            let w = mgr.worker.lock().unwrap();
+            assert!(matches!(
+                w.state("ext.a"),
+                Some(LifecycleState::Mounting { mount_token, .. }) if *mount_token == token
+            ));
+            // Pure transition: no message enqueued in the worker mailbox.
+            assert_eq!(w.mailbox_len("ext.a"), 0);
+        }
+        {
+            let v = mgr.view.lock().unwrap();
+            assert!(
+                v.state("ext.a").is_none(),
+                "view machine must not be touched by worker auto-mount"
+            );
+        }
+
+        // Second call: worker is already Mounting → None (no duplicate emit needed).
+        assert!(
+            mgr.ensure_worker_mounted("ext.a", now).is_none(),
+            "idempotent: second call while Mounting must return None"
+        );
     }
 }

--- a/src-tauri/src/extensions/lifecycle.rs
+++ b/src-tauri/src/extensions/lifecycle.rs
@@ -667,7 +667,8 @@ pub(crate) fn set_enabled(
     extension_id: &str,
     enabled: bool,
 ) -> Result<(), AppError> {
-    // Update registry
+    // Update registry and capture whether this extension declares a worker.
+    let has_background_main: bool;
     {
         let mut reg = registry.extensions.lock().map_err(|_| AppError::Lock)?;
         if let Some(record) = reg.get_mut(extension_id) {
@@ -675,6 +676,12 @@ pub(crate) fn set_enabled(
                 return Err(AppError::Validation("Cannot disable built-in extensions".into()));
             }
             record.enabled = enabled;
+            has_background_main = record
+                .manifest
+                .background
+                .as_ref()
+                .map(|b| !b.main.trim().is_empty())
+                .unwrap_or(false);
         } else {
             return Err(AppError::NotFound(format!("Extension not found: {}", extension_id)));
         }
@@ -787,6 +794,19 @@ pub(crate) fn set_enabled(
             crate::commands::extension_runtime::notify_extension_removed(
                 &mgr,
                 app_handle,
+                extension_id.to_string(),
+            );
+        }
+    } else if has_background_main {
+        // Phase 2.1 always-on worker: enabling an extension with background.main
+        // must materialise its worker iframe immediately. Drives the worker
+        // context Dormant → Mounting and emits EVENT_MOUNT with role: worker;
+        // the frontend's WorkerIframes component then spawns the iframe.
+        if let Some(mgr) = app_handle.try_state::<std::sync::Arc<crate::extensions::extension_runtime::ExtensionRuntimeManager>>() {
+            crate::commands::extension_runtime::auto_mount_worker(
+                &mgr,
+                app_handle,
+                true,
                 extension_id.to_string(),
             );
         }

--- a/src/services/appInitializer.ts
+++ b/src/services/appInitializer.ts
@@ -166,6 +166,19 @@ export const appInitializer = {
         rpcReplyBridge.init().catch((err: any) => {
           logService.warn(`rpcReplyBridge init failed: ${err}`);
         });
+
+        // Tier 2 iframe lifecycle listeners. Must be installed before
+        // extensionManager.init() below invokes `discover_extensions`,
+        // because Rust's post-discovery restoration loop emits
+        // asyar:iframe:mount for every enabled extension with
+        // background.main — events are fire-and-forget and will be lost
+        // if listeners aren't yet registered.
+        // Why await: `listen(...)` returns a Promise that resolves once
+        // Tauri has wired the IPC subscription. We need that complete
+        // before the emit fires.
+        await viewRegistry.init();
+        await workerRegistry.init();
+        extensionReadinessListener.init();
       }
 
       await extensionManager.init(); // Initialize ExtensionManager first
@@ -213,17 +226,6 @@ export const appInitializer = {
         } catch (e) {
           logService.warn(`What's New check failed: ${e}`)
         }
-      }
-
-      // Initialize Tier 2 iframe registries + SDK-ready listener.
-      // viewRegistry and workerRegistry each listen for asyar:iframe:{mount,unmount}
-      // Tauri events from Rust and track their respective context iframes.
-      // The readiness listener handles asyar:extension:loaded postMessages from
-      // SDK iframes and drains the Rust-side mailbox.
-      if (envService.isTauri) {
-        void viewRegistry.init();
-        void workerRegistry.init();
-        extensionReadinessListener.init();
       }
 
       // Initialize extension deeplink service (asyar://extensions/{extId}/{cmdId})

--- a/src/services/extension/extensionManager.svelte.ts
+++ b/src/services/extension/extensionManager.svelte.ts
@@ -374,6 +374,7 @@ export class ExtensionManager implements IExtensionManager {
     isBuiltIn: boolean;
     icon?: string;
     args: import('asyar-sdk/contracts').CommandArgument[];
+    mode?: 'view' | 'background';
   } | null {
     if (!commandObjectId.startsWith('cmd_')) return null;
     const rest = commandObjectId.slice(4);
@@ -390,6 +391,7 @@ export class ExtensionManager implements IExtensionManager {
         isBuiltIn: isBuiltInFeature(manifest.id),
         icon: (cmd as { icon?: string }).icon ?? (manifest as { icon?: string }).icon,
         args: (cmd as { arguments?: import('asyar-sdk/contracts').CommandArgument[] }).arguments ?? [],
+        mode: (cmd as { mode?: 'view' | 'background' }).mode,
       };
     }
     return null;

--- a/src/services/extension/viewRegistry.svelte.test.ts
+++ b/src/services/extension/viewRegistry.svelte.test.ts
@@ -54,9 +54,16 @@ describe('viewRegistry', () => {
 
   it('removes entry on unmount and acks with role=view', async () => {
     viewRegistry.handleMount({ extensionId: 'ext.a', mountToken: 7, role: 'view' });
-    await viewRegistry.handleUnmount({ extensionId: 'ext.a', reason: 'idle' });
+    await viewRegistry.handleUnmount({ extensionId: 'ext.a', reason: 'idle', role: 'view' });
     expect(viewRegistry.entries).toEqual([]);
     expect(iframeUnmountAck).toHaveBeenCalledWith('ext.a', 'view');
+  });
+
+  it('handleUnmount with role=worker is a no-op (does not remove or ack)', async () => {
+    viewRegistry.handleMount({ extensionId: 'ext.a', mountToken: 7, role: 'view' });
+    await viewRegistry.handleUnmount({ extensionId: 'ext.a', reason: 'idle', role: 'worker' });
+    expect(viewRegistry.entries).toEqual([{ extensionId: 'ext.a', mountToken: 7 }]);
+    expect(iframeUnmountAck).not.toHaveBeenCalled();
   });
 
   it('getEntry returns the entry for a registered extension', () => {

--- a/src/services/extension/viewRegistry.svelte.ts
+++ b/src/services/extension/viewRegistry.svelte.ts
@@ -22,7 +22,7 @@ class ViewRegistry {
       'asyar:iframe:mount',
       (e) => this.handleMount(e.payload),
     );
-    this.unlistenUnmount = await listen<{ extensionId: string; reason: string }>(
+    this.unlistenUnmount = await listen<{ extensionId: string; reason: string; role?: string }>(
       'asyar:iframe:unmount',
       (e) => this.handleUnmount(e.payload),
     );
@@ -48,7 +48,8 @@ class ViewRegistry {
     }
   }
 
-  async handleUnmount(p: { extensionId: string; reason: string }): Promise<void> {
+  async handleUnmount(p: { extensionId: string; reason: string; role?: string }): Promise<void> {
+    if (p.role !== 'view') return;
     logService.debug(`[viewRegistry] unmount ${p.extensionId} reason=${p.reason}`);
     const idx = this._entries.findIndex((e) => e.extensionId === p.extensionId);
     if (idx >= 0) this._entries.splice(idx, 1);

--- a/src/services/extension/workerRegistry.svelte.test.ts
+++ b/src/services/extension/workerRegistry.svelte.test.ts
@@ -54,9 +54,16 @@ describe('workerRegistry', () => {
 
   it('removes entry on unmount and acks with role=worker', async () => {
     workerRegistry.handleMount({ extensionId: 'ext.a', mountToken: 7, role: 'worker' });
-    await workerRegistry.handleUnmount({ extensionId: 'ext.a', reason: 'idle' });
+    await workerRegistry.handleUnmount({ extensionId: 'ext.a', reason: 'idle', role: 'worker' });
     expect(workerRegistry.entries).toEqual([]);
     expect(iframeUnmountAck).toHaveBeenCalledWith('ext.a', 'worker');
+  });
+
+  it('handleUnmount with role=view is a no-op (does not remove or ack)', async () => {
+    workerRegistry.handleMount({ extensionId: 'ext.a', mountToken: 7, role: 'worker' });
+    await workerRegistry.handleUnmount({ extensionId: 'ext.a', reason: 'idle', role: 'view' });
+    expect(workerRegistry.entries).toEqual([{ extensionId: 'ext.a', mountToken: 7 }]);
+    expect(iframeUnmountAck).not.toHaveBeenCalled();
   });
 
   it('getEntry returns the entry for a registered extension', () => {

--- a/src/services/extension/workerRegistry.svelte.ts
+++ b/src/services/extension/workerRegistry.svelte.ts
@@ -22,7 +22,7 @@ class WorkerRegistry {
       'asyar:iframe:mount',
       (e) => this.handleMount(e.payload),
     );
-    this.unlistenUnmount = await listen<{ extensionId: string; reason: string }>(
+    this.unlistenUnmount = await listen<{ extensionId: string; reason: string; role?: string }>(
       'asyar:iframe:unmount',
       (e) => this.handleUnmount(e.payload),
     );
@@ -48,7 +48,8 @@ class WorkerRegistry {
     }
   }
 
-  async handleUnmount(p: { extensionId: string; reason: string }): Promise<void> {
+  async handleUnmount(p: { extensionId: string; reason: string; role?: string }): Promise<void> {
+    if (p.role !== 'worker') return;
     logService.debug(`[workerRegistry] unmount ${p.extensionId} reason=${p.reason}`);
     const idx = this._entries.findIndex((e) => e.extensionId === p.extensionId);
     if (idx >= 0) this._entries.splice(idx, 1);

--- a/src/services/search/commandArguments.ts
+++ b/src/services/search/commandArguments.ts
@@ -12,12 +12,12 @@ import { dispatch } from '../extension/extensionDispatcher.svelte';
 export const commandArgumentsService = new CommandArgumentsService({
   getManifestByCommandObjectId: (id) => extensionManager.getCommandArgMeta(id),
   executeBuiltInCommand: (id, args) => commandService.executeCommand(id, args),
-  dispatchTier2Argument: ({ extensionId, commandId, args }) =>
+  dispatchTier2Argument: ({ extensionId, commandId, args, mode }) =>
     dispatch({
       extensionId,
       kind: 'command',
       payload: { commandId, args: { arguments: args } },
       source: 'argument',
-      commandMode: 'view',
+      commandMode: mode,
     }),
 });

--- a/src/services/search/commandArgumentsService.svelte.ts
+++ b/src/services/search/commandArgumentsService.svelte.ts
@@ -12,6 +12,11 @@ export interface CommandArgMeta {
   isBuiltIn: boolean;
   icon?: string;
   args: CommandArgument[];
+  /**
+   * Manifest-declared execution mode for this command. Drives Tier 2 routing:
+   * `"background"` → worker iframe, `"view"` (or omitted) → view iframe.
+   */
+  mode?: 'view' | 'background';
 }
 
 export interface ArgumentDispatchRequest {
@@ -19,6 +24,12 @@ export interface ArgumentDispatchRequest {
   commandId: string;
   /** Nested arguments payload already coerced to declared types. */
   args: Record<string, string | number>;
+  /**
+   * Manifest-declared execution mode. Threaded through so the dispatcher
+   * routes to worker vs. view correctly — hardcoding `'view'` here dropped
+   * background-mode commands onto the view machine and silently timed out.
+   */
+  mode: 'view' | 'background';
 }
 
 export interface CommandArgumentsServiceDeps {
@@ -47,6 +58,7 @@ export interface ActiveArgumentMode {
   args: CommandArgument[];
   values: Record<string, string>;
   currentFieldIdx: number;
+  mode?: 'view' | 'background';
 }
 
 /**
@@ -121,6 +133,7 @@ export class CommandArgumentsService {
       args: meta.args,
       values,
       currentFieldIdx: 0,
+      mode: meta.mode,
     };
     return true;
   }
@@ -219,6 +232,7 @@ export class CommandArgumentsService {
         extensionId: active.extensionId,
         commandId: active.commandId,
         args: payload,
+        mode: active.mode ?? 'view',
       });
     }
 

--- a/src/services/search/commandArgumentsService.test.ts
+++ b/src/services/search/commandArgumentsService.test.ts
@@ -23,13 +23,14 @@ function makeDeps(opts: {
   commandName?: string
   icon?: string
   isBuiltIn?: boolean
+  mode?: 'view' | 'background'
 }) {
   const extensionId = opts.extensionId ?? 'org.asyar.demo'
   const commandId = opts.commandId ?? 'do-thing'
   const commandObjectId = `cmd_${extensionId}_${commandId}`
   const executeBuiltInCommand = vi.fn<(id: string, args?: Record<string, unknown>) => Promise<unknown>>()
   const dispatchTier2Argument =
-    vi.fn<(req: { extensionId: string; commandId: string; args: Record<string, string | number> }) => Promise<void>>()
+    vi.fn<(req: { extensionId: string; commandId: string; args: Record<string, string | number>; mode: 'view' | 'background' }) => Promise<void>>()
   const getManifestByCommandObjectId = vi.fn((id: string) => {
     if (id !== commandObjectId) return null
     return {
@@ -39,6 +40,7 @@ function makeDeps(opts: {
       isBuiltIn: opts.isBuiltIn ?? false,
       icon: opts.icon,
       args: opts.args,
+      mode: opts.mode,
     }
   })
   return {
@@ -194,9 +196,30 @@ describe('CommandArgumentsService', () => {
       extensionId: d.extensionId,
       commandId: d.commandId,
       args: { q: 'hello', n: 7 },
+      mode: 'view',
     })
     expect(d.executeBuiltInCommand).not.toHaveBeenCalled()
     expect(svc.active).toBeNull()
+  })
+
+  it('submit() threads manifest mode=background through to dispatchTier2Argument (regression: caffeinate-for was dispatched as view and timed out against the view iframe)', async () => {
+    const args: CommandArgument[] = [
+      { name: 'hours', type: 'number' },
+      { name: 'minutes', type: 'number' },
+    ]
+    const d = makeDeps({ args, isBuiltIn: false, mode: 'background' })
+    const svc = new CommandArgumentsService(d)
+    await svc.enter(d.commandObjectId)
+    svc.setValue('hours', '0')
+    svc.setValue('minutes', '2')
+    await svc.submit()
+
+    expect(d.dispatchTier2Argument).toHaveBeenCalledWith({
+      extensionId: d.extensionId,
+      commandId: d.commandId,
+      args: { hours: 0, minutes: 2 },
+      mode: 'background',
+    })
   })
 
   it('submit() for a Tier 1 (built-in) command routes through executeBuiltInCommand', async () => {


### PR DESCRIPTION
Enabling an extension with background.main, or relaunching with one
already enabled, now transitions the worker context Dormant → Mounting
and emits EVENT_MOUNT with role=worker — previously the worker iframe
only materialised on the first scheduled/user dispatch, which timed out
at 3 s for extensions like Coffee. Adds ContextMachine::
transition_dormant_to_mounting (pure, no mailbox push),
ExtensionRuntimeManager::ensure_worker_mounted, and a shared
auto_mount_worker helper used by lifecycle::set_enabled and
discover_extensions. Mirrors the existing handleMount role filter in
workerRegistry/viewRegistry handleUnmount so ticker-emitted unmounts
stop cross-talking between registries.