### PR TITLE
Add Windows ARM 64 native build

### DIFF
--- a/.github/workflows/build-cross-platform.yml
+++ b/.github/workflows/build-cross-platform.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 
 jobs:

--- a/.github/workflows/build-cross-platform.yml
+++ b/.github/workflows/build-cross-platform.yml
@@ -97,10 +97,22 @@ jobs:
           retention-days: 7
 
   build-windows:
-    name: Build Windows
+    name: Build Windows ${{ matrix.arch }}
     needs: test-and-lint
-    runs-on: windows-latest
-    timeout-minutes: 40
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-latest
+            rust-target: x86_64-pc-windows-msvc
+            artifact-name: asyar-windows
+          - arch: arm64
+            runner: windows-11-arm
+            rust-target: aarch64-pc-windows-msvc
+            artifact-name: asyar-windows-arm64
     defaults:
       run:
         working-directory: .
@@ -120,11 +132,14 @@ jobs:
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-target }}
 
       - name: Cache Rust
         uses: swatinem/rust-cache@v2
         with:
           workspaces: './src-tauri -> target'
+          key: ${{ matrix.rust-target }}
 
       - name: Wait for SDK on NPM
         shell: pwsh
@@ -151,7 +166,7 @@ jobs:
         run: pnpm svelte-kit sync
 
       - name: Build Tauri app
-        run: pnpm tauri build
+        run: pnpm tauri build --target ${{ matrix.rust-target }}
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -159,8 +174,8 @@ jobs:
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v7
         with:
-          name: asyar-windows
-          path: src-tauri/target/release/bundle/
+          name: ${{ matrix.artifact-name }}
+          path: src-tauri/target/${{ matrix.rust-target }}/release/bundle/
           retention-days: 7
 
   build-linux:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,20 @@ jobs:
 
   build-windows:
     needs: test-and-lint
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-latest
+            rust-target: x86_64-pc-windows-msvc
+            artifact-name: windows-artifacts
+          - arch: arm64
+            runner: windows-11-arm
+            rust-target: aarch64-pc-windows-msvc
+            artifact-name: windows-arm64-artifacts
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -91,9 +104,12 @@ jobs:
         with:
           version: 9
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-target }}
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: './src-tauri -> target'
+          key: ${{ matrix.rust-target }}
       - name: Wait for SDK on NPM
         shell: pwsh
         run: |
@@ -114,18 +130,18 @@ jobs:
 
       - run: pnpm install
       - run: pnpm svelte-kit sync
-      - name: Build Windows
+      - name: Build Windows ${{ matrix.arch }}
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: pnpm tauri build
-      - name: Upload Windows Artifacts
+        run: pnpm tauri build --target ${{ matrix.rust-target }}
+      - name: Upload Windows ${{ matrix.arch }} Artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: windows-artifacts
+          name: ${{ matrix.artifact-name }}
           path: |
-            src-tauri/target/release/bundle/msi/*.msi
-            src-tauri/target/release/bundle/msi/*.msi.sig
+            src-tauri/target/${{ matrix.rust-target }}/release/bundle/msi/*.msi
+            src-tauri/target/${{ matrix.rust-target }}/release/bundle/msi/*.msi.sig
 
   build-linux:
     needs: test-and-lint
@@ -227,48 +243,54 @@ jobs:
             TYPE="beta"
           fi
           
-          # Locate files using find to handle any directory structure
-          # For macOS, we need the .tar.gz for the updater
+          # Locate files using find to handle any directory structure.
+          # Scope Windows finds to per-arch artifact dirs so the x64 and ARM64
+          # MSIs don't get cross-picked.
           MAC_FILE_PATH=$(find artifacts -name "*.app.tar.gz" | head -n 1)
-          WIN_FILE_PATH=$(find artifacts -name "*.msi" | head -n 1)
+          WIN_X64_FILE_PATH=$(find artifacts/windows-artifacts -name "*.msi" | head -n 1)
+          WIN_ARM64_FILE_PATH=$(find artifacts/windows-arm64-artifacts -name "*.msi" | head -n 1)
           LINUX_FILE_PATH=$(find artifacts -name "*.AppImage" | head -n 1)
-          
+
           MAC_SIG_PATH=$(find artifacts -name "*.app.tar.gz.sig" | head -n 1)
-          WIN_SIG_PATH=$(find artifacts -name "*.msi.sig" | head -n 1)
+          WIN_X64_SIG_PATH=$(find artifacts/windows-artifacts -name "*.msi.sig" | head -n 1)
+          WIN_ARM64_SIG_PATH=$(find artifacts/windows-arm64-artifacts -name "*.msi.sig" | head -n 1)
           LINUX_SIG_PATH=$(find artifacts -name "*.AppImage.sig" | head -n 1)
 
           # Verify files exist before proceeding
-          if [[ -z "$MAC_FILE_PATH" || -z "$WIN_FILE_PATH" || -z "$LINUX_FILE_PATH" ]]; then
+          if [[ -z "$MAC_FILE_PATH" || -z "$WIN_X64_FILE_PATH" || -z "$WIN_ARM64_FILE_PATH" || -z "$LINUX_FILE_PATH" ]]; then
             echo "Error: Binaries missing in artifacts. Note: macOS requires .app.tar.gz"
             ls -R artifacts
             exit 1
           fi
-          
-          if [[ -z "$MAC_SIG_PATH" || -z "$WIN_SIG_PATH" || -z "$LINUX_SIG_PATH" ]]; then
+
+          if [[ -z "$MAC_SIG_PATH" || -z "$WIN_X64_SIG_PATH" || -z "$WIN_ARM64_SIG_PATH" || -z "$LINUX_SIG_PATH" ]]; then
             echo "Error: Signatures (.sig files) missing in artifacts. Check tauri.conf.json bundle configuration."
             ls -R artifacts
             exit 1
           fi
-          
+
           # Extract signatures and filenames
           MAC_SIG=$(cat "$MAC_SIG_PATH")
-          WIN_SIG=$(cat "$WIN_SIG_PATH")
+          WIN_X64_SIG=$(cat "$WIN_X64_SIG_PATH")
+          WIN_ARM64_SIG=$(cat "$WIN_ARM64_SIG_PATH")
           LINUX_SIG=$(cat "$LINUX_SIG_PATH")
-          
+
           MAC_FILE=$(basename "$MAC_FILE_PATH")
-          WIN_FILE=$(basename "$WIN_FILE_PATH")
+          WIN_X64_FILE=$(basename "$WIN_X64_FILE_PATH")
+          WIN_ARM64_FILE=$(basename "$WIN_ARM64_FILE_PATH")
           LINUX_FILE=$(basename "$LINUX_FILE_PATH")
-          
+
           REPO="${{ github.repository }}"
           TAG="${{ github.ref_name }}"
           BASE_URL="https://github.com/$REPO/releases/download/$TAG"
 
           # Use printf to construct JSON to avoid heredoc indention issues in YAML
-          PAYLOAD=$(printf '{"version":"%s","type":"%s","notes":"Automated multi-platform release %s","platforms":{"darwin-aarch64":{"url":"%s/%s","signature":"%s"},"darwin-x86_64":{"url":"%s/%s","signature":"%s"},"windows-x86_64":{"url":"%s/%s","signature":"%s"},"linux-x86_64":{"url":"%s/%s","signature":"%s"}}}' \
+          PAYLOAD=$(printf '{"version":"%s","type":"%s","notes":"Automated multi-platform release %s","platforms":{"darwin-aarch64":{"url":"%s/%s","signature":"%s"},"darwin-x86_64":{"url":"%s/%s","signature":"%s"},"windows-x86_64":{"url":"%s/%s","signature":"%s"},"windows-aarch64":{"url":"%s/%s","signature":"%s"},"linux-x86_64":{"url":"%s/%s","signature":"%s"}}}' \
             "$VERSION" "$TYPE" "$VERSION" \
             "$BASE_URL" "$MAC_FILE" "$MAC_SIG" \
             "$BASE_URL" "$MAC_FILE" "$MAC_SIG" \
-            "$BASE_URL" "$WIN_FILE" "$WIN_SIG" \
+            "$BASE_URL" "$WIN_X64_FILE" "$WIN_X64_SIG" \
+            "$BASE_URL" "$WIN_ARM64_FILE" "$WIN_ARM64_SIG" \
             "$BASE_URL" "$LINUX_FILE" "$LINUX_SIG")
           
           curl -X POST "$APP_URL/api/releases" \


### PR DESCRIPTION
With the rising popularity of Windows ARM 64 devices, such as the latest Surface / Snapdragon X laptops, recently released Snapdragon X2 devices and soon to be released Nvidia N1X SOC users are increasingly expecting native applications.

Built and tested both release ARM64 installers (.msi and .exe) on my fork using my Snapdragon X2 Elite Extreme based Asus Zenbook A16 running Windows 11 ARM 26H1.