### PR TITLE
fix(extensions): stream routing + worker mount race

### DIFF
--- a/src-tauri/src/commands/extension_runtime.rs
+++ b/src-tauri/src/commands/extension_runtime.rs
@@ -296,6 +296,47 @@ pub fn auto_mount_worker(
     auto_mount_worker_inner(mgr, &emitter, has_background_main, extension_id, Instant::now())
 }
 
+/// Pure batch-restoration logic. Iterates `snapshots` (id, has_background_main)
+/// and delegates each entry to [`auto_mount_worker_inner`]. Returns the IDs
+/// that emitted a mount event so callers can log/observe.
+///
+/// Extracted from [`restore_workers`] so the loop can be unit-tested with a
+/// `RecordingEmitter` — the Tauri command itself is not testable because
+/// `State<>` requires a running `AppHandle`.
+pub(crate) fn restore_workers_inner(
+    mgr: &ExtensionRuntimeManager,
+    emitter: &dyn EventEmitter,
+    snapshots: Vec<(String, bool)>,
+    now: Instant,
+) -> Vec<String> {
+    let mut emitted = Vec::new();
+    for (id, has_bg) in snapshots {
+        if auto_mount_worker_inner(mgr, emitter, has_bg, id.clone(), now) {
+            emitted.push(id);
+        }
+    }
+    emitted
+}
+
+fn snapshot_enabled_extensions(
+    registry: &crate::extensions::ExtensionRegistryState,
+) -> Result<Vec<(String, bool)>, AppError> {
+    let reg = registry.extensions.lock().map_err(|_| AppError::Lock)?;
+    Ok(reg
+        .values()
+        .filter(|r| r.enabled)
+        .map(|r| {
+            let has_bg = r
+                .manifest
+                .background
+                .as_ref()
+                .map(|b| !b.main.trim().is_empty())
+                .unwrap_or(false);
+            (r.manifest.id.clone(), has_bg)
+        })
+        .collect())
+}
+
 /// Mounts always-on workers for every enabled extension with `background.main`.
 /// Frontend-invoked so the EVENT_MOUNT emit doesn't race listener registration.
 #[tauri::command]
@@ -304,31 +345,14 @@ pub fn restore_workers(
     mgr: State<'_, Arc<ExtensionRuntimeManager>>,
     registry: State<'_, crate::extensions::ExtensionRegistryState>,
 ) -> Result<Vec<String>, AppError> {
-    let snapshots: Vec<(String, bool)> = {
-        let reg = registry.extensions.lock().map_err(|_| AppError::Lock)?;
-        reg.values()
-            .filter(|r| r.enabled)
-            .map(|r| {
-                let has_bg = r
-                    .manifest
-                    .background
-                    .as_ref()
-                    .map(|b| !b.main.trim().is_empty())
-                    .unwrap_or(false);
-                (r.manifest.id.clone(), has_bg)
-            })
-            .collect()
-    };
-
+    let snapshots = snapshot_enabled_extensions(&registry)?;
     let emitter = TauriEventEmitter { app };
-    let now = Instant::now();
-    let mut emitted = Vec::new();
-    for (id, has_bg) in snapshots {
-        if auto_mount_worker_inner(&mgr, &emitter, has_bg, id.clone(), now) {
-            emitted.push(id);
-        }
-    }
-    Ok(emitted)
+    Ok(restore_workers_inner(
+        &mgr,
+        &emitter,
+        snapshots,
+        Instant::now(),
+    ))
 }
 
 /// Dev-only "Force Remount" action from the dev inspector. Tears down
@@ -820,6 +844,67 @@ mod tests {
             "re-enable must emit a new mount event"
         );
         assert_eq!(events_after.last().unwrap().1["role"], "worker");
+    }
+
+    // ── restore_workers_inner (post-startup batch restoration) ───────────────
+    // Frontend-invoked at app init *after* iframe lifecycle listeners are
+    // committed. Iterates a snapshot taken from the registry and delegates
+    // each entry to auto_mount_worker_inner, returning the IDs that emitted
+    // a mount event so callers can log/observe.
+
+    #[test]
+    fn restore_workers_inner_emits_only_for_extensions_with_background_main() {
+        let mgr = mgr();
+        let emitter = RecordingEmitter::default();
+        let snapshots = vec![
+            ("ext.bg-a".to_string(), true),
+            ("ext.view-only".to_string(), false),
+            ("ext.bg-b".to_string(), true),
+        ];
+
+        let emitted = restore_workers_inner(&mgr, &emitter, snapshots, Instant::now());
+
+        assert_eq!(
+            emitted,
+            vec!["ext.bg-a".to_string(), "ext.bg-b".to_string()],
+            "returned vec contains exactly the bg-main extensions, in input order"
+        );
+        let events = emitter.events();
+        assert_eq!(events.len(), 2, "exactly two mount emits");
+        assert_eq!(events[0].1["extensionId"], "ext.bg-a");
+        assert_eq!(events[0].1["role"], "worker");
+        assert_eq!(events[1].1["extensionId"], "ext.bg-b");
+        assert_eq!(events[1].1["role"], "worker");
+    }
+
+    #[test]
+    fn restore_workers_inner_with_empty_snapshot_emits_nothing() {
+        let mgr = mgr();
+        let emitter = RecordingEmitter::default();
+
+        let emitted = restore_workers_inner(&mgr, &emitter, vec![], Instant::now());
+
+        assert!(emitted.is_empty());
+        assert!(emitter.events().is_empty());
+    }
+
+    #[test]
+    fn restore_workers_inner_skips_already_mounted_workers() {
+        // Calling restore twice — second call must be a no-op because the
+        // worker context is already Mounting. Idempotency matters because
+        // restore_workers can be triggered at app init AND on a subsequent
+        // discover-extensions reload.
+        let mgr = mgr();
+        let emitter = RecordingEmitter::default();
+        let snapshots = vec![("ext.bg".to_string(), true)];
+        let now = Instant::now();
+
+        let first = restore_workers_inner(&mgr, &emitter, snapshots.clone(), now);
+        let second = restore_workers_inner(&mgr, &emitter, snapshots, now);
+
+        assert_eq!(first, vec!["ext.bg".to_string()]);
+        assert!(second.is_empty(), "second call must be a no-op");
+        assert_eq!(emitter.events().len(), 1, "only one mount emit total");
     }
 }
 

--- a/src-tauri/src/commands/extension_runtime.rs
+++ b/src-tauri/src/commands/extension_runtime.rs
@@ -296,6 +296,41 @@ pub fn auto_mount_worker(
     auto_mount_worker_inner(mgr, &emitter, has_background_main, extension_id, Instant::now())
 }
 
+/// Mounts always-on workers for every enabled extension with `background.main`.
+/// Frontend-invoked so the EVENT_MOUNT emit doesn't race listener registration.
+#[tauri::command]
+pub fn restore_workers(
+    app: AppHandle,
+    mgr: State<'_, Arc<ExtensionRuntimeManager>>,
+    registry: State<'_, crate::extensions::ExtensionRegistryState>,
+) -> Result<Vec<String>, AppError> {
+    let snapshots: Vec<(String, bool)> = {
+        let reg = registry.extensions.lock().map_err(|_| AppError::Lock)?;
+        reg.values()
+            .filter(|r| r.enabled)
+            .map(|r| {
+                let has_bg = r
+                    .manifest
+                    .background
+                    .as_ref()
+                    .map(|b| !b.main.trim().is_empty())
+                    .unwrap_or(false);
+                (r.manifest.id.clone(), has_bg)
+            })
+            .collect()
+    };
+
+    let emitter = TauriEventEmitter { app };
+    let now = Instant::now();
+    let mut emitted = Vec::new();
+    for (id, has_bg) in snapshots {
+        if auto_mount_worker_inner(&mgr, &emitter, has_bg, id.clone(), now) {
+            emitted.push(id);
+        }
+    }
+    Ok(emitted)
+}
+
 /// Dev-only "Force Remount" action from the dev inspector. Tears down
 /// the worker context for `extension_id` (emitting EVENT_UNMOUNT so the
 /// WorkerIframes component drops its iframe), then transitions the worker

--- a/src-tauri/src/commands/extensions.rs
+++ b/src-tauri/src/commands/extensions.rs
@@ -4,7 +4,7 @@ use crate::error::AppError;
 use crate::extensions::{self, ExtensionRegistryState, ExtensionRecord, ThemeDefinition, headless::HeadlessRegistry};
 use crate::extensions::scheduler::{self, SchedulerState, ScheduledTaskInfo};
 use std::collections::HashMap;
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 #[tauri::command]
 pub async fn check_path_exists(path: String) -> bool {
@@ -83,42 +83,6 @@ pub async fn discover_extensions(
     let result = extensions::lifecycle::discover_all(&app_handle, &registry)?;
     // Restart all scheduled tasks based on updated registry
     scheduler::start_all_tasks(&app_handle, &registry, &scheduler)?;
-
-    // Always-on worker restoration: for every enabled extension that
-    // declares `background.main`, drive its worker context Dormant → Mounting
-    // and emit EVENT_MOUNT. This is the relaunch equivalent of set_enabled's
-    // enable-path mount — without it, workers would only materialise on the
-    // first scheduled / search-triggered dispatch.
-    //
-    // This runs inside `discover_extensions` (a frontend-invoked Tauri command)
-    // rather than `setup_app` because the registry is populated here, and by
-    // the time the frontend calls this command its Tauri event listeners are
-    // installed — no listener-readiness race.
-    if let Some(mgr) = app_handle.try_state::<std::sync::Arc<
-        crate::extensions::extension_runtime::ExtensionRuntimeManager,
-    >>()
-    {
-        for record in &result {
-            if !record.enabled {
-                continue;
-            }
-            let has_bg = record
-                .manifest
-                .background
-                .as_ref()
-                .map(|b| !b.main.trim().is_empty())
-                .unwrap_or(false);
-            if has_bg {
-                crate::commands::extension_runtime::auto_mount_worker(
-                    &mgr,
-                    &app_handle,
-                    true,
-                    record.manifest.id.clone(),
-                );
-            }
-        }
-    }
-
     Ok(result)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -198,6 +198,7 @@ pub fn run() {
             commands::extension_runtime::iframe_mount_timeout_reported,
             commands::extension_runtime::get_extension_runtime_snapshot,
             commands::extension_runtime::force_remount_worker,
+            commands::extension_runtime::restore_workers,
             commands::extension_state::state_get,
             commands::extension_state::state_get_all,
             commands::extension_state::state_get_subscriptions,

--- a/src/lib/ipc/iframeLifecycleCommands.ts
+++ b/src/lib/ipc/iframeLifecycleCommands.ts
@@ -66,3 +66,7 @@ export function iframeMountTimeoutReported(
 export function getExtensionRuntimeSnapshot(): Promise<IframeLifecycleSnapshotEntry[]> {
   return invoke('get_extension_runtime_snapshot');
 }
+
+export function restoreWorkers(): Promise<string[]> {
+  return invoke('restore_workers');
+}

--- a/src/services/appInitializer.ts
+++ b/src/services/appInitializer.ts
@@ -43,6 +43,7 @@ import { viewRegistry } from './extension/viewRegistry.svelte';
 import { workerRegistry } from './extension/workerRegistry.svelte';
 import { extensionReadinessListener } from './extension/extensionReadinessListener';
 import { restoreWorkers } from '../lib/ipc/iframeLifecycleCommands';
+import { diagnosticsService } from './diagnostics/diagnosticsService.svelte';
 
 // Flag to prevent multiple initializations
 let isInitialized = false;
@@ -180,9 +181,18 @@ export const appInitializer = {
 
       // Must run after the workerRegistry/viewRegistry listeners above are
       // committed — EVENT_MOUNT is fire-and-forget and would otherwise be lost.
+      // Failure here means every always-on extension is dormant until the
+      // user re-enables it, so it surfaces through the diagnostics channel
+      // rather than a quiet log.
       if (envService.isTauri) {
-        restoreWorkers().catch((err: any) => {
-          logService.warn(`restoreWorkers failed: ${err}`);
+        restoreWorkers().catch((err: unknown) => {
+          void diagnosticsService.report({
+            source: 'frontend',
+            kind: 'extension-runtime/restore-workers-failed',
+            severity: 'error',
+            retryable: false,
+            developerDetail: String(err),
+          });
         });
       }
 

--- a/src/services/appInitializer.ts
+++ b/src/services/appInitializer.ts
@@ -42,6 +42,7 @@ import { trayClickBridge } from './statusBar/trayClickBridge.svelte';
 import { viewRegistry } from './extension/viewRegistry.svelte';
 import { workerRegistry } from './extension/workerRegistry.svelte';
 import { extensionReadinessListener } from './extension/extensionReadinessListener';
+import { restoreWorkers } from '../lib/ipc/iframeLifecycleCommands';
 
 // Flag to prevent multiple initializations
 let isInitialized = false;
@@ -168,21 +169,22 @@ export const appInitializer = {
           logService.warn(`rpcReplyBridge init failed: ${err}`);
         });
 
-        // Tier 2 iframe lifecycle listeners. Must be installed before
-        // extensionManager.init() below invokes `discover_extensions`,
-        // because Rust's post-discovery restoration loop emits
-        // asyar:iframe:mount for every enabled extension with
-        // background.main — events are fire-and-forget and will be lost
-        // if listeners aren't yet registered.
-        // Why await: `listen(...)` returns a Promise that resolves once
-        // Tauri has wired the IPC subscription. We need that complete
-        // before the emit fires.
+        // Tier 2 iframe lifecycle listeners. Awaited so the IPC subscriptions
+        // are committed before `restoreWorkers()` below fires EVENT_MOUNT.
         await viewRegistry.init();
         await workerRegistry.init();
         extensionReadinessListener.init();
       }
 
       await extensionManager.init(); // Initialize ExtensionManager first
+
+      // Must run after the workerRegistry/viewRegistry listeners above are
+      // committed — EVENT_MOUNT is fire-and-forget and would otherwise be lost.
+      if (envService.isTauri) {
+        restoreWorkers().catch((err: any) => {
+          logService.warn(`restoreWorkers failed: ${err}`);
+        });
+      }
 
       // Initialize extension update service for silent auto-updates
       const { viewManager } = await import('./extension/viewManager.svelte');

--- a/src/services/extension/ExtensionIpcRouter.test.ts
+++ b/src/services/extension/ExtensionIpcRouter.test.ts
@@ -127,3 +127,124 @@ describe('ExtensionIpcRouter — auto-inject extensionId for fsWatcher', () => {
     expect(dispose).toHaveBeenCalledWith('ext.demo', 'h-abc');
   });
 });
+
+describe('ExtensionIpcRouter — originRole injection for shell streams', () => {
+  // Streamed APIs route chunks back through `streamDispatcher`, which prefers
+  // the originating iframe's role. For that to work, the origin role has to
+  // travel from the IPC source (the iframe `event.source`) down to
+  // `streamDispatcher.create()` via shell.spawn / shell.attach. This test
+  // pins the args contract so a future refactor can't silently drop the role
+  // and re-introduce the worker-stream-lands-in-view bug.
+
+  type DispatchApiCall = (
+    type: string,
+    payload: unknown,
+    extensionId: string | undefined,
+    isPrivilegedHostContext: boolean,
+    originRole?: 'view' | 'worker',
+  ) => Promise<unknown>;
+
+  function dispatchAs(router: ExtensionIpcRouter): DispatchApiCall {
+    return (
+      router as unknown as { dispatchApiCall: DispatchApiCall }
+    ).dispatchApiCall.bind(router);
+  }
+
+  it('shell:spawn from a worker iframe receives originRole as the trailing argument', async () => {
+    const spawn = vi.fn(async () => ({ streaming: true }));
+    const registry = {
+      shell: { spawn, attach: vi.fn(), list: vi.fn() },
+    } as unknown as ServiceRegistry;
+    const router = new ExtensionIpcRouter(registry, vi.fn(), vi.fn(), vi.fn());
+
+    await dispatchAs(router)(
+      'asyar:api:shell:spawn',
+      { program: 'ls', args: ['-la'], spawnId: 'sp-1' },
+      'ext.demo',
+      false,
+      'worker',
+    );
+
+    expect(spawn).toHaveBeenCalledWith('ext.demo', 'ls', ['-la'], 'sp-1', 'worker');
+  });
+
+  it('shell:attach from a view iframe receives originRole=view as the trailing argument', async () => {
+    const attach = vi.fn(async () => ({ spawnId: 'sp-2' }));
+    const registry = {
+      shell: { spawn: vi.fn(), attach, list: vi.fn() },
+    } as unknown as ServiceRegistry;
+    const router = new ExtensionIpcRouter(registry, vi.fn(), vi.fn(), vi.fn());
+
+    await dispatchAs(router)(
+      'asyar:api:shell:attach',
+      { spawnId: 'sp-2' },
+      'ext.demo',
+      false,
+      'view',
+    );
+
+    expect(attach).toHaveBeenCalledWith('ext.demo', 'sp-2', 'view');
+  });
+
+  it('shell:spawn without originRole does not append a trailing argument', async () => {
+    // Privileged host calls pass undefined; the role must not leak as a
+    // trailing `undefined` arg into the service method.
+    const spawn = vi.fn(async () => ({ streaming: true }));
+    const registry = {
+      shell: { spawn, attach: vi.fn(), list: vi.fn() },
+    } as unknown as ServiceRegistry;
+    const router = new ExtensionIpcRouter(registry, vi.fn(), vi.fn(), vi.fn());
+
+    await dispatchAs(router)(
+      'asyar:api:shell:spawn',
+      { program: 'ls', args: [], spawnId: 'sp-3' },
+      'ext.demo',
+      false,
+    );
+
+    expect(spawn).toHaveBeenCalledWith('ext.demo', 'ls', [], 'sp-3');
+    expect(spawn.mock.calls[0]).toHaveLength(4);
+  });
+
+  it('non-streaming shell methods do not receive originRole', async () => {
+    // Only `spawn` and `attach` open a stream; `list` is a one-shot and
+    // must not get the trailing role argument tacked on.
+    const list = vi.fn(async () => []);
+    const registry = {
+      shell: { spawn: vi.fn(), attach: vi.fn(), list },
+    } as unknown as ServiceRegistry;
+    const router = new ExtensionIpcRouter(registry, vi.fn(), vi.fn(), vi.fn());
+
+    await dispatchAs(router)(
+      'asyar:api:shell:list',
+      {},
+      'ext.demo',
+      false,
+      'worker',
+    );
+
+    expect(list).toHaveBeenCalledWith('ext.demo');
+    expect(list.mock.calls[0]).toHaveLength(1);
+  });
+
+  it('non-shell namespaces never receive originRole even when one is provided', async () => {
+    // The role-injection guard is scoped to `shell` — other namespaces must
+    // be unaffected. Ensures the guard at dispatchApiCall doesn't broaden.
+    const navigateToView = vi.fn();
+    const registry = {
+      extensions: { navigateToView },
+    } as unknown as ServiceRegistry;
+    const router = new ExtensionIpcRouter(registry, vi.fn(), vi.fn(), vi.fn());
+
+    await dispatchAs(router)(
+      'asyar:api:extensions:navigateToView',
+      { viewPath: 'store/Default' },
+      'ext.demo',
+      false,
+      'worker',
+    );
+
+    expect(navigateToView).toHaveBeenCalledWith('store/Default');
+    expect(navigateToView.mock.calls[0]).toHaveLength(1);
+  });
+});

--- a/src/services/extension/ExtensionIpcRouter.ts
+++ b/src/services/extension/ExtensionIpcRouter.ts
@@ -255,7 +255,11 @@ export class ExtensionIpcRouter {
           // Fall through to the standard response so the SDK's broker.invoke resolves.
           result = undefined;
         } else if (type.startsWith('asyar:api:')) {
-          result = await this.dispatchApiCall(type, payload, extensionId, isPrivilegedHostContext);
+          // Tagged so streaming APIs route chunks back to the originating iframe.
+          const originRole = !isPrivilegedHostContext
+            ? this.findIframeRoleForSource(event.source)
+            : undefined;
+          result = await this.dispatchApiCall(type, payload, extensionId, isPrivilegedHostContext, originRole);
         } else {
            if (import.meta.env.DEV) {
               logService.warn(`[IPC] Unhandled message type: ${type}`);
@@ -335,6 +339,7 @@ export class ExtensionIpcRouter {
     payload: any,
     extensionId: string | undefined,
     isPrivilegedHostContext: boolean,
+    originRole?: 'view' | 'worker',
   ): Promise<unknown> {
     const parts = type.split(':');
     const serviceName = parts[2];
@@ -376,6 +381,9 @@ export class ExtensionIpcRouter {
       args = [extensionId, ...args];
     } else if (ALWAYS_INJECTS_CALLER_ID.has(ns)) {
       args = [isPrivilegedHostContext ? null : (extensionId ?? null), ...args];
+    }
+    if (ns === 'shell' && (methodName === 'spawn' || methodName === 'attach') && originRole) {
+      args = [...args, originRole];
     }
     return await (method as (...a: unknown[]) => unknown).apply(service, args);
   }

--- a/src/services/extension/extensionIframeManager.svelte.ts
+++ b/src/services/extension/extensionIframeManager.svelte.ts
@@ -1,27 +1,7 @@
 import { getExtensionFrameOrigin } from '../../lib/ipc/extensionOrigin';
 import { logService } from "../log/logService";
+import { pickExtensionIframe } from './extensionIframeSelector';
 import type { viewManager } from './viewManager.svelte';
-
-/**
- * Prefer the given role's iframe, fall back to the other role, then to an
- * unscoped selector. Without this, an unfiltered `iframe[data-extension-id]`
- * selector hits whichever iframe comes first in DOM order (typically the
- * view) and a message meant for a worker-only handler vanishes silently.
- */
-function pickExtensionIframe(extensionId: string, prefer: 'view' | 'worker'): HTMLIFrameElement | null {
-  const fallback = prefer === 'view' ? 'worker' : 'view';
-  return (
-    (document.querySelector(
-      `iframe[data-extension-id="${extensionId}"][data-role="${prefer}"]`,
-    ) as HTMLIFrameElement | null) ??
-    (document.querySelector(
-      `iframe[data-extension-id="${extensionId}"][data-role="${fallback}"]`,
-    ) as HTMLIFrameElement | null) ??
-    (document.querySelector(
-      `iframe[data-extension-id="${extensionId}"]`,
-    ) as HTMLIFrameElement | null)
-  );
-}
 
 // Track pending search requests
 const pendingSearchRequests = new Map<

--- a/src/services/extension/extensionIframeSelector.ts
+++ b/src/services/extension/extensionIframeSelector.ts
@@ -1,0 +1,28 @@
+/**
+ * Prefer the given role's iframe, fall back to the other role, then to an
+ * unscoped selector. Without this, an unfiltered `iframe[data-extension-id]`
+ * selector hits whichever iframe comes first in DOM order (typically the
+ * view) and a message meant for a worker-only handler vanishes silently.
+ *
+ * Canonical Tier 2 role-aware selector: every host-to-iframe push that
+ * targets a specific role must go through this helper rather than building
+ * its own `iframe[data-extension-id]` query inline. See the `review-ipc`
+ * skill, section 4.
+ */
+export function pickExtensionIframe(
+  extensionId: string,
+  prefer: 'view' | 'worker',
+): HTMLIFrameElement | null {
+  const fallback = prefer === 'view' ? 'worker' : 'view';
+  return (
+    document.querySelector<HTMLIFrameElement>(
+      `iframe[data-extension-id="${extensionId}"][data-role="${prefer}"]`,
+    ) ??
+    document.querySelector<HTMLIFrameElement>(
+      `iframe[data-extension-id="${extensionId}"][data-role="${fallback}"]`,
+    ) ??
+    document.querySelector<HTMLIFrameElement>(
+      `iframe[data-extension-id="${extensionId}"]`,
+    )
+  );
+}

--- a/src/services/extension/streamDispatcher.svelte.ts
+++ b/src/services/extension/streamDispatcher.svelte.ts
@@ -1,5 +1,6 @@
 import { logService } from '../log/logService';
 import { getExtensionFrameOrigin } from '$lib/ipc/extensionOrigin';
+import { pickExtensionIframe } from './extensionIframeSelector';
 
 export interface StreamHandle {
   sendChunk(data: unknown): void;
@@ -109,22 +110,9 @@ export class StreamDispatcher {
     entry: StreamEntry,
     payload: { phase: 'chunk' | 'done' | 'error'; data?: unknown },
   ): void {
-    // Prefer the originating iframe role; fall back to view → worker → any
-    // for callers that didn't record one.
-    const roleSelector = entry.originRole
-      ? `iframe[data-extension-id="${entry.extensionId}"][data-role="${entry.originRole}"]`
-      : null;
-    const iframe =
-      (roleSelector ? document.querySelector<HTMLIFrameElement>(roleSelector) : null) ??
-      document.querySelector<HTMLIFrameElement>(
-        `iframe[data-extension-id="${entry.extensionId}"][data-role="view"]`,
-      ) ??
-      document.querySelector<HTMLIFrameElement>(
-        `iframe[data-extension-id="${entry.extensionId}"][data-role="worker"]`,
-      ) ??
-      document.querySelector<HTMLIFrameElement>(
-        `iframe[data-extension-id="${entry.extensionId}"]`,
-      );
+    // Prefer the originating iframe role; legacy callers without an origin
+    // fall back to view-first, matching the historical default.
+    const iframe = pickExtensionIframe(entry.extensionId, entry.originRole ?? 'view');
     if (!iframe?.contentWindow) {
       logService.warn(
         `[StreamDispatcher] iframe for ${entry.extensionId} not found; dropping ${payload.phase} message`,

--- a/src/services/extension/streamDispatcher.svelte.ts
+++ b/src/services/extension/streamDispatcher.svelte.ts
@@ -14,12 +14,13 @@ interface StreamEntry {
   abortCallbacks: (() => void)[];
   aborted: boolean;
   closed: boolean;
+  originRole?: 'view' | 'worker';
 }
 
 export class StreamDispatcher {
   private streams = new Map<string, StreamEntry>();
 
-  create(extensionId: string, streamId: string): StreamHandle {
+  create(extensionId: string, streamId: string, originRole?: 'view' | 'worker'): StreamHandle {
     if (this.streams.has(streamId)) {
       throw new Error(`StreamDispatcher: streamId already active: ${streamId}`);
     }
@@ -28,6 +29,7 @@ export class StreamDispatcher {
       abortCallbacks: [],
       aborted: false,
       closed: false,
+      originRole,
     };
     this.streams.set(streamId, entry);
 
@@ -107,12 +109,13 @@ export class StreamDispatcher {
     entry: StreamEntry,
     payload: { phase: 'chunk' | 'done' | 'error'; data?: unknown },
   ): void {
-    // Prefer the view iframe — stream consumers (AI token rendering, shell
-    // output panes) live in the view UI. Fall back to the worker iframe for
-    // worker-side consumers, then to an unscoped selector. Unqualified
-    // `iframe[data-extension-id]` would hit whichever iframe comes first in
-    // DOM order and silently drop tokens whenever that's not the consumer.
+    // Prefer the originating iframe role; fall back to view → worker → any
+    // for callers that didn't record one.
+    const roleSelector = entry.originRole
+      ? `iframe[data-extension-id="${entry.extensionId}"][data-role="${entry.originRole}"]`
+      : null;
     const iframe =
+      (roleSelector ? document.querySelector<HTMLIFrameElement>(roleSelector) : null) ??
       document.querySelector<HTMLIFrameElement>(
         `iframe[data-extension-id="${entry.extensionId}"][data-role="view"]`,
       ) ??

--- a/src/services/extension/streamDispatcher.test.ts
+++ b/src/services/extension/streamDispatcher.test.ts
@@ -228,6 +228,78 @@ describe('StreamDispatcher', () => {
     expect(postMessage).not.toHaveBeenCalled()
   })
 
+  // ── Role-aware routing (originRole) ──────────────────────────────────────
+  // The dispatcher records the originating iframe role at create() time and
+  // prefers the matching iframe at deliver() time. Without this, a worker-
+  // originated stream (e.g. shell.spawn from a worker) would land on the
+  // view iframe in DOM order and the worker-side consumer would silently
+  // drop chunks.
+
+  it('worker-originated stream prefers the worker iframe over the view iframe', () => {
+    const { iframe: workerFrame, postMessage: workerPost } = makeIframe('ext-1')
+    const { iframe: viewFrame, postMessage: viewPost } = makeIframe('ext-1')
+    querySpy.mockImplementation((selector: string) => {
+      if (selector.includes('data-role="worker"')) return workerFrame
+      if (selector.includes('data-role="view"')) return viewFrame
+      return null
+    })
+
+    const handle = dispatcher.create('ext-1', 'stream-w', 'worker')
+    handle.sendChunk({ token: 'hi' })
+
+    expect(workerPost).toHaveBeenCalledTimes(1)
+    expect(viewPost).not.toHaveBeenCalled()
+  })
+
+  it('view-originated stream prefers the view iframe', () => {
+    const { iframe: workerFrame, postMessage: workerPost } = makeIframe('ext-1')
+    const { iframe: viewFrame, postMessage: viewPost } = makeIframe('ext-1')
+    querySpy.mockImplementation((selector: string) => {
+      if (selector.includes('data-role="worker"')) return workerFrame
+      if (selector.includes('data-role="view"')) return viewFrame
+      return null
+    })
+
+    const handle = dispatcher.create('ext-1', 'stream-v', 'view')
+    handle.sendChunk({ token: 'hi' })
+
+    expect(viewPost).toHaveBeenCalledTimes(1)
+    expect(workerPost).not.toHaveBeenCalled()
+  })
+
+  it('worker-originated stream falls back to view when the worker iframe is missing', () => {
+    // Simulates a torn-down/dormant worker: the chunk should still be
+    // delivered via the next-best iframe rather than dropped.
+    const { iframe: viewFrame, postMessage: viewPost } = makeIframe('ext-1')
+    querySpy.mockImplementation((selector: string) => {
+      if (selector.includes('data-role="view"')) return viewFrame
+      return null
+    })
+
+    const handle = dispatcher.create('ext-1', 'stream-fb', 'worker')
+    handle.sendChunk({ token: 'hi' })
+
+    expect(viewPost).toHaveBeenCalledTimes(1)
+  })
+
+  it('stream without originRole behaves like view-preferred (legacy callers)', () => {
+    // Callers that didn't record an originRole get the historical view-first
+    // selection. Documents the back-compat fallback.
+    const { iframe: viewFrame, postMessage: viewPost } = makeIframe('ext-1')
+    const { iframe: workerFrame, postMessage: workerPost } = makeIframe('ext-1')
+    querySpy.mockImplementation((selector: string) => {
+      if (selector.includes('data-role="view"')) return viewFrame
+      if (selector.includes('data-role="worker"')) return workerFrame
+      return null
+    })
+
+    const handle = dispatcher.create('ext-1', 'stream-legacy')
+    handle.sendChunk({ token: 'hi' })
+
+    expect(viewPost).toHaveBeenCalledTimes(1)
+    expect(workerPost).not.toHaveBeenCalled()
+  })
+
   it('two concurrent streams to different extensions do not interfere', () => {
     const { iframe: iframe1, postMessage: pm1 } = makeIframe('ext-1')
     const { iframe: iframe2, postMessage: pm2 } = makeIframe('ext-2')

--- a/src/services/shell/shellService.svelte.ts
+++ b/src/services/shell/shellService.svelte.ts
@@ -62,6 +62,7 @@ class ShellService {
     program: string,
     args: string[] = [],
     spawnId: string,
+    originRole?: 'view' | 'worker',
   ): Promise<{ streaming: true }> {
     const resolvedPath = await invoke<string>('shell_resolve_path', { program });
 
@@ -72,7 +73,7 @@ class ShellService {
 
     await this.ensureGlobalListeners();
 
-    const handle = streamDispatcher.create(extensionId, spawnId);
+    const handle = streamDispatcher.create(extensionId, spawnId, originRole);
     handle.onAbort(() => {
       invoke('shell_kill', { spawnId }).catch((err) => {
         logService.error(`[ShellService] Failed to kill process on abort: ${err}`);
@@ -97,14 +98,18 @@ class ShellService {
     return invoke<ShellDescriptor[]>('shell_list', { extensionId });
   }
 
-  async attach(extensionId: string, spawnId: string): Promise<ShellDescriptor> {
+  async attach(
+    extensionId: string,
+    spawnId: string,
+    originRole?: 'view' | 'worker',
+  ): Promise<ShellDescriptor> {
     await this.ensureGlobalListeners();
 
     // Re-use a live streamDispatcher entry when the original spawn() is
     // still pumping; otherwise open a fresh one so the Rust-side terminal
     // emit (for already-finished entries) has somewhere to land.
     if (!streamDispatcher.has(spawnId)) {
-      const handle = streamDispatcher.create(extensionId, spawnId);
+      const handle = streamDispatcher.create(extensionId, spawnId, originRole);
       handle.onAbort(() => {
         invoke('shell_kill', { spawnId }).catch((err) => {
           logService.error(`[ShellService] Failed to kill process on abort: ${err}`);

--- a/src/services/shell/shellService.test.ts
+++ b/src/services/shell/shellService.test.ts
@@ -148,7 +148,7 @@ describe('ShellService', () => {
 
       await shellService.attach('ext-a', 'reattach-2');
 
-      expect(streamDispatcher.create).toHaveBeenCalledWith('ext-a', 'reattach-2');
+      expect(streamDispatcher.create).toHaveBeenCalledWith('ext-a', 'reattach-2', undefined);
     });
 
     it('reuses the existing streamDispatcher entry when the spawn is still live', async () => {


### PR DESCRIPTION
**Worker streams**
When an extension's worker called `shell.spawn`, the resulting output chunks could land in the extension's view iframe by mistake because the dispatcher looked for "any iframe of this extension" and preferred the view.

Now the spawn is tagged with which iframe role originated it, and chunks route back to that exact iframe. It falls back to the old view-preferred lookup when no role is recorded to avoid changes there.

**Worker mount race**
Always-on workers (extensions with `background.main`) sometimes failed to mount on launch. The Rust side fired EVENT_MOUNT from inside `discover_extensions`, but the frontend's listeners weren't always bound and the iframe DOM didn't exist, so the mount timed out.

I've moved the restoration into a dedicated `restore_workers` command that the front-end calls after listeners are bound, which fixes the race.

Test:
- Install or enable an extension with a `background.main` worker, restart the launcher, confirm its worker is alive without opening the extension first (e.g. shortcuts, system-events, or any extension that listens passively).
- Run a worker-side `shell.spawn` from an extension that also keeps a view, confirm the worker receives chunks and `onDone` fires.