### PR TITLE
fix(extensions): deliver scheduled commands to worker iframes

### DIFF
--- a/src-tauri/src/extensions/scheduler.rs
+++ b/src-tauri/src/extensions/scheduler.rs
@@ -4,14 +4,15 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use log::warn;
 use serde::Serialize;
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Manager};
 use tokio::task::JoinHandle;
 
 use crate::error::AppError;
 use crate::extensions::extension_runtime::{
     ContextRole, DispatchOutcome, ExtensionRuntimeManager, MessageKind, PendingMessage,
-    TriggerSource, EVENT_MOUNT,
+    TriggerSource, EVENT_DELIVER, EVENT_MOUNT,
 };
+use crate::extensions::extension_runtime::emitter::{emit_typed, EventEmitter};
 use super::ExtensionRegistryState;
 use std::sync::Arc;
 
@@ -65,13 +66,82 @@ pub struct ScheduledTaskInfo {
     pub active: bool,
 }
 
-/// Spawn a tokio task that dispatches a scheduled Action into the Worker machine.
+/// Build the `PendingMessage` that the scheduler enqueues for a single tick.
+///
+/// Extracted from `spawn_timer` to create a pure, testable seam.
+fn build_scheduled_command_message(command_id: &str, now: std::time::Instant) -> PendingMessage {
+    PendingMessage {
+        kind: MessageKind::Command,
+        payload: serde_json::json!({
+            "commandId": command_id,
+            "args": { "scheduledTick": true },
+        }),
+        enqueued_at: now,
+        source: TriggerSource::Schedule,
+    }
+}
+
+/// Handle a `DispatchOutcome` from `enqueue_worker`, emitting Tauri events as needed.
+///
+/// Extracted from `spawn_timer` to create a pure, testable seam via `EventEmitter`.
+fn handle_dispatch_outcome(
+    emitter: &dyn EventEmitter,
+    extension_id: &str,
+    command_id: &str,
+    outcome: &DispatchOutcome,
+) {
+    match outcome {
+        DispatchOutcome::ReadyDeliverNow { messages } => {
+            let serialized: Vec<serde_json::Value> = messages
+                .iter()
+                .map(|m| serde_json::json!({
+                    "kind": m.kind,
+                    "payload": m.payload,
+                    "source": m.source,
+                }))
+                .collect();
+            emit_typed(
+                emitter,
+                EVENT_DELIVER,
+                &serde_json::json!({
+                    "extensionId": extension_id,
+                    "role": ContextRole::Worker,
+                    "messages": serialized,
+                }),
+            );
+        }
+        DispatchOutcome::NeedsMount { mount_token } => {
+            emit_typed(
+                emitter,
+                EVENT_MOUNT,
+                &serde_json::json!({
+                    "extensionId": extension_id,
+                    "mountToken": mount_token,
+                    "role": ContextRole::Worker,
+                }),
+            );
+        }
+        DispatchOutcome::Degraded { strikes } => {
+            warn!(
+                "Scheduler: worker machine degraded for {}::{} (strikes={})",
+                extension_id, command_id, strikes
+            );
+        }
+        DispatchOutcome::MountingWaitForReady => {
+            // Mailbox holds the message until the worker's ready ack drains it
+            // via the existing readiness listener. No-op here.
+        }
+    }
+}
+
+/// Spawn a tokio task that dispatches a scheduled Command into the Worker machine.
 fn spawn_timer(
     app_handle: AppHandle,
     extension_id: String,
     command_id: String,
     interval_secs: u64,
 ) -> JoinHandle<()> {
+    use crate::extensions::extension_runtime::emitter::TauriEventEmitter;
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(
             tokio::time::Duration::from_secs(interval_secs),
@@ -81,38 +151,11 @@ fn spawn_timer(
         loop {
             interval.tick().await;
             let now = std::time::Instant::now();
-            let msg = PendingMessage {
-                kind: MessageKind::Action,
-                payload: serde_json::json!({ "commandId": command_id }),
-                enqueued_at: now,
-                source: TriggerSource::Schedule,
-            };
+            let msg = build_scheduled_command_message(&command_id, now);
             if let Some(mgr) = app_handle.try_state::<Arc<ExtensionRuntimeManager>>() {
                 let outcome = mgr.enqueue_worker(&extension_id, msg, now);
-                match &outcome {
-                    DispatchOutcome::NeedsMount { mount_token } => {
-                        if let Err(e) = app_handle.emit(
-                            EVENT_MOUNT,
-                            &serde_json::json!({
-                                "extensionId": extension_id,
-                                "mountToken": mount_token,
-                                "role": ContextRole::Worker,
-                            }),
-                        ) {
-                            warn!(
-                                "Scheduler: emit worker mount for {}::{}: {}",
-                                extension_id, command_id, e
-                            );
-                        }
-                    }
-                    DispatchOutcome::Degraded { strikes } => {
-                        warn!(
-                            "Scheduler: worker machine degraded for {}::{} (strikes={})",
-                            extension_id, command_id, strikes
-                        );
-                    }
-                    _ => {}
-                }
+                let emitter = TauriEventEmitter { app: app_handle.clone() };
+                handle_dispatch_outcome(&emitter, &extension_id, &command_id, &outcome);
             } else {
                 warn!(
                     "Scheduler: ExtensionRuntimeManager unavailable for {}::{}",
@@ -289,5 +332,105 @@ mod tests {
         assert_eq!(validate_interval(30).unwrap(), 30);
         assert_eq!(validate_interval(300).unwrap(), 300);
         assert_eq!(validate_interval(3600).unwrap(), 3600);
+    }
+
+    #[test]
+    fn scheduled_command_message_must_use_command_kind_not_action() {
+        // Contract: scheduler ticks are dispatched to extension workers via
+        // PendingMessage.kind. The frontend delivery layer maps Action ->
+        // 'asyar:action:execute' (looked up by payload.actionId) and Command
+        // -> 'asyar:command:execute' (calls extension.executeCommand). Scheduler
+        // payloads carry commandId, not actionId, so an Action message would be
+        // silently dropped by the SDK's ExtensionBridge actionRegistry lookup.
+        // Scheduled ticks MUST be Command.
+        let now = std::time::Instant::now();
+        let msg = build_scheduled_command_message("tick-test", now);
+        assert!(
+            matches!(msg.kind, MessageKind::Command),
+            "Scheduled commands must dispatch as MessageKind::Command, not Action — \
+             Action would be dropped by ExtensionBridge because the scheduler payload \
+             carries commandId not actionId"
+        );
+    }
+
+    #[test]
+    fn scheduled_command_payload_must_include_scheduled_tick_flag() {
+        // Contract: the scheduler-driven payload must carry args.scheduledTick = true
+        // so the SDK worker's recordTick() can distinguish real platform ticks from
+        // manual button-press simulations. The view filters its SCHEDULER counter on
+        // this flag.
+        let now = std::time::Instant::now();
+        let msg = build_scheduled_command_message("tick-test", now);
+        let scheduled = msg
+            .payload
+            .get("args")
+            .and_then(|a| a.get("scheduledTick"))
+            .and_then(|v| v.as_bool());
+        assert_eq!(
+            scheduled,
+            Some(true),
+            "payload must include args.scheduledTick = true for the worker's recordTick() to flag it as a scheduler-driven event; got payload={}",
+            msg.payload
+        );
+    }
+
+    #[test]
+    fn ready_deliver_now_must_emit_event_deliver_with_messages() {
+        // Contract: when enqueue_worker drains the mailbox into ReadyDeliverNow,
+        // the scheduler MUST emit EVENT_DELIVER so the TS side can post the
+        // drained messages to the worker iframe. Without this emit, every
+        // scheduler tick to a Ready worker is silently dropped — the bug that
+        // motivated this regression test.
+        use crate::extensions::extension_runtime::emitter::RecordingEmitter;
+        let emitter = RecordingEmitter::default();
+        let now = std::time::Instant::now();
+        let msg = build_scheduled_command_message("tick-test", now);
+        let outcome = DispatchOutcome::ReadyDeliverNow {
+            messages: vec![msg],
+        };
+        handle_dispatch_outcome(&emitter, "org.asyar.sdk-playground", "tick-test", &outcome);
+
+        let recorded = emitter.events();
+        let deliver = recorded
+            .iter()
+            .find(|(name, _)| name == "asyar:iframe:deliver");
+        assert!(
+            deliver.is_some(),
+            "expected EVENT_DELIVER ('asyar:iframe:deliver') to be emitted on ReadyDeliverNow; got {:?}",
+            recorded.iter().map(|(n, _)| n).collect::<Vec<_>>()
+        );
+        let (_, payload) = deliver.unwrap();
+        assert_eq!(
+            payload.get("extensionId").and_then(|v| v.as_str()),
+            Some("org.asyar.sdk-playground")
+        );
+        assert_eq!(
+            payload.get("role").and_then(|v| v.as_str()),
+            Some("worker"),
+            "EVENT_DELIVER role must be 'worker' so the TS listener targets the worker iframe (matches ContextRole serialization)"
+        );
+        let messages = payload.get("messages").and_then(|v| v.as_array());
+        assert!(messages.is_some(), "EVENT_DELIVER payload must include 'messages' array");
+        assert_eq!(messages.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn needs_mount_still_emits_event_mount() {
+        // Don't regress the existing NeedsMount behavior while adding ReadyDeliverNow handling.
+        use crate::extensions::extension_runtime::emitter::RecordingEmitter;
+        let emitter = RecordingEmitter::default();
+        let outcome = DispatchOutcome::NeedsMount { mount_token: 42 };
+        handle_dispatch_outcome(&emitter, "ext.a", "tick-test", &outcome);
+
+        let recorded = emitter.events();
+        assert!(
+            recorded.iter().any(|(name, p)| {
+                name == "asyar:iframe:mount"
+                    && p.get("mountToken").and_then(|v| v.as_u64()) == Some(42)
+            }),
+            "NeedsMount must still emit EVENT_MOUNT with mountToken={}; got {:?}",
+            42,
+            recorded
+        );
     }
 }

--- a/src/services/appInitializer.ts
+++ b/src/services/appInitializer.ts
@@ -42,6 +42,7 @@ import { trayClickBridge } from './statusBar/trayClickBridge.svelte';
 import { viewRegistry } from './extension/viewRegistry.svelte';
 import { workerRegistry } from './extension/workerRegistry.svelte';
 import { extensionReadinessListener } from './extension/extensionReadinessListener';
+import { iframeDeliveryListener } from './extension/iframeDeliveryListener.svelte';
 import { restoreWorkers } from '../lib/ipc/iframeLifecycleCommands';
 import { diagnosticsService } from './diagnostics/diagnosticsService.svelte';
 
@@ -177,6 +178,7 @@ export const appInitializer = {
         // are committed before `restoreWorkers()` below fires EVENT_MOUNT.
         await viewRegistry.init();
         await workerRegistry.init();
+        await iframeDeliveryListener.init();           // NEW
         extensionReadinessListener.init();
       }
 

--- a/src/services/extension/iframeDeliveryListener.svelte.test.ts
+++ b/src/services/extension/iframeDeliveryListener.svelte.test.ts
@@ -1,0 +1,99 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const listeners = new Map<string, (e: { payload: unknown }) => void>();
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async (event: string, cb: (e: { payload: unknown }) => void) => {
+    listeners.set(event, cb);
+    return () => listeners.delete(event);
+  }),
+}));
+
+const postSpy = vi.fn();
+vi.mock('./extensionDelivery', () => ({
+  post: (iframe: HTMLIFrameElement, m: unknown) => postSpy(iframe, m),
+}));
+
+vi.mock('../diagnostics/diagnosticsService.svelte', () => ({
+  diagnosticsService: {
+    report: vi.fn(),
+    registerRetry: vi.fn(() => 'retry-x'),
+  },
+}));
+
+import { iframeDeliveryListener } from './iframeDeliveryListener.svelte';
+import { diagnosticsService } from '../diagnostics/diagnosticsService.svelte';
+
+function makeIframe(extensionId: string, role: string, id: string): HTMLIFrameElement {
+  const el = document.createElement('iframe');
+  el.setAttribute('data-extension-id', extensionId);
+  el.setAttribute('data-role', role);
+  el.id = id;
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('iframeDeliveryListener', () => {
+  beforeEach(() => {
+    listeners.clear();
+    postSpy.mockClear();
+    vi.mocked(diagnosticsService.report).mockClear();
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+    iframeDeliveryListener.reset();
+  });
+
+  it('posts each message to the iframe matching extensionId + role on EVENT_DELIVER', async () => {
+    makeIframe('org.asyar.sdk-playground', 'view', 'v');
+    makeIframe('org.asyar.sdk-playground', 'worker', 'w');
+    makeIframe('org.other', 'worker', 'o');
+    await iframeDeliveryListener.init();
+
+    const handler = listeners.get('asyar:iframe:deliver');
+    expect(handler, 'listener must subscribe to asyar:iframe:deliver').toBeDefined();
+
+    const m1 = { kind: 'command', payload: { commandId: 'tick-test' }, source: 'schedule' };
+    const m2 = { kind: 'command', payload: { commandId: 'tick-test', args: { scheduledTick: true } }, source: 'schedule' };
+    handler!({
+      payload: {
+        extensionId: 'org.asyar.sdk-playground',
+        role: 'worker',
+        messages: [m1, m2],
+      },
+    });
+
+    expect(postSpy).toHaveBeenCalledTimes(2);
+    expect((postSpy.mock.calls[0][0] as HTMLIFrameElement).id).toBe('w');
+    expect((postSpy.mock.calls[1][0] as HTMLIFrameElement).id).toBe('w');
+    expect(postSpy.mock.calls[0][1]).toEqual(m1);
+    expect(postSpy.mock.calls[1][1]).toEqual(m2);
+  });
+
+  it('reports a warning diagnostic and skips post when the iframe is missing', async () => {
+    // no iframes in DOM
+    await iframeDeliveryListener.init();
+    const handler = listeners.get('asyar:iframe:deliver')!;
+    handler({
+      payload: {
+        extensionId: 'org.absent',
+        role: 'worker',
+        messages: [
+          { kind: 'command', payload: {}, source: 'schedule' },
+          { kind: 'command', payload: {}, source: 'schedule' },
+        ],
+      },
+    });
+    expect(postSpy).not.toHaveBeenCalled();
+    expect(diagnosticsService.report).toHaveBeenCalledTimes(1);
+    expect(diagnosticsService.report).toHaveBeenCalledWith({
+      source: 'frontend',
+      kind: 'extension-runtime/scheduler-deliver-no-iframe',
+      severity: 'warning',
+      retryable: false,
+      developerDetail: 'no iframe for org.absent role=worker; dropping 2 message(s)',
+      context: { extensionId: 'org.absent', role: 'worker', messageCount: '2' },
+    });
+  });
+});

--- a/src/services/extension/iframeDeliveryListener.svelte.ts
+++ b/src/services/extension/iframeDeliveryListener.svelte.ts
@@ -1,0 +1,43 @@
+import { listen } from '@tauri-apps/api/event';
+import { post } from './extensionDelivery';
+import type { IpcPendingMessage } from '../../lib/ipc/iframeLifecycleCommands';
+import { diagnosticsService } from '../diagnostics/diagnosticsService.svelte';
+
+interface DeliverPayload {
+  extensionId: string;
+  role: 'view' | 'worker';
+  messages: IpcPendingMessage[];
+}
+
+export class IframeDeliveryListener {
+  private unlisten: (() => void) | null = null;
+
+  async init(): Promise<void> {
+    if (this.unlisten) return;
+    this.unlisten = await listen<DeliverPayload>('asyar:iframe:deliver', (e) => {
+      const { extensionId, role, messages } = e.payload;
+      const iframe = document.querySelector<HTMLIFrameElement>(
+        `iframe[data-extension-id="${extensionId}"][data-role="${role}"]`,
+      );
+      if (!iframe) {
+        void diagnosticsService.report({
+          source: 'frontend',
+          kind: 'extension-runtime/scheduler-deliver-no-iframe',
+          severity: 'warning',
+          retryable: false,
+          developerDetail: `no iframe for ${extensionId} role=${role}; dropping ${messages.length} message(s)`,
+          context: { extensionId, role, messageCount: String(messages.length) },
+        });
+        return;
+      }
+      for (const m of messages) post(iframe, m);
+    });
+  }
+
+  reset(): void {
+    this.unlisten?.();
+    this.unlisten = null;
+  }
+}
+
+export const iframeDeliveryListener = new IframeDeliveryListener();


### PR DESCRIPTION
Scheduler used the wrong wire type (Action vs Command) and discarded
ReadyDeliverNow drained messages, silently dropping every scheduled
tick. Emit EVENT_DELIVER so a new TS listener forwards drained messages
to the worker iframe; payload now carries args.scheduledTick=true.