### PR TITLE
fix(applications): index custom scan dirs reliably

### DIFF
--- a/src-tauri/src/application/index_watcher.rs
+++ b/src-tauri/src/application/index_watcher.rs
@@ -93,6 +93,26 @@ pub fn sync_result_to_event(result: &SyncResult) -> Option<IndexEvent> {
     })
 }
 
+/// Shared, mutable list of user-configured extra scan paths. One handle
+/// lives on `IndexWatcher`; an aliased clone is captured by the debouncer
+/// callback. See [`build_extras_state`] for why.
+type ExtrasState = Arc<Mutex<Vec<PathBuf>>>;
+
+/// Builds the shared extras state used by [`IndexWatcher::start`]. Returns
+/// the same [`ExtrasState`] twice: the first goes into `Self.extras`, the
+/// second is captured by the debouncer callback. Both names alias the same
+/// underlying allocation — that's load-bearing: writes to `Self.extras`
+/// from `set_extra_paths` must be visible to the callback that fires on FS
+/// events.
+///
+/// Extracted so the shared-`Arc` invariant can be regression-tested
+/// without standing up a Tauri `AppHandle`.
+fn build_extras_state(initial: Vec<PathBuf>) -> (ExtrasState, ExtrasState) {
+    let extras = Arc::new(Mutex::new(initial));
+    let callback_extras = Arc::clone(&extras);
+    (extras, callback_extras)
+}
+
 /// Long-lived watcher handle. Drop drops the debouncer which unwatches all
 /// paths, so this must be stored in managed state for the app's lifetime.
 pub struct IndexWatcher {
@@ -104,7 +124,7 @@ pub struct IndexWatcher {
     debouncer: Mutex<Debouncer<notify::RecommendedWatcher, RecommendedCache>>,
     // Shared with the debouncer closure so set_extra_paths writes are
     // visible to FS-event rescans.
-    extras: Arc<Mutex<Vec<PathBuf>>>,
+    extras: ExtrasState,
     app_handle: AppHandle,
     hub: Arc<IndexEventsHub>,
 }
@@ -122,10 +142,9 @@ impl IndexWatcher {
         let defaults = get_default_app_scan_paths();
         let initial_watch = compute_watch_set(&defaults, &initial_extras);
 
-        let extras = Arc::new(Mutex::new(initial_extras));
+        let (extras, callback_extras) = build_extras_state(initial_extras);
         let handler_app = app_handle.clone();
         let handler_hub = hub.clone();
-        let callback_extras = extras.clone();
 
         let mut debouncer = new_debouncer(
             DEBOUNCE_WINDOW,
@@ -165,10 +184,30 @@ impl IndexWatcher {
     }
 
     /// Replace the user-configured extra scan paths. Unwatches paths that
-    /// were removed, watches paths that were added, and runs an immediate
-    /// rescan against the new extras so existing apps in newly-added
-    /// directories land in the index without waiting for an FS event.
+    /// were removed, watches paths that were added. When the post-canonical
+    /// set actually differs from the previous one, kicks off a full rescan
+    /// in a detached background thread so apps already present in newly-
+    /// added directories land in the index without waiting for an FS event.
     /// Default paths are untouched.
+    ///
+    /// ### Why the rescan runs on a detached thread
+    ///
+    /// `on_debounced_batch` calls `sync_application_index`, which walks
+    /// every watched directory and diffs against the index — multi-second
+    /// work on machines with large `/Applications`. This function is called
+    /// synchronously from the `set_application_scan_paths` Tauri command,
+    /// so blocking here blocks both the bootstrap path (`initScanPathsSync`
+    /// fires on launcher init) and the Settings UI's awaited `invoke(...)`.
+    /// Mirrors the precedent at `lib.rs` where `IndexWatcher::start` was
+    /// detached for the same reason.
+    ///
+    /// ### Why the no-diff short-circuit
+    ///
+    /// At bootstrap, `initScanPathsSync` pushes the same paths the
+    /// constructor already received via `applicationService.init()`'s prior
+    /// scan. Without this short-circuit, the launcher would always run a
+    /// redundant second scan a few hundred ms after startup. Skipping it
+    /// when the canonical set is unchanged keeps that thread idle.
     ///
     /// Called from the `set_application_scan_paths` Tauri command when the
     /// user edits `additionalScanPaths` in settings.
@@ -179,7 +218,7 @@ impl IndexWatcher {
             .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()))
             .collect();
 
-        let extras_for_rescan = {
+        let needs_rescan = {
             let mut extras_guard = self.extras.lock().map_err(|_| AppError::Lock)?;
             let mut debouncer = self.debouncer.lock().map_err(|_| AppError::Lock)?;
 
@@ -219,11 +258,22 @@ impl IndexWatcher {
             }
 
             *extras_guard = new_extras.clone();
-            new_extras
+            old_canonical != new_canonical
         };
 
-        // Pick up existing apps in newly-added dirs without waiting for an FS event.
-        on_debounced_batch(&self.app_handle, &self.hub, extras_for_rescan);
+        if !needs_rescan {
+            return Ok(());
+        }
+
+        // Detached rescan — see the doc comment above. Subscribers receive
+        // `ApplicationsChanged` through `IndexEventsHub` the same way they
+        // would for an FS-event-driven rescan; the dispatch contract is
+        // identical regardless of which thread invoked `on_debounced_batch`.
+        let app_handle = self.app_handle.clone();
+        let hub = self.hub.clone();
+        std::thread::spawn(move || {
+            on_debounced_batch(&app_handle, &hub, new_extras);
+        });
 
         Ok(())
     }
@@ -506,34 +556,36 @@ mod tests {
         );
     }
 
-    // Regression: callback used to read a separate Mutex from the one
-    // set_extra_paths wrote to.
+    // Regression: an earlier shape of `start()` constructed two separate
+    // allocations — `Self.extras` was a bare `Mutex<Vec<PathBuf>>`, and the
+    // debouncer callback captured a *different* `Arc<Mutex<Vec<PathBuf>>>`
+    // seeded with a clone of the same initial Vec. Writes via
+    // `set_extra_paths` (against `Self.extras`) were therefore invisible
+    // to the callback, so re-arming the watcher worked but the post-event
+    // rescan ran with stale extras. The fix unified both names onto a
+    // single `Arc` allocation. This test pins that invariant.
+    //
+    // `Arc::ptr_eq` is the load-bearing assertion: it would have returned
+    // false against the pre-fix construction (two `Arc::new(Mutex::new(...))`
+    // calls produce distinct allocations even with identical contents).
     #[test]
-    fn set_extra_paths_propagates_to_debouncer_callback() {
-        let extras: Arc<Mutex<Vec<PathBuf>>> = Arc::new(Mutex::new(Vec::new()));
-        let callback_extras = extras.clone();
-
-        let snapshot_via_callback = || {
-            callback_extras
-                .lock()
-                .map(|g| g.clone())
-                .unwrap_or_default()
-        };
+    fn build_extras_state_aliases_a_single_arc() {
+        let (self_extras, callback_extras) =
+            build_extras_state(vec![PathBuf::from("/Users/test/Apps")]);
 
         assert!(
-            snapshot_via_callback().is_empty(),
-            "fresh watcher: callback sees empty extras"
+            Arc::ptr_eq(&self_extras, &callback_extras),
+            "Self.extras and the debouncer callback must clone-share the \
+             same Arc — otherwise set_extra_paths writes won't reach the \
+             FS-event rescan path"
         );
 
-        let new_extras = vec![PathBuf::from("/Users/test/Applications")];
-        *extras.lock().unwrap() = new_extras.clone();
-
-        assert_eq!(
-            snapshot_via_callback(),
-            new_extras,
-            "after set_extra_paths writes, the debouncer callback must see \
-             the new value — not a stale snapshot from start()"
-        );
+        // Demonstrate the consequence: a write through one handle is
+        // observable through the other (a property only true because
+        // they alias the same Mutex).
+        let new_extras = vec![PathBuf::from("/Users/test/Other")];
+        *self_extras.lock().unwrap() = new_extras.clone();
+        assert_eq!(*callback_extras.lock().unwrap(), new_extras);
     }
 
     #[test]

--- a/src-tauri/src/application/index_watcher.rs
+++ b/src-tauri/src/application/index_watcher.rs
@@ -102,7 +102,11 @@ pub struct IndexWatcher {
     // public type alias `Debouncer<RecommendedWatcher, RecommendedCache>`
     // is the stable surface.
     debouncer: Mutex<Debouncer<notify::RecommendedWatcher, RecommendedCache>>,
-    extras: Mutex<Vec<PathBuf>>,
+    // Shared with the debouncer closure so set_extra_paths writes are
+    // visible to FS-event rescans.
+    extras: Arc<Mutex<Vec<PathBuf>>>,
+    app_handle: AppHandle,
+    hub: Arc<IndexEventsHub>,
 }
 
 impl IndexWatcher {
@@ -118,10 +122,10 @@ impl IndexWatcher {
         let defaults = get_default_app_scan_paths();
         let initial_watch = compute_watch_set(&defaults, &initial_extras);
 
+        let extras = Arc::new(Mutex::new(initial_extras));
         let handler_app = app_handle.clone();
         let handler_hub = hub.clone();
-        let handler_extras = Arc::new(Mutex::new(initial_extras.clone()));
-        let callback_extras = handler_extras.clone();
+        let callback_extras = extras.clone();
 
         let mut debouncer = new_debouncer(
             DEBOUNCE_WINDOW,
@@ -152,18 +156,19 @@ impl IndexWatcher {
             }
         }
 
-        // `handler_extras` tracks the currently-watched extras so the debounce
-        // callback always sees the latest set; `self.extras` mirrors the same
-        // value so `set_extra_paths` can compute the diff.
         Ok(Arc::new(Self {
             debouncer: Mutex::new(debouncer),
-            extras: Mutex::new(initial_extras),
+            extras,
+            app_handle,
+            hub,
         }))
     }
 
     /// Replace the user-configured extra scan paths. Unwatches paths that
-    /// were removed, watches paths that were added. Default paths are
-    /// untouched.
+    /// were removed, watches paths that were added, and runs an immediate
+    /// rescan against the new extras so existing apps in newly-added
+    /// directories land in the index without waiting for an FS event.
+    /// Default paths are untouched.
     ///
     /// Called from the `set_application_scan_paths` Tauri command when the
     /// user edits `additionalScanPaths` in settings.
@@ -174,45 +179,52 @@ impl IndexWatcher {
             .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()))
             .collect();
 
-        let mut extras_guard = self.extras.lock().map_err(|_| AppError::Lock)?;
-        let mut debouncer = self.debouncer.lock().map_err(|_| AppError::Lock)?;
+        let extras_for_rescan = {
+            let mut extras_guard = self.extras.lock().map_err(|_| AppError::Lock)?;
+            let mut debouncer = self.debouncer.lock().map_err(|_| AppError::Lock)?;
 
-        let old_canonical: HashSet<PathBuf> = extras_guard
-            .iter()
-            .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()))
-            .collect();
-        let new_canonical: HashSet<PathBuf> = new_extras
-            .iter()
-            .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()))
-            .collect();
+            let old_canonical: HashSet<PathBuf> = extras_guard
+                .iter()
+                .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()))
+                .collect();
+            let new_canonical: HashSet<PathBuf> = new_extras
+                .iter()
+                .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()))
+                .collect();
 
-        // Unwatch paths removed from extras — but only if they're not
-        // defaults. A user-added path that happens to be a default stays
-        // watched regardless.
-        for removed in old_canonical.difference(&new_canonical) {
-            if default_set.contains(removed) {
-                continue;
+            // Unwatch paths removed from extras — but only if they're not
+            // defaults. A user-added path that happens to be a default stays
+            // watched regardless.
+            for removed in old_canonical.difference(&new_canonical) {
+                if default_set.contains(removed) {
+                    continue;
+                }
+                if let Err(e) = debouncer.unwatch(removed) {
+                    debug!("[index_watcher] unwatch {:?} skipped: {}", removed, e);
+                }
             }
-            if let Err(e) = debouncer.unwatch(removed) {
-                debug!("[index_watcher] unwatch {:?} skipped: {}", removed, e);
-            }
-        }
 
-        // Watch newly-added paths that aren't already watched by defaults.
-        for added in new_canonical.difference(&old_canonical) {
-            if default_set.contains(added) {
-                continue;
+            // Watch newly-added paths that aren't already watched by defaults.
+            for added in new_canonical.difference(&old_canonical) {
+                if default_set.contains(added) {
+                    continue;
+                }
+                if !added.exists() {
+                    debug!("[index_watcher] skipping non-existent extra {:?}", added);
+                    continue;
+                }
+                if let Err(e) = debouncer.watch(added, RecursiveMode::Recursive) {
+                    warn!("[index_watcher] failed to watch {:?}: {}", added, e);
+                }
             }
-            if !added.exists() {
-                debug!("[index_watcher] skipping non-existent extra {:?}", added);
-                continue;
-            }
-            if let Err(e) = debouncer.watch(added, RecursiveMode::Recursive) {
-                warn!("[index_watcher] failed to watch {:?}: {}", added, e);
-            }
-        }
 
-        *extras_guard = new_extras;
+            *extras_guard = new_extras.clone();
+            new_extras
+        };
+
+        // Pick up existing apps in newly-added dirs without waiting for an FS event.
+        on_debounced_batch(&self.app_handle, &self.hub, extras_for_rescan);
+
         Ok(())
     }
 
@@ -491,6 +503,36 @@ mod tests {
                 removed: 0,
                 total: 1,
             }
+        );
+    }
+
+    // Regression: callback used to read a separate Mutex from the one
+    // set_extra_paths wrote to.
+    #[test]
+    fn set_extra_paths_propagates_to_debouncer_callback() {
+        let extras: Arc<Mutex<Vec<PathBuf>>> = Arc::new(Mutex::new(Vec::new()));
+        let callback_extras = extras.clone();
+
+        let snapshot_via_callback = || {
+            callback_extras
+                .lock()
+                .map(|g| g.clone())
+                .unwrap_or_default()
+        };
+
+        assert!(
+            snapshot_via_callback().is_empty(),
+            "fresh watcher: callback sees empty extras"
+        );
+
+        let new_extras = vec![PathBuf::from("/Users/test/Applications")];
+        *extras.lock().unwrap() = new_extras.clone();
+
+        assert_eq!(
+            snapshot_via_callback(),
+            new_extras,
+            "after set_extra_paths writes, the debouncer callback must see \
+             the new value — not a stale snapshot from start()"
         );
     }
 

--- a/src/services/appInitializer.ts
+++ b/src/services/appInitializer.ts
@@ -110,6 +110,9 @@ export const appInitializer = {
         await clipboardHistoryService.initialize();
         logService.info(`Clipboard history service initialized.`);
 
+        // Must precede applicationService.init() — its first scan reads additionalScanPaths.
+        await settingsService.init();
+
         await applicationService.init();
 
         // Push the user-configured additionalScanPaths down to the Rust


### PR DESCRIPTION
Apps in custom scan directories weren't showing in search.

The application service was running its first scan before settings finished loading, so the Rust indexer always saw empty `additionalScanPaths`.

The file-system watcher was keeping two copies of the extras list. Tauri updated one, and debounce read the other, so newly watched paths never made it into the index.

Rmoving/re-adding a dir only triggered a rescan on the next FS event.

Now apps in custom dirs should appear at startup, and changes should be reflected immediately.

Test:
- Add a custom app dir in Settings, confirm relevant apps show in the launcher.
- Quit and relaunch, confirm the same apps appear.
- Remove the custom dir, confirm the apps no longer appear.
- Re-add the dir, confirm the apps re-appear.
- Drop a new `.app` into the dir, confirm it appears without a relaunch.