### PR TITLE
feat(onboarding): add launcher first-run flow

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main", "settings"],
+  "windows": ["main", "settings", "onboarding"],
   "permissions": [
     "autostart:allow-enable",
     "autostart:allow-disable",

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -374,6 +374,44 @@ fn parse_css_color(s: &str) -> Result<(f64, f64, f64, f64), AppError> {
     Ok((chan(parts[0])?, chan(parts[1])?, chan(parts[2])?, a))
 }
 
+/// Shows the launcher panel using the same logic as the global-hotkey handler.
+///
+/// Intended for use from non-command code (e.g., `onboarding::window`) that
+/// holds an `&AppHandle` but not a `State<'_, AppState>`. Accesses managed
+/// state via `app.state::<AppState>()`.
+pub fn show_launcher(app: &AppHandle) -> Result<(), AppError> {
+    let state = app.state::<AppState>();
+    state.asyar_visible.store(true, Ordering::Relaxed);
+    #[cfg(target_os = "macos")]
+    {
+        let panel = app
+            .get_webview_panel(SPOTLIGHT_LABEL)
+            .map_err(|_| AppError::NotFound("launcher panel".to_string()))?;
+        let window = app
+            .get_webview_window(SPOTLIGHT_LABEL)
+            .ok_or_else(|| AppError::NotFound("launcher panel window".to_string()))?;
+        crate::platform::macos::set_window_alpha(&window, 1.0);
+        crate::platform::macos::center_at_cursor_monitor(&window)
+            .map_err(|e| AppError::Platform(format!("center_at_cursor_monitor: {e}")))?;
+        panel.show();
+        crate::platform::macos::reseat_first_responder(&window);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        // Intentionally omits capture_previous_foreground: the caller is
+        // the onboarding completion flow, where the previously-focused
+        // window is Asyar's own onboarding window. Recording it would
+        // corrupt the snippet/paste target on the first launch.
+        let window = app
+            .get_webview_window(SPOTLIGHT_LABEL)
+            .ok_or_else(|| AppError::NotFound("launcher window".to_string()))?;
+        center_on_primary_monitor(&window)?;
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+    Ok(())
+}
+
 /// Cleanly exits the application.
 #[tauri::command]
 pub fn quit_app(app_handle: AppHandle) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,6 +60,7 @@ pub mod auth;
 pub mod hud_window;
 pub mod selection;
 pub mod oauth;
+pub mod onboarding;
 pub mod shell;
 pub mod application;
 pub mod window_management;
@@ -145,6 +146,9 @@ pub fn run() {
             linux_prev_window_id: Mutex::new(0),
             is_expanding: AtomicBool::new(false),
         })
+        .manage(crate::onboarding::commands::OnboardingCursor::new(
+            cfg!(target_os = "macos"),
+        ))
         .setup(setup_app)
         .invoke_handler(tauri::generate_handler![
             commands::set_focus_lock,
@@ -348,6 +352,13 @@ pub fn run() {
             aliases::commands::list_aliases,
             aliases::commands::find_alias_conflict,
             aliases::commands::get_indexed_items,
+            // Onboarding
+            crate::onboarding::commands::get_onboarding_state,
+            crate::onboarding::commands::advance_onboarding_step,
+            crate::onboarding::commands::go_back_onboarding_step,
+            crate::onboarding::commands::complete_onboarding,
+            crate::onboarding::commands::dismiss_onboarding,
+            crate::onboarding::commands::reset_onboarding,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -527,6 +538,14 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             let logical_width = size.width as f64 / scale;
             let _ = window.set_size(Size::Logical(LogicalSize { width: logical_width, height: 96.0 }));
         }
+    }
+
+    // Onboarding: open the window if the user hasn't completed it yet.
+    // This runs synchronously in setup; if the read fails we fall back to
+    // "not completed" and open the window — same fail-soft pattern as
+    // read_launch_view.
+    if let Err(e) = crate::onboarding::window::open_if_needed(handle) {
+        log::warn!("Onboarding window failed to open: {}", e);
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/onboarding/commands.rs
+++ b/src-tauri/src/onboarding/commands.rs
@@ -1,0 +1,146 @@
+//! Tauri-layer wrappers around the onboarding state machine. Pure logic
+//! lives in `state.rs` and `persistence.rs`.
+
+use crate::error::AppError;
+use crate::onboarding::state::{advance, go_back, initial, OnboardingState};
+use std::sync::Mutex;
+
+/// Cursor stored across invocations — reset to `initial(...)` whenever
+/// the onboarding window is opened (Task 6 owns that reset).
+pub struct OnboardingCursor(pub Mutex<OnboardingState>);
+
+impl OnboardingCursor {
+    pub fn new(is_macos: bool) -> Self {
+        Self(Mutex::new(initial(is_macos)))
+    }
+}
+
+pub fn get_state_inner(cursor: &OnboardingCursor) -> Result<OnboardingState, AppError> {
+    let guard = cursor.0.lock().map_err(|_| AppError::Lock)?;
+    Ok(*guard)
+}
+
+pub fn advance_inner(cursor: &OnboardingCursor) -> Result<OnboardingState, AppError> {
+    let mut guard = cursor.0.lock().map_err(|_| AppError::Lock)?;
+    *guard = advance(*guard);
+    Ok(*guard)
+}
+
+pub fn go_back_inner(cursor: &OnboardingCursor) -> Result<OnboardingState, AppError> {
+    let mut guard = cursor.0.lock().map_err(|_| AppError::Lock)?;
+    *guard = go_back(*guard);
+    Ok(*guard)
+}
+
+// ── Tauri command wrappers ─────────────────────────────────────────────────
+
+use tauri::{AppHandle, Emitter, State};
+
+/// Emit cross-window settings events so the launcher webview's listeners
+/// (in `appInitializer.ts`) apply the user's onboarding choices to the
+/// running launcher panel — geometry for `launchView`, `applyTheme` for
+/// `activeTheme`. The launcher reacts identically whether the source is
+/// the Settings window or onboarding.
+fn broadcast_onboarding_settings(app: &AppHandle) {
+    let launch_view = crate::onboarding::persistence::read_launch_view(app);
+    if let Err(e) = app.emit(
+        "asyar:launch-view-changed",
+        serde_json::json!({ "launchView": launch_view }),
+    ) {
+        log::warn!("emit asyar:launch-view-changed: {e}");
+    }
+
+    let theme_id = crate::onboarding::persistence::read_active_theme(app);
+    if let Err(e) = app.emit(
+        "asyar:theme-changed",
+        serde_json::json!({ "themeId": theme_id }),
+    ) {
+        log::warn!("emit asyar:theme-changed: {e}");
+    }
+}
+
+#[tauri::command]
+pub fn get_onboarding_state(
+    cursor: State<'_, OnboardingCursor>,
+) -> Result<OnboardingState, AppError> {
+    get_state_inner(&cursor)
+}
+
+#[tauri::command]
+pub fn advance_onboarding_step(
+    cursor: State<'_, OnboardingCursor>,
+) -> Result<OnboardingState, AppError> {
+    advance_inner(&cursor)
+}
+
+#[tauri::command]
+pub fn go_back_onboarding_step(
+    cursor: State<'_, OnboardingCursor>,
+) -> Result<OnboardingState, AppError> {
+    go_back_inner(&cursor)
+}
+
+#[tauri::command]
+pub fn complete_onboarding(app: AppHandle) -> Result<(), AppError> {
+    crate::onboarding::persistence::write_onboarding_completed(&app, true)?;
+    // Broadcast the user's choices to the launcher webview before showing
+    // it — guarantees the launcher applies the selected launch view + theme
+    // even if a JS-emit during the flow was racy.
+    broadcast_onboarding_settings(&app);
+    crate::onboarding::window::close(&app)?;
+    crate::onboarding::window::show_launcher_panel(&app)?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn dismiss_onboarding(app: AppHandle) -> Result<(), AppError> {
+    // Recommended close behavior: dismiss = mark completed, no panel pop.
+    crate::onboarding::persistence::write_onboarding_completed(&app, true)?;
+    crate::onboarding::window::close(&app)?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn reset_onboarding(
+    app: AppHandle,
+    cursor: State<'_, OnboardingCursor>,
+) -> Result<(), AppError> {
+    crate::onboarding::persistence::write_onboarding_completed(&app, false)?;
+    {
+        let mut guard = cursor.0.lock().map_err(|_| AppError::Lock)?;
+        *guard = initial(cfg!(target_os = "macos"));
+    }
+    crate::onboarding::window::open(&app)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::onboarding::state::OnboardingStep;
+
+    #[test]
+    fn get_state_returns_initial() {
+        let c = OnboardingCursor::new(true);
+        let s = get_state_inner(&c).unwrap();
+        assert_eq!(s.current, OnboardingStep::Welcome);
+        assert_eq!(s.position, 1);
+    }
+
+    #[test]
+    fn advance_then_get_returns_advanced() {
+        let c = OnboardingCursor::new(true);
+        let advanced = advance_inner(&c).unwrap();
+        let fetched = get_state_inner(&c).unwrap();
+        assert_eq!(fetched, advanced);
+        assert_eq!(fetched.current, OnboardingStep::GrantAccessibility);
+    }
+
+    #[test]
+    fn go_back_at_first_step_is_idempotent() {
+        let c = OnboardingCursor::new(false);
+        let s1 = go_back_inner(&c).unwrap();
+        let s2 = go_back_inner(&c).unwrap();
+        assert_eq!(s1, s2);
+    }
+}

--- a/src-tauri/src/onboarding/mod.rs
+++ b/src-tauri/src/onboarding/mod.rs
@@ -1,0 +1,4 @@
+pub mod state;
+pub mod persistence;
+pub mod commands;
+pub mod window;

--- a/src-tauri/src/onboarding/persistence.rs
+++ b/src-tauri/src/onboarding/persistence.rs
@@ -1,0 +1,167 @@
+use serde_json::{json, Value};
+
+/// Returns true if onboarding has been completed.
+/// Same fail-soft pattern as `parse_launch_view`: missing/malformed → false.
+pub fn parse_onboarding_completed(settings: &Value) -> bool {
+    settings
+        .get("onboarding")
+        .and_then(|o| o.get("completed"))
+        .and_then(|c| c.as_bool())
+        .unwrap_or(false)
+}
+
+/// Returns the input value with `onboarding.completed` set to `completed`.
+/// Creates the `onboarding` object if it doesn't exist.
+pub fn set_onboarding_completed(mut settings: Value, completed: bool) -> Value {
+    if !settings.is_object() {
+        settings = json!({});
+    }
+    let obj = settings.as_object_mut().expect("settings must be object");
+    let onboarding = obj
+        .entry("onboarding".to_string())
+        .or_insert_with(|| json!({}));
+    if !onboarding.is_object() {
+        *onboarding = json!({});
+    }
+    onboarding
+        .as_object_mut()
+        .expect("onboarding must be object")
+        .insert("completed".to_string(), json!(completed));
+    settings
+}
+
+/// Reads `settings.onboarding.completed` from `settings.dat`.
+/// Mirrors the same call pattern as `read_launch_view` in `lib.rs`.
+/// Returns `false` on any store or parse failure (fail-soft).
+pub fn read_onboarding_completed(app: &tauri::AppHandle) -> bool {
+    use tauri_plugin_store::StoreExt;
+    let Ok(store) = app.store("settings.dat") else {
+        return false;
+    };
+    let value = store
+        .get("settings")
+        .unwrap_or_else(|| serde_json::json!({}));
+    parse_onboarding_completed(&value)
+}
+
+/// Reads `settings.appearance.launchView` from `settings.dat`. Returns
+/// `"compact"` only when the persisted value is exactly that; any other
+/// shape or value (or store failure) yields `"default"`.
+pub fn read_launch_view(app: &tauri::AppHandle) -> &'static str {
+    use tauri_plugin_store::StoreExt;
+    let Ok(store) = app.store("settings.dat") else {
+        return "default";
+    };
+    let value = store
+        .get("settings")
+        .unwrap_or_else(|| serde_json::json!({}));
+    let is_compact = value
+        .get("appearance")
+        .and_then(|a| a.get("launchView"))
+        .and_then(|v| v.as_str())
+        == Some("compact");
+    if is_compact {
+        "compact"
+    } else {
+        "default"
+    }
+}
+
+/// Reads `settings.appearance.activeTheme` from `settings.dat`. Returns
+/// `Some(themeId)` if a non-empty string is set, `None` otherwise.
+pub fn read_active_theme(app: &tauri::AppHandle) -> Option<String> {
+    use tauri_plugin_store::StoreExt;
+    let store = app.store("settings.dat").ok()?;
+    let value = store.get("settings")?;
+    value
+        .get("appearance")?
+        .get("activeTheme")?
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// Writes `settings.onboarding.completed` to `settings.dat`.
+/// Reads current settings, merges the new value, and saves.
+pub fn write_onboarding_completed(
+    app: &tauri::AppHandle,
+    completed: bool,
+) -> Result<(), crate::error::AppError> {
+    use tauri_plugin_store::StoreExt;
+    let store = app
+        .store("settings.dat")
+        .map_err(|e| crate::error::AppError::Other(format!("store: {}", e)))?;
+    let current = store
+        .get("settings")
+        .unwrap_or_else(|| serde_json::json!({}));
+    let updated = set_onboarding_completed(current, completed);
+    store.set("settings", updated);
+    store
+        .save()
+        .map_err(|e| crate::error::AppError::Other(format!("store save: {}", e)))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn missing_section_returns_false() {
+        assert!(!parse_onboarding_completed(&json!({})));
+    }
+
+    #[test]
+    fn missing_completed_returns_false() {
+        assert!(!parse_onboarding_completed(&json!({ "onboarding": {} })));
+    }
+
+    #[test]
+    fn non_bool_completed_returns_false() {
+        assert!(!parse_onboarding_completed(
+            &json!({ "onboarding": { "completed": "yes" } })
+        ));
+    }
+
+    #[test]
+    fn true_completed_returns_true() {
+        assert!(parse_onboarding_completed(
+            &json!({ "onboarding": { "completed": true } })
+        ));
+    }
+
+    #[test]
+    fn set_creates_section_when_missing() {
+        let updated = set_onboarding_completed(json!({}), true);
+        assert_eq!(updated["onboarding"]["completed"], json!(true));
+    }
+
+    #[test]
+    fn set_overwrites_existing_value() {
+        let updated = set_onboarding_completed(
+            json!({ "onboarding": { "completed": false } }),
+            true,
+        );
+        assert_eq!(updated["onboarding"]["completed"], json!(true));
+    }
+
+    #[test]
+    fn set_preserves_other_top_level_keys() {
+        let updated = set_onboarding_completed(
+            json!({ "appearance": { "launchView": "compact" } }),
+            true,
+        );
+        assert_eq!(updated["appearance"]["launchView"], json!("compact"));
+        assert_eq!(updated["onboarding"]["completed"], json!(true));
+    }
+
+    #[test]
+    fn read_returns_false_when_settings_dat_missing_path() {
+        // Pure unit: parse_* covers parsing; this is the anchor for the
+        // Tauri-Store-backed reader added below. Reader/writer themselves
+        // are exercised via manual smoke (see Task 18) — there's no easy
+        // unit harness for the Store plugin without a Tauri AppHandle.
+        assert!(!parse_onboarding_completed(&serde_json::json!({})));
+    }
+}

--- a/src-tauri/src/onboarding/state.rs
+++ b/src-tauri/src/onboarding/state.rs
@@ -1,0 +1,140 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum OnboardingStep {
+    Welcome,
+    GrantAccessibility,
+    PickHotkey,
+    PickLaunchView,
+    PickTheme,
+    FeaturedExtensions,
+    Done,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingState {
+    pub current: OnboardingStep,
+    pub total: u8,
+    pub position: u8, // 1-indexed for display
+    pub is_macos: bool,
+}
+
+pub fn step_order(is_macos: bool) -> Vec<OnboardingStep> {
+    let mut steps = vec![OnboardingStep::Welcome];
+    if is_macos {
+        steps.push(OnboardingStep::GrantAccessibility);
+    }
+    steps.extend([
+        OnboardingStep::PickHotkey,
+        OnboardingStep::PickLaunchView,
+        OnboardingStep::PickTheme,
+        OnboardingStep::FeaturedExtensions,
+        OnboardingStep::Done,
+    ]);
+    steps
+}
+
+pub fn initial(is_macos: bool) -> OnboardingState {
+    let order = step_order(is_macos);
+    OnboardingState {
+        current: order[0],
+        total: order.len() as u8,
+        position: 1,
+        is_macos,
+    }
+}
+
+pub fn advance(state: OnboardingState) -> OnboardingState {
+    let order = step_order(state.is_macos);
+    let idx = order.iter().position(|s| *s == state.current).unwrap_or(0);
+    let next_idx = (idx + 1).min(order.len() - 1);
+    OnboardingState {
+        current: order[next_idx],
+        total: order.len() as u8,
+        position: (next_idx + 1) as u8,
+        is_macos: state.is_macos,
+    }
+}
+
+pub fn go_back(state: OnboardingState) -> OnboardingState {
+    let order = step_order(state.is_macos);
+    let idx = order.iter().position(|s| *s == state.current).unwrap_or(0);
+    let prev_idx = idx.saturating_sub(1);
+    OnboardingState {
+        current: order[prev_idx],
+        total: order.len() as u8,
+        position: (prev_idx + 1) as u8,
+        is_macos: state.is_macos,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn order_on_macos_includes_accessibility() {
+        let order = step_order(true);
+        assert_eq!(
+            order,
+            vec![
+                OnboardingStep::Welcome,
+                OnboardingStep::GrantAccessibility,
+                OnboardingStep::PickHotkey,
+                OnboardingStep::PickLaunchView,
+                OnboardingStep::PickTheme,
+                OnboardingStep::FeaturedExtensions,
+                OnboardingStep::Done,
+            ]
+        );
+    }
+
+    #[test]
+    fn order_off_macos_skips_accessibility() {
+        let order = step_order(false);
+        assert!(!order.contains(&OnboardingStep::GrantAccessibility));
+        assert_eq!(order.len(), 6);
+    }
+
+    #[test]
+    fn initial_starts_at_welcome_position_one() {
+        let s = initial(true);
+        assert_eq!(s.current, OnboardingStep::Welcome);
+        assert_eq!(s.position, 1);
+        assert_eq!(s.total, 7);
+        assert!(s.is_macos);
+    }
+
+    #[test]
+    fn advance_moves_one_step() {
+        let s = advance(initial(true));
+        assert_eq!(s.current, OnboardingStep::GrantAccessibility);
+        assert_eq!(s.position, 2);
+    }
+
+    #[test]
+    fn advance_at_done_stays_done() {
+        let mut s = initial(false);
+        for _ in 0..10 {
+            s = advance(s);
+        }
+        assert_eq!(s.current, OnboardingStep::Done);
+        assert_eq!(s.position, s.total);
+    }
+
+    #[test]
+    fn go_back_at_welcome_stays_welcome() {
+        let s = go_back(initial(true));
+        assert_eq!(s.current, OnboardingStep::Welcome);
+        assert_eq!(s.position, 1);
+    }
+
+    #[test]
+    fn go_back_after_advance_returns() {
+        let s = go_back(advance(initial(true)));
+        assert_eq!(s.current, OnboardingStep::Welcome);
+        assert_eq!(s.position, 1);
+    }
+}

--- a/src-tauri/src/onboarding/window.rs
+++ b/src-tauri/src/onboarding/window.rs
@@ -1,0 +1,73 @@
+//! Onboarding window lifecycle helpers.
+//!
+//! Creates, shows, and closes the dedicated `onboarding` webview window.
+//! `open_if_needed` is called from `setup_app` (Task 7 owns that call site).
+
+use crate::error::AppError;
+use tauri::{AppHandle, Manager};
+
+const WINDOW_LABEL: &str = "onboarding";
+const WINDOW_URL: &str = "/onboarding";
+// Match the launcher panel's footprint (tauri.conf.json `main` window).
+const WINDOW_WIDTH: f64 = 750.0;
+const WINDOW_HEIGHT: f64 = 480.0;
+
+/// Open the onboarding window (creates if it doesn't exist; focuses if it does).
+pub fn open(app: &AppHandle) -> Result<(), AppError> {
+    if let Some(existing) = app.get_webview_window(WINDOW_LABEL) {
+        existing
+            .show()
+            .map_err(|e| AppError::Other(format!("show onboarding: {e}")))?;
+        existing
+            .set_focus()
+            .map_err(|e| AppError::Other(format!("focus onboarding: {e}")))?;
+        return Ok(());
+    }
+
+    tauri::WebviewWindowBuilder::new(
+        app,
+        WINDOW_LABEL,
+        tauri::WebviewUrl::App(WINDOW_URL.into()),
+    )
+    .title("Welcome to Asyar")
+    .inner_size(WINDOW_WIDTH, WINDOW_HEIGHT)
+    .resizable(false)
+    .center()
+    .always_on_top(true)
+    .decorations(false)
+    // Window must be transparent so rounded-corner CSS isn't clipped by a
+    // square OS-painted backing. The content background itself is opaque
+    // (see +layout.svelte) — only the area outside the rounded corners
+    // shows through.
+    .transparent(true)
+    .shadow(true)
+    .visible(true)
+    .focused(true)
+    .build()
+    .map_err(|e| AppError::Other(format!("create onboarding: {e}")))?;
+
+    Ok(())
+}
+
+/// Open the onboarding window only if `settings.onboarding.completed != true`.
+/// Called from `setup_app` (Task 7 owns the call site).
+pub fn open_if_needed(app: &AppHandle) -> Result<(), AppError> {
+    if crate::onboarding::persistence::read_onboarding_completed(app) {
+        return Ok(());
+    }
+    open(app)
+}
+
+/// Close the onboarding window if open. No-op if not.
+pub fn close(app: &AppHandle) -> Result<(), AppError> {
+    if let Some(w) = app.get_webview_window(WINDOW_LABEL) {
+        w.close()
+            .map_err(|e| AppError::Other(format!("close onboarding: {e}")))?;
+    }
+    Ok(())
+}
+
+/// Show the launcher panel. Mirrors whatever code path the global hotkey uses.
+pub fn show_launcher_panel(app: &AppHandle) -> Result<(), AppError> {
+    crate::commands::app::show_launcher(app)
+}

--- a/src/built-in-features/store/storeFetch.ts
+++ b/src/built-in-features/store/storeFetch.ts
@@ -1,0 +1,16 @@
+import { envService } from '../../services/envService';
+import type { ApiExtension } from './state.svelte';
+
+/**
+ * Fetches the raw list of extensions from the store registry. Used by the
+ * Store UI as well as the onboarding featured-extensions/themes steps. Does
+ * not apply local install-status overrides — callers add those if needed.
+ */
+export async function fetchAllStoreItems(): Promise<ApiExtension[]> {
+  const response = await fetch(`${envService.storeApiBaseUrl}/api/extensions`);
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  const data = await response.json();
+  return Array.isArray(data) ? data : (data.data || []);
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -67,6 +67,9 @@ export { default as ExtensionPreferencesForm } from './settings/ExtensionPrefere
 // Form
 export { default as FormField } from './form/FormField.svelte';
 
+// Onboarding
+export { default as StepProgress } from './onboarding/StepProgress.svelte';
+
 // Search
 export { default as ArgumentChipRow } from './search/ArgumentChipRow.svelte';
 export { default as CommandArgInput } from './search/CommandArgInput.svelte';

--- a/src/components/onboarding/StepProgress.svelte
+++ b/src/components/onboarding/StepProgress.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  let { total, position } = $props<{ total: number; position: number }>()
+</script>
+
+<ol class="dots" aria-label={`Step ${position} of ${total}`}>
+  {#each Array(total) as _, i}
+    <li class:dot--active={i + 1 === position}></li>
+  {/each}
+</ol>
+
+<style>
+  .dots {
+    display: flex;
+    gap: var(--space-2);
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .dots li {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--border-color);
+  }
+  .dot--active {
+    background: var(--asyar-brand);
+  }
+</style>

--- a/src/lib/ipc/commands.ts
+++ b/src/lib/ipc/commands.ts
@@ -952,3 +952,36 @@ export async function updateShowMoreBarStyle(style: ShowMoreBarStyle): Promise<v
   ): Promise<void> {
     return invoke('oauth_revoke_extension_token', { extensionId, providerId });
   }
+
+  // ── Onboarding ────────────────────────────────────────────────────────────────
+
+  export type OnboardingStepKind =
+    | 'welcome'
+    | 'grantAccessibility'
+    | 'pickHotkey'
+    | 'pickLaunchView'
+    | 'pickTheme'
+    | 'featuredExtensions'
+    | 'done'
+
+  export interface OnboardingState {
+    current: OnboardingStepKind
+    total: number
+    position: number
+    isMacos: boolean
+  }
+
+  export const onboardingCommands = {
+    getState: () =>
+      invoke<OnboardingState>('get_onboarding_state'),
+    advance: () =>
+      invoke<OnboardingState>('advance_onboarding_step'),
+    goBack: () =>
+      invoke<OnboardingState>('go_back_onboarding_step'),
+    complete: () =>
+      invoke<void>('complete_onboarding'),
+    dismiss: () =>
+      invoke<void>('dismiss_onboarding'),
+    reset: () =>
+      invoke<void>('reset_onboarding'),
+  }

--- a/src/routes/onboarding/+layout.svelte
+++ b/src/routes/onboarding/+layout.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { onboardingService } from '../../services/onboarding/onboardingService.svelte'
+  import { settingsService } from '../../services/settings/settingsService.svelte'
+  import { applyTheme } from '../../services/theme/themeService'
+  import { logService } from '../../services/log/logService'
+  import '../../resources/styles/style.css'
+
+  let { children } = $props()
+
+  onMount(async () => {
+    // The launcher webview owns its own settingsService instance; the
+    // onboarding webview is a separate webview and must initialize its own
+    // copy before any step reads currentSettings (otherwise reads return
+    // DEFAULT_SETTINGS regardless of what's on disk).
+    try {
+      await settingsService.init()
+    } catch (err) {
+      logService.warn(`[onboarding] settingsService.init failed: ${err}`)
+    }
+
+    // If a theme is already active per persisted settings, apply it to this
+    // window so the onboarding visually matches the launcher.
+    const activeTheme = settingsService.currentSettings.appearance.activeTheme
+    if (activeTheme) {
+      applyTheme(activeTheme).catch((err) => {
+        logService.warn(`[onboarding] applyTheme failed for ${activeTheme}: ${err}`)
+      })
+    }
+
+    void onboardingService.load()
+  })
+
+  function handleClose() {
+    void onboardingService.dismiss()
+  }
+</script>
+
+<div class="onboarding-frame">
+  <header class="onboarding-frame__header">
+    <button
+      type="button"
+      class="onboarding-frame__close"
+      aria-label="Close"
+      onclick={handleClose}
+    >
+      ✕
+    </button>
+  </header>
+  <main class="onboarding-frame__main">
+    {@render children()}
+  </main>
+</div>
+
+<style>
+  /* The Tauri window is transparent so the rounded corners aren't clipped
+     by a square OS backing. html/body are reset to transparent and
+     overflow:hidden so only the rounded .onboarding-frame is visible. */
+  :global(html),
+  :global(body) {
+    background: transparent;
+    overflow: hidden;
+  }
+  .onboarding-frame {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    width: 100vw;
+    /* Fully opaque surface — content does NOT show the desktop through it. */
+    background: var(--bg-popup);
+    color: var(--text-primary);
+    border-radius: var(--radius-xl);
+    overflow: hidden;
+  }
+  .onboarding-frame__header {
+    display: flex;
+    justify-content: flex-end;
+    padding: var(--space-3);
+  }
+  .onboarding-frame__close {
+    background: transparent;
+    border: 0;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 16px;
+  }
+  .onboarding-frame__main {
+    flex: 1;
+    padding: var(--space-6);
+    overflow: auto;
+  }
+</style>

--- a/src/routes/onboarding/+layout.ts
+++ b/src/routes/onboarding/+layout.ts
@@ -1,0 +1,2 @@
+export const ssr = false
+export const prerender = false

--- a/src/routes/onboarding/+page.svelte
+++ b/src/routes/onboarding/+page.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { onboardingService } from '../../services/onboarding/onboardingService.svelte'
+  import StepProgress from '../../components/onboarding/StepProgress.svelte'
+  import Welcome from './steps/Welcome.svelte'
+  import GrantAccessibility from './steps/GrantAccessibility.svelte'
+  import PickHotkey from './steps/PickHotkey.svelte'
+  import PickLaunchView from './steps/PickLaunchView.svelte'
+  import PickTheme from './steps/PickTheme.svelte'
+  import FeaturedExtensions from './steps/FeaturedExtensions.svelte'
+  import Done from './steps/Done.svelte'
+
+  const state = $derived(onboardingService.state)
+</script>
+
+{#if state}
+  <div class="onboarding-page">
+    <StepProgress total={state.total} position={state.position} />
+    {#if state.current === 'welcome'}
+      <Welcome />
+    {:else if state.current === 'grantAccessibility'}
+      <GrantAccessibility />
+    {:else if state.current === 'pickHotkey'}
+      <PickHotkey />
+    {:else if state.current === 'pickLaunchView'}
+      <PickLaunchView />
+    {:else if state.current === 'pickTheme'}
+      <PickTheme />
+    {:else if state.current === 'featuredExtensions'}
+      <FeaturedExtensions />
+    {:else if state.current === 'done'}
+      <Done />
+    {/if}
+  </div>
+{:else}
+  <p>Loading…</p>
+{/if}
+
+<style>
+  .onboarding-page {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+  }
+</style>

--- a/src/routes/onboarding/stepLogic.test.ts
+++ b/src/routes/onboarding/stepLogic.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../services/onboarding/onboardingService.svelte', () => ({
+  onboardingService: {
+    advance: vi.fn(),
+    goBack: vi.fn(),
+    complete: vi.fn(),
+  },
+}))
+
+vi.mock('../../built-in-features/store/storeFetch', () => ({
+  fetchAllStoreItems: vi.fn(),
+}))
+
+import { advanceStep, goBackStep, completeStep, fetchTopThemes, fetchTopExtensions } from './stepLogic'
+import { onboardingService } from '../../services/onboarding/onboardingService.svelte'
+import { fetchAllStoreItems } from '../../built-in-features/store/storeFetch'
+
+describe('stepLogic', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('advanceStep delegates to onboardingService.advance', async () => {
+    await advanceStep()
+    expect(onboardingService.advance).toHaveBeenCalledOnce()
+  })
+
+  it('goBackStep delegates to onboardingService.goBack', async () => {
+    await goBackStep()
+    expect(onboardingService.goBack).toHaveBeenCalledOnce()
+  })
+
+  it('completeStep delegates to onboardingService.complete', async () => {
+    await completeStep()
+    expect(onboardingService.complete).toHaveBeenCalledOnce()
+  })
+})
+
+describe('fetchTopThemes', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('keeps only items with category=theme and sorts by install_count desc', async () => {
+    vi.mocked(fetchAllStoreItems).mockResolvedValueOnce([
+      { id: 1, name: 'A', category: 'theme', install_count: 5 } as any,
+      { id: 2, name: 'B', category: 'utility', install_count: 99 } as any,
+      { id: 3, name: 'C', category: 'Theme', install_count: 100 } as any,
+      { id: 4, name: 'D', category: 'theme', install_count: 50 } as any,
+    ])
+    const out = await fetchTopThemes(2)
+    expect(out.map((t) => t.id)).toEqual([3, 4])
+  })
+
+  it('returns empty array on fetch error', async () => {
+    vi.mocked(fetchAllStoreItems).mockRejectedValueOnce(new Error('net'))
+    const out = await fetchTopThemes(5)
+    expect(out).toEqual([])
+  })
+})
+
+describe('fetchTopExtensions', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('keeps non-theme items, filters by platform, sorts by install_count desc', async () => {
+    vi.mocked(fetchAllStoreItems).mockResolvedValueOnce([
+      { id: 1, name: 'A', category: 'utility', install_count: 10, manifest: { platforms: ['macos'] } } as any,
+      { id: 2, name: 'B', category: 'theme', install_count: 99 } as any,
+      { id: 3, name: 'C', category: 'utility', install_count: 100, manifest: { platforms: ['linux'] } } as any,
+      { id: 4, name: 'D', category: 'productivity', install_count: 50 } as any,
+    ])
+    const out = await fetchTopExtensions(5, 'macos')
+    expect(out.map((e) => e.id)).toEqual([4, 1])
+  })
+
+  it('returns empty array on fetch error', async () => {
+    vi.mocked(fetchAllStoreItems).mockRejectedValueOnce(new Error('net'))
+    const out = await fetchTopExtensions(5, 'macos')
+    expect(out).toEqual([])
+  })
+})

--- a/src/routes/onboarding/stepLogic.ts
+++ b/src/routes/onboarding/stepLogic.ts
@@ -1,0 +1,50 @@
+import { onboardingService } from '../../services/onboarding/onboardingService.svelte'
+import { fetchAllStoreItems } from '../../built-in-features/store/storeFetch'
+import type { ApiExtension } from '../../built-in-features/store/state.svelte'
+
+export async function advanceStep(): Promise<void> {
+  await onboardingService.advance()
+}
+
+export async function goBackStep(): Promise<void> {
+  await onboardingService.goBack()
+}
+
+export async function completeStep(): Promise<void> {
+  await onboardingService.complete()
+}
+
+function isTheme(item: ApiExtension): boolean {
+  return item.category?.toLowerCase() === 'theme'
+}
+
+export async function fetchTopThemes(limit: number): Promise<ApiExtension[]> {
+  try {
+    const all = await fetchAllStoreItems()
+    return all
+      .filter(isTheme)
+      .sort((a, b) => b.install_count - a.install_count)
+      .slice(0, limit)
+  } catch {
+    return []
+  }
+}
+
+export async function fetchTopExtensions(
+  limit: number,
+  platform: string,
+): Promise<ApiExtension[]> {
+  try {
+    const all = await fetchAllStoreItems()
+    return all
+      .filter((it) => !isTheme(it))
+      .filter((it) => {
+        const p = it.manifest?.platforms
+        return !p?.length || p.includes(platform)
+      })
+      .sort((a, b) => b.install_count - a.install_count)
+      .slice(0, limit)
+  } catch {
+    return []
+  }
+}

--- a/src/routes/onboarding/steps/Done.svelte
+++ b/src/routes/onboarding/steps/Done.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { Card, Button } from '../../../components'
+  import { completeStep, goBackStep } from '../stepLogic'
+</script>
+
+<Card>
+  <h1>You're set</h1>
+  <p>Hit your hotkey to summon Asyar anytime. Have fun.</p>
+  <div class="actions">
+    <Button class="btn-secondary" onclick={goBackStep}>Back</Button>
+    <Button onclick={completeStep}>Open Asyar</Button>
+  </div>
+</Card>
+
+<style>
+  .actions { display: flex; justify-content: space-between; margin-top: var(--space-5); }
+</style>

--- a/src/routes/onboarding/steps/FeaturedExtensions.svelte
+++ b/src/routes/onboarding/steps/FeaturedExtensions.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { Card, Button, EmptyState, LoadingState } from '../../../components';
+  import { advanceStep, goBackStep, fetchTopExtensions } from '../stepLogic';
+  import type { ApiExtension } from '../../../built-in-features/store/state.svelte';
+  import storeExtension from '../../../built-in-features/store/index.svelte';
+  import { platform } from '@tauri-apps/plugin-os';
+
+  let extensions = $state<ApiExtension[]>([]);
+  let selected = $state<Set<number>>(new Set());
+  let loading = $state(true);
+  let installingIds = $state<Set<number>>(new Set());
+  let failedIds = $state<Set<number>>(new Set());
+
+  async function load() {
+    loading = true;
+    try {
+      const p = platform();
+      extensions = await fetchTopExtensions(5, p);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function toggle(id: number) {
+    const next = new Set(selected);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    selected = next;
+  }
+
+  async function installSelected() {
+    const ids = Array.from(selected);
+    await Promise.allSettled(
+      ids.map(async (id) => {
+        installingIds = new Set([...installingIds, id]);
+        try {
+          const ext = extensions.find((e) => e.id === id);
+          if (ext) await storeExtension.installExtension(ext.slug, ext.id, ext.name);
+        } catch {
+          failedIds = new Set([...failedIds, id]);
+        } finally {
+          const next = new Set(installingIds);
+          next.delete(id);
+          installingIds = next;
+        }
+      }),
+    );
+    await advanceStep();
+  }
+
+  onMount(load);
+</script>
+
+<Card>
+  <h1>Try a few extensions</h1>
+  <p>Optional — pick any you like and we'll install them now.</p>
+
+  {#if loading}
+    <LoadingState message="Loading…" />
+  {:else if extensions.length === 0}
+    <EmptyState message="Couldn't reach the extension store.">
+      <Button onclick={load}>Retry</Button>
+    </EmptyState>
+  {:else}
+    <ul class="list">
+      {#each extensions as ext (ext.id)}
+        <li>
+          <label>
+            <input
+              type="checkbox"
+              checked={selected.has(ext.id)}
+              onchange={() => toggle(ext.id)}
+              disabled={installingIds.has(ext.id)}
+            />
+            <span class="name">{ext.name}</span>
+            {#if installingIds.has(ext.id)}<span class="hint">Installing…</span>{/if}
+            {#if failedIds.has(ext.id)}<span class="error">Failed</span>{/if}
+          </label>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  <div class="actions">
+    <Button class="btn-secondary" onclick={goBackStep}>Back</Button>
+    <Button class="btn-secondary" onclick={advanceStep}>Skip</Button>
+    <Button onclick={installSelected} disabled={selected.size === 0}>
+      Install {selected.size} selected
+    </Button>
+  </div>
+</Card>
+
+<style>
+  .list {
+    list-style: none;
+    padding: 0;
+    margin: var(--space-4) 0;
+  }
+  .list li {
+    padding: var(--space-2) 0;
+  }
+  .name {
+    margin-left: var(--space-2);
+  }
+  .hint {
+    margin-left: var(--space-2);
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+  .error {
+    margin-left: var(--space-2);
+    color: var(--accent-danger);
+    font-size: var(--font-size-sm);
+  }
+  .actions {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-2);
+    margin-top: var(--space-5);
+  }
+</style>

--- a/src/routes/onboarding/steps/GrantAccessibility.svelte
+++ b/src/routes/onboarding/steps/GrantAccessibility.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte'
+  import { Card, Button, StatusDot } from '../../../components'
+  import { advanceStep, goBackStep } from '../stepLogic'
+  import { invoke } from '@tauri-apps/api/core'
+
+  let granted = $state(false)
+  let loading = $state(false)
+
+  async function check() {
+    try {
+      granted = await invoke<boolean>('check_snippet_permission')
+    } catch {
+      granted = false
+    }
+  }
+
+  async function openPrefs() {
+    loading = true
+    try {
+      await invoke('open_accessibility_preferences')
+    } finally {
+      loading = false
+    }
+  }
+
+  onMount(() => {
+    void check()
+    window.addEventListener('focus', check)
+  })
+
+  onDestroy(() => {
+    window.removeEventListener('focus', check)
+  })
+</script>
+
+<Card>
+  <h1>Grant accessibility access</h1>
+  <p>
+    Asyar uses the macOS Accessibility API to paste snippets and capture
+    selections. You can grant this now or later.
+  </p>
+
+  <div class="status">
+    <StatusDot color={granted ? 'success' : 'warning'} />
+    <span>{granted ? 'Granted' : 'Not granted yet'}</span>
+  </div>
+
+  {#if !granted}
+    <Button onclick={openPrefs} disabled={loading}>
+      Open System Settings
+    </Button>
+  {/if}
+
+  <div class="actions">
+    <Button class="btn-secondary" onclick={goBackStep}>Back</Button>
+    <Button onclick={advanceStep}>{granted ? 'Continue' : 'Skip for now'}</Button>
+  </div>
+</Card>
+
+<style>
+  .status { display: flex; align-items: center; gap: var(--space-2); margin: var(--space-3) 0; }
+  .actions { display: flex; justify-content: space-between; margin-top: var(--space-5); }
+</style>

--- a/src/routes/onboarding/steps/PickHotkey.svelte
+++ b/src/routes/onboarding/steps/PickHotkey.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { Card, Button, ShortcutRecorder } from '../../../components'
+  import { advanceStep, goBackStep } from '../stepLogic'
+  import { settingsService } from '../../../services/settings/settingsService.svelte'
+  import { updateShortcut } from '../../../utils/shortcutManager'
+
+  let modifier = $state(settingsService.currentSettings.shortcut.modifier)
+  let key = $state(settingsService.currentSettings.shortcut.key)
+
+  async function handleSave(detail: { modifier: string; key: string }): Promise<string | true> {
+    const success = await updateShortcut(detail.modifier, detail.key)
+    if (success) return true
+    return 'Failed to save shortcut'
+  }
+</script>
+
+<Card>
+  <h1>Pick your global hotkey</h1>
+  <p>Press the keys you want to use to summon Asyar.</p>
+
+  <ShortcutRecorder bind:modifier bind:key onsave={handleSave} />
+
+  <div class="actions">
+    <Button class="btn-secondary" onclick={goBackStep}>Back</Button>
+    <Button onclick={advanceStep}>Continue</Button>
+  </div>
+</Card>
+
+<style>
+  .actions { display: flex; justify-content: space-between; margin-top: var(--space-5); }
+</style>

--- a/src/routes/onboarding/steps/PickLaunchView.svelte
+++ b/src/routes/onboarding/steps/PickLaunchView.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  import { emit } from '@tauri-apps/api/event';
+  import { Card, Button, AppearanceThemeSelector, WindowModeSelector } from '../../../components';
+  import { advanceStep, goBackStep } from '../stepLogic';
+  import { settingsService } from '../../../services/settings/settingsService.svelte';
+
+  const currentTheme = $derived(settingsService.currentSettings.appearance.theme);
+  const currentLaunchView = $derived(settingsService.currentSettings.appearance.launchView);
+
+  async function pickTheme(theme: 'light' | 'dark' | 'system') {
+    await settingsService.updateSettings('appearance', { theme });
+  }
+
+  async function pickLaunchView(launchView: 'default' | 'compact') {
+    await settingsService.updateSettings('appearance', { launchView });
+    // Cross-window event so the launcher webview's compactSyncService updates
+    // its geometry while we're still in onboarding (matches GeneralTab).
+    await emit('asyar:launch-view-changed', { launchView });
+  }
+</script>
+
+<Card>
+  <h1>Choose how Asyar looks</h1>
+  <p>You can change these any time in Settings.</p>
+
+  <div class="row">
+    <div class="row__label">
+      <span class="row__title">Appearance</span>
+      <span class="row__hint">Light, dark, or follow your system.</span>
+    </div>
+    <AppearanceThemeSelector value={currentTheme} onchange={pickTheme} />
+  </div>
+
+  <div class="row">
+    <div class="row__label">
+      <span class="row__title">Window mode</span>
+      <span class="row__hint">Default shows results panel; Compact is just the search bar.</span>
+    </div>
+    <WindowModeSelector value={currentLaunchView} onchange={pickLaunchView} />
+  </div>
+
+  <div class="actions">
+    <Button class="btn-secondary" onclick={goBackStep}>Back</Button>
+    <Button onclick={advanceStep}>Continue</Button>
+  </div>
+</Card>
+
+<style>
+  .row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-5);
+    padding: var(--space-4) 0;
+    border-bottom: 1px solid var(--separator);
+  }
+  .row:last-of-type {
+    border-bottom: none;
+  }
+  .row__label {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .row__title {
+    font-size: var(--font-size-md);
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .row__hint {
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary);
+  }
+  .actions {
+    display: flex;
+    justify-content: space-between;
+    margin-top: var(--space-5);
+  }
+</style>

--- a/src/routes/onboarding/steps/PickTheme.svelte
+++ b/src/routes/onboarding/steps/PickTheme.svelte
@@ -1,0 +1,218 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { emit } from '@tauri-apps/api/event';
+  import { Card, Button, EmptyState, LoadingState } from '../../../components';
+  import { advanceStep, goBackStep, fetchTopThemes } from '../stepLogic';
+  import type { ApiExtension } from '../../../built-in-features/store/state.svelte';
+  import storeExtension from '../../../built-in-features/store/index.svelte';
+  import { settingsService } from '../../../services/settings/settingsService.svelte';
+  import { applyTheme, removeTheme } from '../../../services/theme/themeService';
+  import { discoverExtensions } from '../../../lib/ipc/commands';
+  import { logService } from '../../../services/log/logService';
+  import { diagnosticsService } from '../../../services/diagnostics/diagnosticsService.svelte';
+
+  let themes = $state<ApiExtension[]>([]);
+  let loading = $state(true);
+  let installingId = $state<number | null>(null);
+  // Maps store-API theme name → on-disk manifest.id. Populated as themes are
+  // discovered (at load time and after each install). Lets us answer "is this
+  // theme installed?" and "is this theme applied?" from the API row.
+  let nameToManifestId = $state<Record<string, string>>({});
+  // Reactive: re-reads whenever settingsService finishes loading or another
+  // window writes the setting via store.onChange. The layout calls init()
+  // on mount, but children may render briefly before that completes.
+  const activeThemeId = $derived(
+    settingsService.currentSettings.appearance.activeTheme ?? null,
+  );
+
+  async function refreshDiscovery() {
+    try {
+      const records = await discoverExtensions();
+      const next: Record<string, string> = {};
+      for (const r of records) {
+        if (r.manifest.type === 'theme') next[r.manifest.name] = r.manifest.id;
+      }
+      nameToManifestId = next;
+    } catch (err) {
+      logService.warn(`[onboarding] discoverExtensions failed: ${err}`);
+    }
+  }
+
+  async function load() {
+    loading = true;
+    // Defensive: ensure persisted settings are loaded before we render
+    // theme tiles. `init()` is idempotent — the layout already calls it.
+    await settingsService.init();
+    themes = await fetchTopThemes(6);
+    await refreshDiscovery();
+    loading = false;
+  }
+
+  async function install(theme: ApiExtension) {
+    installingId = theme.id;
+    try {
+      await storeExtension.installExtension(theme.slug, theme.id, theme.name);
+      await refreshDiscovery();
+
+      const themeId = nameToManifestId[theme.name];
+      if (!themeId) {
+        logService.warn(`[onboarding] installed theme not found in registry after install: ${theme.name}`);
+        diagnosticsService.report({
+          source: 'frontend',
+          kind: 'manual',
+          severity: 'warning',
+          retryable: true,
+          context: { message: `Couldn't apply ${theme.name} — try again from Settings.` },
+        });
+        return;
+      }
+
+      await applyTheme(themeId);
+      await settingsService.updateSettings('appearance', { activeTheme: themeId });
+      await emit('asyar:theme-changed', { themeId });
+      // activeThemeId is $derived — it re-reads automatically once the
+      // store write completes.
+    } catch (err) {
+      logService.error(`[onboarding] failed to install/apply theme ${theme.name}: ${err}`);
+      diagnosticsService.report({
+        source: 'frontend',
+        kind: 'manual',
+        severity: 'error',
+        retryable: true,
+        context: { message: `Could not install "${theme.name}"` },
+      });
+    } finally {
+      installingId = null;
+    }
+  }
+
+  function statusFor(theme: ApiExtension): 'installing' | 'applied' | 'installed' | 'available' {
+    if (installingId === theme.id) return 'installing';
+    const mid = nameToManifestId[theme.name];
+    if (!mid) return 'available';
+    if (activeThemeId === mid) return 'applied';
+    return 'installed';
+  }
+
+  async function useDefault() {
+    try {
+      removeTheme();
+      await settingsService.updateSettings('appearance', { activeTheme: null });
+      await emit('asyar:theme-changed', { themeId: null });
+      // activeThemeId is $derived — auto-updates from settingsService.
+    } catch (err) {
+      logService.error(`[onboarding] failed to revert to default theme: ${err}`);
+      diagnosticsService.report({
+        source: 'frontend',
+        kind: 'manual',
+        severity: 'error',
+        retryable: true,
+        context: { message: 'Could not revert to default theme' },
+      });
+    }
+  }
+
+  onMount(load);
+</script>
+
+<Card>
+  <h1>Pick a theme</h1>
+  <p>Optional — make Asyar feel like home.</p>
+
+  {#if loading}
+    <LoadingState message="Loading themes…" />
+  {:else if themes.length === 0}
+    <EmptyState message="Couldn't load themes.">
+      <Button onclick={load}>Retry</Button>
+    </EmptyState>
+  {:else}
+    <ul class="grid">
+      <li class="grid__item" class:grid__item--active={activeThemeId === null}>
+        <div class="grid__label">
+          <span class="grid__name">Default</span>
+          <span class="grid__hint">Built-in Asyar theme</span>
+        </div>
+        {#if activeThemeId === null}
+          <span class="grid__status grid__status--applied">Applied</span>
+        {:else}
+          <Button class="btn-secondary" onclick={useDefault} disabled={installingId !== null}>
+            Use default
+          </Button>
+        {/if}
+      </li>
+
+      {#each themes as theme (theme.id)}
+        {@const status = statusFor(theme)}
+        <li class="grid__item" class:grid__item--active={status === 'applied'}>
+          <span class="grid__name">{theme.name}</span>
+          {#if status === 'installing'}
+            <span class="grid__status">Installing…</span>
+          {:else if status === 'applied'}
+            <span class="grid__status grid__status--applied">Applied</span>
+          {:else}
+            <Button onclick={() => install(theme)} disabled={installingId !== null}>
+              {status === 'installed' ? 'Apply' : 'Install'}
+            </Button>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  <div class="actions">
+    <Button class="btn-secondary" onclick={goBackStep}>Back</Button>
+    <Button class="btn-secondary" onclick={advanceStep}>Skip</Button>
+    <Button onclick={advanceStep}>Continue</Button>
+  </div>
+</Card>
+
+<style>
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-3);
+    margin: var(--space-4) 0;
+    padding: 0;
+    list-style: none;
+  }
+  .grid__item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3);
+    background: var(--bg-secondary);
+    border: 1px solid transparent;
+    border-radius: var(--radius-md);
+    transition: border-color var(--transition-fast);
+  }
+  .grid__item--active {
+    border-color: var(--asyar-brand);
+  }
+  .grid__label {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .grid__name {
+    font-weight: 500;
+  }
+  .grid__hint {
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary);
+  }
+  .grid__status {
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary);
+  }
+  .grid__status--applied {
+    color: var(--asyar-brand);
+    font-weight: 600;
+  }
+  .actions {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-2);
+    margin-top: var(--space-5);
+  }
+</style>

--- a/src/routes/onboarding/steps/Welcome.svelte
+++ b/src/routes/onboarding/steps/Welcome.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { Card, Button } from '../../../components'
+  import { advanceStep } from '../stepLogic'
+</script>
+
+<Card>
+  <h1>Welcome to Asyar</h1>
+  <p>A keyboard-first launcher for everything on your Mac, Linux, or Windows machine.</p>
+  <p class="hint">In a moment we'll set up your hotkey and let you pick a few extensions to try.</p>
+  <div class="actions">
+    <Button onclick={advanceStep}>Get started</Button>
+  </div>
+</Card>
+
+<style>
+  h1 { font-size: var(--font-size-xl); margin: 0 0 var(--space-2); }
+  .hint { color: var(--text-secondary); }
+  .actions { display: flex; justify-content: flex-end; margin-top: var(--space-5); }
+</style>

--- a/src/routes/settings/tabs/GeneralTab.svelte
+++ b/src/routes/settings/tabs/GeneralTab.svelte
@@ -7,7 +7,9 @@
     ShortcutRecorder,
     AppearanceThemeSelector,
     WindowModeSelector,
+    Button,
   } from '../../../components';
+  import { onboardingCommands } from '../../../lib/ipc/commands';
   import type { SettingsHandler } from '../settingsHandlers.svelte';
   import { shortcutService } from '../../../built-in-features/shortcuts/shortcutService';
   import { normalizeShortcut } from '../../../built-in-features/shortcuts/shortcutFormatter';
@@ -79,6 +81,19 @@
     await emit('asyar:launch-view-changed', { launchView });
   }
 
+  async function rerunOnboarding() {
+    try {
+      await onboardingCommands.reset();
+    } catch (e) {
+      logService.error(`Failed to re-run onboarding: ${e}`);
+      diagnosticsService.report({
+        source: 'frontend', kind: 'manual', severity: 'error',
+        retryable: false,
+        context: { message: 'Could not re-run onboarding' },
+      });
+    }
+  }
+
   async function selectTheme(themeId: string | null) {
     try {
       if (themeId) {
@@ -135,6 +150,13 @@
       onchange={selectLaunchView}
     />
   </SettingsFormRow>
+
+  <SettingsFormRow label="Onboarding" separator>
+    <div class="onboarding-row">
+      <span class="onboarding-row__hint">Walk through the welcome flow again.</span>
+      <Button class="btn-secondary" onclick={rerunOnboarding}>Re-run onboarding</Button>
+    </div>
+  </SettingsFormRow>
 </SettingsForm>
 
 {#if themeExtensions.length > 0}
@@ -165,6 +187,19 @@
 {/if}
 
 <style>
+  .onboarding-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-3);
+    width: 100%;
+  }
+
+  .onboarding-row__hint {
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
   .themes-section {
     display: flex;
     flex-direction: column;

--- a/src/services/onboarding/onboardingService.svelte.test.ts
+++ b/src/services/onboarding/onboardingService.svelte.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+vi.mock('../log/logService', () => ({
+  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('../diagnostics/diagnosticsService.svelte', () => ({
+  diagnosticsService: { report: vi.fn() },
+}))
+
+import { onboardingService } from './onboardingService.svelte'
+import { invoke } from '@tauri-apps/api/core'
+
+const initialState = {
+  current: 'welcome',
+  total: 7,
+  position: 1,
+  isMacos: true,
+}
+
+describe('onboardingService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    onboardingService.reset()
+  })
+
+  it('loads initial state from Rust', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce(initialState)
+    await onboardingService.load()
+    expect(invoke).toHaveBeenCalledWith('get_onboarding_state')
+    expect(onboardingService.state).toEqual(initialState)
+  })
+
+  it('advances and stores returned state', async () => {
+    vi.mocked(invoke)
+      .mockResolvedValueOnce(initialState)
+      .mockResolvedValueOnce({
+        ...initialState,
+        current: 'grantAccessibility',
+        position: 2,
+      })
+    await onboardingService.load()
+    await onboardingService.advance()
+    expect(invoke).toHaveBeenCalledWith('advance_onboarding_step')
+    expect(onboardingService.state?.current).toBe('grantAccessibility')
+  })
+
+  it('goes back and stores returned state', async () => {
+    vi.mocked(invoke)
+      .mockResolvedValueOnce({ ...initialState, current: 'pickHotkey', position: 3 })
+      .mockResolvedValueOnce({ ...initialState, current: 'grantAccessibility', position: 2 })
+    await onboardingService.load()
+    await onboardingService.goBack()
+    expect(invoke).toHaveBeenCalledWith('go_back_onboarding_step')
+    expect(onboardingService.state?.current).toBe('grantAccessibility')
+  })
+
+  it('completes calls Rust', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce(undefined)
+    await onboardingService.complete()
+    expect(invoke).toHaveBeenCalledWith('complete_onboarding')
+  })
+
+  it('dismiss calls Rust', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce(undefined)
+    await onboardingService.dismiss()
+    expect(invoke).toHaveBeenCalledWith('dismiss_onboarding')
+  })
+
+  it('reports diagnostics on load failure', async () => {
+    const { diagnosticsService } = await import(
+      '../diagnostics/diagnosticsService.svelte'
+    )
+    vi.mocked(invoke).mockRejectedValueOnce(new Error('boom'))
+    await onboardingService.load()
+    expect(diagnosticsService.report).toHaveBeenCalled()
+  })
+})

--- a/src/services/onboarding/onboardingService.svelte.ts
+++ b/src/services/onboarding/onboardingService.svelte.ts
@@ -1,0 +1,89 @@
+import { onboardingCommands, type OnboardingState } from '../../lib/ipc/commands'
+import { logService } from '../log/logService'
+import { diagnosticsService } from '../diagnostics/diagnosticsService.svelte'
+
+class OnboardingServiceClass {
+  state = $state<OnboardingState | null>(null)
+  loading = $state(false)
+
+  async load(): Promise<void> {
+    this.loading = true
+    try {
+      this.state = await onboardingCommands.getState()
+    } catch (err) {
+      logService.warn('[onboardingService] load failed', err)
+      diagnosticsService.report({
+        source: 'frontend',
+        kind: 'onboarding-load-failed',
+        severity: 'error',
+        retryable: false,
+        developerDetail: String(err),
+      })
+    } finally {
+      this.loading = false
+    }
+  }
+
+  async advance(): Promise<void> {
+    try {
+      this.state = await onboardingCommands.advance()
+    } catch (err) {
+      diagnosticsService.report({
+        source: 'frontend',
+        kind: 'onboarding-advance-failed',
+        severity: 'error',
+        retryable: false,
+        developerDetail: String(err),
+      })
+    }
+  }
+
+  async goBack(): Promise<void> {
+    try {
+      this.state = await onboardingCommands.goBack()
+    } catch (err) {
+      diagnosticsService.report({
+        source: 'frontend',
+        kind: 'onboarding-go-back-failed',
+        severity: 'error',
+        retryable: false,
+        developerDetail: String(err),
+      })
+    }
+  }
+
+  async complete(): Promise<void> {
+    try {
+      await onboardingCommands.complete()
+    } catch (err) {
+      diagnosticsService.report({
+        source: 'frontend',
+        kind: 'onboarding-complete-failed',
+        severity: 'error',
+        retryable: false,
+        developerDetail: String(err),
+      })
+    }
+  }
+
+  async dismiss(): Promise<void> {
+    try {
+      await onboardingCommands.dismiss()
+    } catch (err) {
+      diagnosticsService.report({
+        source: 'frontend',
+        kind: 'onboarding-dismiss-failed',
+        severity: 'error',
+        retryable: false,
+        developerDetail: String(err),
+      })
+    }
+  }
+
+  reset(): void {
+    this.state = null
+    this.loading = false
+  }
+}
+
+export const onboardingService = new OnboardingServiceClass()

--- a/src/services/settings/settingsService.svelte.ts
+++ b/src/services/settings/settingsService.svelte.ts
@@ -44,6 +44,9 @@ const DEFAULT_SETTINGS: AppSettings = {
     enabled: {},
     autoUpdate: true,
   },
+  onboarding: {
+    completed: false,
+  },
   updates: {
     channel: "stable" as const,
     autoCheck: true,
@@ -321,6 +324,7 @@ class SettingsService implements ISettingsService {
             ...typedStored?.extensions?.enabled,
           },
         },
+        onboarding: { ...DEFAULT_SETTINGS.onboarding, ...typedStored?.onboarding },
         updates: typedStored?.updates
           ? { ...DEFAULT_SETTINGS.updates, ...typedStored.updates }
           : DEFAULT_SETTINGS.updates,

--- a/src/services/settings/settingsService.test.ts
+++ b/src/services/settings/settingsService.test.ts
@@ -40,6 +40,9 @@ const DEFAULT: AppSettings = {
     enabled: {},
     autoUpdate: true,
   },
+  onboarding: {
+    completed: false,
+  },
   updates: {
     channel: 'stable',
   },
@@ -125,6 +128,35 @@ describe('mergeWithDefaults', () => {
     const result = merge({ appearance: { theme: 'dark' } })
     expect(result.appearance.theme).toBe('dark')
     expect(result.appearance.windowWidth).toBe(DEFAULT.appearance.windowWidth)
+  })
+
+  it('mergeWithDefaults fills onboarding with defaults when missing from stored settings', () => {
+    const stored = {
+      general: {},
+      search: {},
+      shortcut: {},
+      appearance: {},
+      extensions: {},
+      ai: {},
+      // no onboarding key — simulates existing user upgrading
+    }
+    const merged = merge(stored)
+    expect(merged.onboarding).toBeDefined()
+    expect(merged.onboarding.completed).toBe(false)
+  })
+
+  it('mergeWithDefaults preserves stored onboarding.completed=true', () => {
+    const stored = {
+      general: {},
+      search: {},
+      shortcut: {},
+      appearance: {},
+      extensions: {},
+      ai: {},
+      onboarding: { completed: true },
+    }
+    const merged = merge(stored)
+    expect(merged.onboarding.completed).toBe(true)
   })
 })
 
@@ -303,5 +335,14 @@ describe('rust read_launch_view contract', () => {
   it('keeps the appearance key at the top level (not nested under ui/window/etc.)', () => {
     const topLevelKeys = Object.keys(serializedDefaults)
     expect(topLevelKeys).toContain('appearance')
+  })
+
+  it('persists onboarding.completed under settings.onboarding', () => {
+    const settings = { ...DEFAULT, onboarding: { completed: true } }
+    expect(settings.onboarding.completed).toBe(true)
+  })
+
+  it('defaults onboarding.completed to false', () => {
+    expect(DEFAULT.onboarding.completed).toBe(false)
   })
 })

--- a/src/services/settings/types/AppSettingsType.ts
+++ b/src/services/settings/types/AppSettingsType.ts
@@ -34,6 +34,9 @@ export interface AppSettings {
     enabled: Record<string, boolean>;
     autoUpdate?: boolean;
   };
+  onboarding: {
+    completed: boolean;
+  };
   updates?: {
     channel: "stable" | "beta";
     autoCheck: boolean;


### PR DESCRIPTION
Dedicated Tauri webview that opens on first launch and walks the user
through accessibility (macOS), hotkey, appearance + window mode, theme
install, and featured extensions. Settings persisted via existing
appearance keys; cross-window events propagate to the launcher panel
so picks apply instantly. "Re-run onboarding" surfaced in Settings →
General. Capability scoping updated so the new window can invoke core
APIs.