### PR TITLE
feat: typed Diagnostic wire shape with severity classification

### DIFF
--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -1,0 +1,36 @@
+use serde::Serialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Info,
+    Success,
+    Warning,
+    Error,
+    Fatal,
+}
+
+pub trait HasSeverity {
+    fn kind(&self) -> &'static str;
+    fn severity(&self) -> Severity;
+    fn retryable(&self) -> bool;
+    fn context(&self) -> HashMap<&'static str, String>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn severity_serializes_lowercase() {
+        let json = serde_json::to_value(&Severity::Warning).unwrap();
+        assert_eq!(json, serde_json::json!("warning"));
+    }
+
+    #[test]
+    fn severity_fatal_serializes() {
+        let json = serde_json::to_value(&Severity::Fatal).unwrap();
+        assert_eq!(json, serde_json::json!("fatal"));
+    }
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -60,7 +60,71 @@ impl Serialize for AppError {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("Diagnostic", 6)?;
+        state.serialize_field("source", "rust")?;
+        state.serialize_field("kind", self.kind())?;
+        state.serialize_field("severity", &self.severity())?;
+        state.serialize_field("retryable", &self.retryable())?;
+        state.serialize_field("context", &self.context())?;
+        state.serialize_field("developerDetail", &self.to_string())?;
+        state.end()
+    }
+}
+
+use crate::diagnostics::{HasSeverity, Severity};
+use std::collections::HashMap;
+
+impl HasSeverity for AppError {
+    fn kind(&self) -> &'static str {
+        match self {
+            AppError::Io(_) => "io_failure",
+            AppError::Json(_) => "json_failure",
+            AppError::Network(_) => "network_failure",
+            AppError::Lock => "lock_poisoned",
+            AppError::NotFound(_) => "not_found",
+            AppError::Extension(_) => "extension_failure",
+            AppError::Shortcut(_) => "shortcut_failure",
+            AppError::Platform(_) => "platform_failure",
+            AppError::Validation(_) => "validation_failure",
+            AppError::Encryption(_) => "encryption_failure",
+            AppError::Permission(_) => "permission_denied",
+            AppError::Auth(_) => "auth_failure",
+            AppError::Database(_) => "database_failure",
+            AppError::OAuth(_) => "oauth_failure",
+            AppError::Power(_) => "power_failure",
+            AppError::Other(_) => "unknown",
+        }
+    }
+
+    fn severity(&self) -> Severity {
+        match self {
+            AppError::Lock | AppError::Database(_) | AppError::Encryption(_) => Severity::Fatal,
+            AppError::Permission(_) | AppError::Validation(_) | AppError::NotFound(_) => Severity::Warning,
+            _ => Severity::Error,
+        }
+    }
+
+    fn retryable(&self) -> bool {
+        matches!(
+            self,
+            AppError::Network(_) | AppError::Io(_) | AppError::Auth(_) | AppError::OAuth(_)
+        )
+    }
+
+    fn context(&self) -> HashMap<&'static str, String> {
+        let mut ctx = HashMap::new();
+        match self {
+            AppError::Permission(s) => { ctx.insert("permission", s.clone()); }
+            AppError::NotFound(s) => { ctx.insert("target", s.clone()); }
+            AppError::Extension(s) => { ctx.insert("extension", s.clone()); }
+            AppError::Shortcut(s) => { ctx.insert("shortcut", s.clone()); }
+            AppError::Platform(s) => { ctx.insert("platform", s.clone()); }
+            AppError::Validation(s) => { ctx.insert("field", s.clone()); }
+            AppError::Auth(s) | AppError::OAuth(s) => { ctx.insert("provider", s.clone()); }
+            _ => {}
+        }
+        ctx
     }
 }
 
@@ -98,38 +162,78 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_produces_json_string() {
-        let err = AppError::Extension("load failed".to_string());
-        let value = serde_json::to_value(&err).unwrap();
-        assert!(value.is_string());
-        assert!(value.as_str().unwrap().contains("load failed"));
-    }
-
-    #[test]
     fn test_encryption_display() {
         let err = AppError::Encryption("bad key".to_string());
         assert_eq!(err.to_string(), "Encryption error: bad key");
     }
 
     #[test]
-    fn test_all_string_variants_serialize() {
-        let variants: Vec<AppError> = vec![
-            AppError::Lock,
-            AppError::NotFound("x".to_string()),
-            AppError::Extension("x".to_string()),
-            AppError::Shortcut("x".to_string()),
-            AppError::Platform("x".to_string()),
-            AppError::Validation("x".to_string()),
-            AppError::Encryption("x".to_string()),
-            AppError::Permission("x".to_string()),
-            AppError::Auth("x".to_string()),
-            AppError::Database("x".to_string()),
-            AppError::Other("x".to_string()),
-        ];
-        for variant in &variants {
-            let result = serde_json::to_value(variant);
-            assert!(result.is_ok());
-            assert!(result.unwrap().is_string());
-        }
+    fn serialize_emits_diagnostic_struct_shape() {
+        let err = AppError::Permission("clipboard:read".into());
+        let v: serde_json::Value = serde_json::to_value(&err).unwrap();
+        assert!(v.is_object(), "expected object, got {v}");
+        assert_eq!(v["source"], "rust");
+        assert_eq!(v["kind"], "permission_denied");
+        assert_eq!(v["severity"], "warning");
+        assert_eq!(v["retryable"], false);
+        assert_eq!(v["context"]["permission"], "clipboard:read");
+        assert!(v["developerDetail"].as_str().unwrap().contains("clipboard:read"));
+    }
+
+    #[test]
+    fn serialize_lock_shape() {
+        let v: serde_json::Value = serde_json::to_value(&AppError::Lock).unwrap();
+        assert_eq!(v["kind"], "lock_poisoned");
+        assert_eq!(v["severity"], "fatal");
+        assert!(v["context"].as_object().unwrap().is_empty());
+    }
+}
+
+#[cfg(test)]
+mod severity_tests {
+    use super::*;
+    use crate::diagnostics::{HasSeverity, Severity};
+
+    #[test]
+    fn permission_is_warning() {
+        let err = AppError::Permission("clipboard:read".into());
+        assert_eq!(err.severity(), Severity::Warning);
+        assert_eq!(err.kind(), "permission_denied");
+        assert!(!err.retryable());
+        assert_eq!(err.context().get("permission"), Some(&"clipboard:read".to_string()));
+    }
+
+    #[test]
+    fn lock_is_fatal() {
+        assert_eq!(AppError::Lock.severity(), Severity::Fatal);
+        assert_eq!(AppError::Lock.kind(), "lock_poisoned");
+    }
+
+    #[test]
+    fn database_is_fatal() {
+        let err = AppError::Database("disk full".into());
+        assert_eq!(err.severity(), Severity::Fatal);
+        assert_eq!(err.kind(), "database_failure");
+    }
+
+    #[test]
+    fn other_is_error_default() {
+        let err = AppError::Other("x".into());
+        assert_eq!(err.severity(), Severity::Error);
+        assert!(!err.retryable());
+        assert_eq!(err.kind(), "unknown");
+    }
+
+    #[test]
+    fn not_found_kind() {
+        let err = AppError::NotFound("item".into());
+        assert_eq!(err.kind(), "not_found");
+        assert_eq!(err.context().get("target"), Some(&"item".to_string()));
+    }
+
+    #[test]
+    fn validation_is_warning() {
+        let err = AppError::Validation("bad input".into());
+        assert_eq!(err.severity(), Severity::Warning);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,6 +48,7 @@ pub mod tray;
 pub mod platform;
 pub mod error;
 pub mod uri_schemes;
+pub mod diagnostics;
 mod search_engine;
 mod snippets;
 pub mod storage;
@@ -386,6 +387,30 @@ fn parse_launch_view(settings_root: Option<&serde_json::Value>) -> &'static str 
 
 fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     tray::setup_tray(app)?;
+
+    // Install a panic hook that emits a `diagnostics:report` event before
+    // the process unwinds.  Only `app_handle` is captured (cheap clone) so
+    // the closure is `Send + 'static`.
+    {
+        let app_handle = app.handle().clone();
+        std::panic::set_hook(Box::new(move |info| {
+            let location = info
+                .location()
+                .map(|l| format!("{}:{}", l.file(), l.line()))
+                .unwrap_or_else(|| "unknown".into());
+            let detail = info.to_string();
+            let payload = serde_json::json!({
+                "source": "rust",
+                "kind": "panic",
+                "severity": "fatal",
+                "retryable": false,
+                "context": { "location": location },
+                "developerDetail": detail,
+            });
+            let _ = tauri::Emitter::emit(&app_handle, "diagnostics:report", payload);
+            log::error!("panic: {info}");
+        }));
+    }
 
     // Notification-action registry. Each `notifications:send` with actions
     // seeds `(notification_id, action_id) -> (extension_id, command_id, args)`
@@ -1045,6 +1070,26 @@ mod launch_view_tests {
             "ai": { "providers": {}, "temperature": 0.7, "maxTokens": 2048 },
         });
         assert_eq!(parse_launch_view(Some(&v)), "compact");
+    }
+}
+
+#[cfg(test)]
+mod panic_hook_tests {
+    #[test]
+    fn diagnostic_panic_payload_shape() {
+        let info_str = "panic at src/foo.rs:1:1: oh no";
+        let location = ("src/foo.rs", 1u32);
+        let payload = serde_json::json!({
+            "source": "rust",
+            "kind": "panic",
+            "severity": "fatal",
+            "retryable": false,
+            "context": { "location": format!("{}:{}", location.0, location.1) },
+            "developerDetail": info_str,
+        });
+        assert_eq!(payload["kind"], "panic");
+        assert_eq!(payload["severity"], "fatal");
+        assert_eq!(payload["context"]["location"], "src/foo.rs:1");
     }
 }
 

--- a/src-tauri/src/search_engine/mod.rs
+++ b/src-tauri/src/search_engine/mod.rs
@@ -175,13 +175,44 @@ pub enum SearchError {
     // Keep other generic errors if needed, remove Tantivy/Schema errors
 }
 
-// Implement Serialize for the error type (needed for Tauri)
+impl crate::diagnostics::HasSeverity for SearchError {
+    fn kind(&self) -> &'static str {
+        match self {
+            SearchError::LockError => "search_lock_poisoned",
+            SearchError::Json(_) => "search_json_failure",
+            SearchError::Io(_) => "search_io_failure",
+            SearchError::NotFound(_) => "search_not_found",
+            SearchError::Other(_) => "search_other",
+        }
+    }
+    fn severity(&self) -> crate::diagnostics::Severity {
+        match self {
+            SearchError::LockError => crate::diagnostics::Severity::Fatal,
+            SearchError::NotFound(_) => crate::diagnostics::Severity::Warning,
+            _ => crate::diagnostics::Severity::Error,
+        }
+    }
+    fn retryable(&self) -> bool { matches!(self, SearchError::Io(_)) }
+    fn context(&self) -> std::collections::HashMap<&'static str, String> {
+        let mut ctx = std::collections::HashMap::new();
+        if let SearchError::NotFound(s) = self { ctx.insert("target", s.clone()); }
+        if let SearchError::Other(s) = self { ctx.insert("detail", s.clone()); }
+        ctx
+    }
+}
+
 impl serde::Serialize for SearchError {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.to_string())
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        use crate::diagnostics::HasSeverity;
+        let mut state = s.serialize_struct("Diagnostic", 6)?;
+        state.serialize_field("source", "rust")?;
+        state.serialize_field("kind", self.kind())?;
+        state.serialize_field("severity", &self.severity())?;
+        state.serialize_field("retryable", &self.retryable())?;
+        state.serialize_field("context", &self.context())?;
+        state.serialize_field("developerDetail", &self.to_string())?;
+        state.end()
     }
 }
 
@@ -987,5 +1018,29 @@ mod service_tests {
         } else {
             panic!("Expected Command variant");
         }
+    }
+
+    #[test]
+    fn search_error_severities() {
+        use crate::diagnostics::{HasSeverity, Severity};
+        assert_eq!(SearchError::LockError.severity(), Severity::Fatal);
+        assert_eq!(SearchError::NotFound("x".into()).severity(), Severity::Warning);
+        assert_eq!(SearchError::Other("y".into()).severity(), Severity::Error);
+    }
+
+    #[test]
+    fn search_error_kinds() {
+        use crate::diagnostics::HasSeverity;
+        assert_eq!(SearchError::LockError.kind(), "search_lock_poisoned");
+        assert_eq!(SearchError::NotFound("x".into()).kind(), "search_not_found");
+        assert_eq!(SearchError::Other("x".into()).kind(), "search_other");
+    }
+
+    #[test]
+    fn search_error_serializes_diagnostic_shape() {
+        let v = serde_json::to_value(&SearchError::NotFound("item".into())).unwrap();
+        assert_eq!(v["kind"], "search_not_found");
+        assert_eq!(v["severity"], "warning");
+        assert_eq!(v["context"]["target"], "item");
     }
 }


### PR DESCRIPTION
Introduce HasSeverity trait + Severity enum in src-tauri/src/diagnostics.rs.
Implement HasSeverity for AppError and SearchError. Replace string-based
Serialize impls with a typed struct shape (source/kind/severity/retryable/
context/developerDetail) consumed by the upcoming launcher-frontend
diagnostics channel. Install a panic hook in setup_app that emits the
same shape as a `diagnostics:report` Tauri event.

Spec at docs/superpowers/specs/2026-04-27-unified-status-channel-design.md.