### PR TITLE
fix(macos): launcher panel honors theme setting at runtime

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -387,6 +387,36 @@ fn parse_css_color(s: &str) -> Result<(f64, f64, f64, f64), AppError> {
     Ok((chan(parts[0])?, chan(parts[1])?, chan(parts[2])?, a))
 }
 
+/// Updates the NSVisualEffectView material on the launcher panel to match the
+/// given theme preference. On non-macOS this is a no-op — the command still
+/// succeeds so the JS caller does not need platform guards.
+///
+/// Passes the *preference* string (not the resolved value) so Rust can
+/// re-resolve `"system"` consistently with the OS-notification observer path.
+#[tauri::command]
+pub fn set_panel_appearance(app_handle: AppHandle, pref: String) -> Result<(), AppError> {
+    #[cfg(target_os = "macos")]
+    {
+        let theme_pref = crate::parse_theme_preference_str(&pref);
+        {
+            if let Some(state) = app_handle.try_state::<std::sync::Mutex<crate::ThemePreference>>() {
+                *state.lock().map_err(|_| AppError::Lock)? = theme_pref;
+            }
+        }
+        let handle_clone = app_handle.clone();
+        let _ = app_handle.run_on_main_thread(move || {
+            if let Some(window) = handle_clone.get_webview_window(crate::SPOTLIGHT_LABEL) {
+                crate::platform::macos::apply_panel_appearance(&window, theme_pref);
+            }
+        });
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = pref;
+    }
+    Ok(())
+}
+
 /// Shows the launcher panel using the same logic as the global-hotkey handler.
 ///
 /// Intended for use from non-command code (e.g., `onboarding::window`) that

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -412,7 +412,7 @@ pub fn set_panel_appearance(app_handle: AppHandle, pref: String) -> Result<(), A
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = pref;
+        let _ = (app_handle, pref);
     }
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -164,6 +164,7 @@ pub fn run() {
             commands::set_launcher_height,
             commands::mark_launcher_ready,
             commands::update_show_more_bar_style,
+            commands::set_panel_appearance,
             commands::quit_app,
             commands::list_applications,
             commands::sync_application_index,
@@ -447,6 +448,16 @@ fn read_appearance_theme(app: &tauri::AppHandle) -> ThemePreference {
     parse_appearance_theme(store.get("settings").as_ref())
 }
 
+/// Maps the JS string argument sent by `set_panel_appearance` to a
+/// `ThemePreference`. Unknown strings fall back to `System` (safe default).
+pub fn parse_theme_preference_str(s: &str) -> ThemePreference {
+    match s {
+        "light" => ThemePreference::Light,
+        "dark" => ThemePreference::Dark,
+        _ => ThemePreference::System,
+    }
+}
+
 /// Pure JSON-navigation helper for `appearance.theme`.
 /// Returns `System` on missing/unknown values, matching JS defaults.
 pub fn parse_appearance_theme(settings_root: Option<&serde_json::Value>) -> ThemePreference {
@@ -571,7 +582,16 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         .ok_or("Main launcher window not found")?;
     
     #[cfg(target_os = "macos")]
-    let panel = crate::platform::macos::setup_spotlight_window(&window, handle, read_appearance_theme(handle))?;
+    let initial_theme_pref = read_appearance_theme(handle);
+
+    #[cfg(target_os = "macos")]
+    app.manage(Mutex::new(initial_theme_pref));
+
+    #[cfg(target_os = "macos")]
+    let panel = crate::platform::macos::setup_spotlight_window(&window, handle, initial_theme_pref)?;
+
+    #[cfg(target_os = "macos")]
+    crate::platform::macos::install_appearance_observer(handle);
 
     // Seed the launcher geometry from the persisted launchView BEFORE the
     // first panel.show(), so compact users never see the 480→96 reflow that
@@ -1269,6 +1289,31 @@ mod appearance_theme_tests {
     fn returns_system_when_json_is_empty_object() {
         let v = json!({});
         assert_eq!(parse_appearance_theme(Some(&v)), ThemePreference::System);
+    }
+}
+
+#[cfg(test)]
+mod theme_preference_str_tests {
+    use super::*;
+
+    #[test]
+    fn maps_light_string_to_light() {
+        assert_eq!(parse_theme_preference_str("light"), ThemePreference::Light);
+    }
+
+    #[test]
+    fn maps_dark_string_to_dark() {
+        assert_eq!(parse_theme_preference_str("dark"), ThemePreference::Dark);
+    }
+
+    #[test]
+    fn maps_system_string_to_system() {
+        assert_eq!(parse_theme_preference_str("system"), ThemePreference::System);
+    }
+
+    #[test]
+    fn unknown_string_falls_back_to_system() {
+        assert_eq!(parse_theme_preference_str("hot-pink"), ThemePreference::System);
     }
 }
 

--- a/src-tauri/src/onboarding/window.rs
+++ b/src-tauri/src/onboarding/window.rs
@@ -24,8 +24,7 @@ pub fn open(app: &AppHandle) -> Result<(), AppError> {
         return Ok(());
     }
 
-    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
-    let window = tauri::WebviewWindowBuilder::new(
+    let _window = tauri::WebviewWindowBuilder::new(
         app,
         WINDOW_LABEL,
         tauri::WebviewUrl::App(WINDOW_URL.into()),
@@ -53,12 +52,12 @@ pub fn open(app: &AppHandle) -> Result<(), AppError> {
         // Native Windows polish: strip WS_EX_LAYERED so DWM owns the backdrop,
         // round the corners, then paint Acrylic (Win10 + Win11) with a Mica
         // fallback (Win11 only, in case Acrylic is disabled by the user).
-        if let Ok(hwnd) = window.hwnd() {
+        if let Ok(hwnd) = _window.hwnd() {
             crate::platform::windows::apply_dwm_polish(hwnd);
         }
         use window_vibrancy::{apply_acrylic, apply_mica};
-        if apply_acrylic(&window, Some((0, 0, 0, 0))).is_err() {
-            let _ = apply_mica(&window, None);
+        if apply_acrylic(&_window, Some((0, 0, 0, 0))).is_err() {
+            let _ = apply_mica(&_window, None);
         }
     }
 

--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -120,6 +120,13 @@ pub fn setup_spotlight_window<R: Runtime>(window: &WebviewWindow<R>, app: &AppHa
     apply_vibrancy(window, material, None, Some(15.0))
         .expect("Failed to apply vibrancy");
 
+    // Seed the NSWindow appearance so the first composited frame already has
+    // the correct blur tint — without this, a mismatch between Asyar's stored
+    // theme and the OS appearance produces a washed-out panel on the very
+    // first show. apply_panel_appearance is idempotent and no-ops on the
+    // material if it was just set by apply_vibrancy above.
+    apply_panel_appearance(window, theme_pref);
+
     Ok(panel)
 }
 
@@ -390,6 +397,165 @@ pub fn extract_icon(path: &Path) -> Option<Vec<u8>> {
         }
     }
     None
+}
+
+/// Sets the NSWindow's NSAppearance and the NSVisualEffectView material to
+/// match `pref`. Both operations are needed: the material's tint is
+/// determined by `effectiveAppearance`, so without the appearance override
+/// even `HudWindow` material renders light-tinted when the OS is in light
+/// mode, producing the washed-out panel the user sees when Asyar=Dark but
+/// OS=Light.
+///
+/// NSAppearance mapping:
+/// - `Light`  → `NSAppearanceNameAqua`   (explicit light appearance)
+/// - `Dark`   → `NSAppearanceNameDarkAqua` (explicit dark appearance)
+/// - `System` → `nil` (AppKit auto-tracks the OS; idiomatic pattern)
+///
+/// The material switch is idempotent — reads the current value and skips
+/// `setMaterial:` if unchanged. The appearance override is always applied
+/// because nil vs non-nil can't be compared cheaply via objc2.
+///
+/// Must be called on the main thread. Returns silently if the window or
+/// vibrancy view cannot be located.
+pub fn apply_panel_appearance<R: Runtime>(window: &WebviewWindow<R>, pref: crate::ThemePreference) {
+    let ns_window = match window.ns_window() {
+        Ok(ptr) => ptr as *mut AnyObject,
+        Err(_) => {
+            log::warn!("[apply_panel_appearance] ns_window() failed");
+            return;
+        }
+    };
+
+    unsafe {
+        // Set the window's NSAppearance so the blur material tints correctly
+        // regardless of the OS appearance. nil means "follow the OS".
+        let appearance: *mut AnyObject = match pref {
+            crate::ThemePreference::Light => {
+                let cls = match AnyClass::get("NSAppearance") {
+                    Some(c) => c,
+                    None => {
+                        log::warn!("[apply_panel_appearance] NSAppearance class not found");
+                        return;
+                    }
+                };
+                let name = NSString::from_str("NSAppearanceNameAqua");
+                msg_send![cls, appearanceNamed: Retained::as_ptr(&name)]
+            }
+            crate::ThemePreference::Dark => {
+                let cls = match AnyClass::get("NSAppearance") {
+                    Some(c) => c,
+                    None => {
+                        log::warn!("[apply_panel_appearance] NSAppearance class not found");
+                        return;
+                    }
+                };
+                let name = NSString::from_str("NSAppearanceNameDarkAqua");
+                msg_send![cls, appearanceNamed: Retained::as_ptr(&name)]
+            }
+            crate::ThemePreference::System => std::ptr::null_mut(),
+        };
+        let _: () = msg_send![ns_window, setAppearance: appearance];
+
+        // Update the vibrancy material to match the resolved appearance.
+        let resolved = resolve_theme_preference(pref);
+        let target_material = material_for_resolved_theme(resolved);
+        let target_raw = target_material as i64;
+
+        let content_view: *mut AnyObject = msg_send![ns_window, contentView];
+        let vibrancy = find_vibrancy_view(content_view);
+        if vibrancy.is_null() {
+            log::warn!("[apply_panel_appearance] vibrancy view not found");
+            return;
+        }
+
+        let current_raw: i64 = msg_send![vibrancy, material];
+        if current_raw != target_raw {
+            let _: () = msg_send![vibrancy, setMaterial: target_raw];
+        }
+    }
+}
+
+/// Registers a `NSDistributedNotificationCenter` observer for
+/// `AppleInterfaceThemeChangedNotification`. When the OS appearance changes,
+/// the block re-reads the managed `Mutex<ThemePreference>`. If the preference
+/// is `System`, it re-applies both the NSWindow appearance and the vibrancy
+/// material — if the user chose Light or Dark explicitly, the OS toggle is
+/// ignored (user's explicit choice wins; the appearance was already pinned via
+/// setAppearance: at preference-set time).
+///
+/// Delivers on the main queue so AppKit calls are safe without a further
+/// thread hop.
+///
+/// The observer is leaked intentionally: it must live for the entire app
+/// lifetime, and `NSDistributedNotificationCenter` retains it internally.
+pub fn install_appearance_observer<R: Runtime + 'static>(app: &AppHandle<R>) {
+    use objc2::rc::Retained;
+    use objc2_foundation::{NSNotification, NSString};
+
+    let app_handle = app.clone();
+
+    let block = block2::RcBlock::new(move |_note: std::ptr::NonNull<NSNotification>| {
+        let pref = {
+            let state = app_handle.try_state::<std::sync::Mutex<crate::ThemePreference>>();
+            match state {
+                Some(s) => *s.lock().unwrap_or_else(|p| p.into_inner()),
+                None => crate::ThemePreference::System,
+            }
+        };
+
+        // Only act on OS flips when the user chose System. For Light/Dark,
+        // setAppearance: already pinned the window appearance — skipping
+        // here avoids a redundant AppKit call and keeps intent clear.
+        if pref == crate::ThemePreference::System {
+            if let Some(window) = app_handle.get_webview_window(crate::SPOTLIGHT_LABEL) {
+                apply_panel_appearance(&window, pref);
+            }
+        }
+    });
+
+    unsafe {
+        let center_cls = match AnyClass::get("NSDistributedNotificationCenter") {
+            Some(c) => c,
+            None => {
+                log::error!("[install_appearance_observer] NSDistributedNotificationCenter class not found");
+                return;
+            }
+        };
+        let center: *mut AnyObject = msg_send![center_cls, defaultCenter];
+        if center.is_null() {
+            log::error!("[install_appearance_observer] defaultCenter returned null");
+            return;
+        }
+
+        let notif_name = NSString::from_str("AppleInterfaceThemeChangedNotification");
+        let main_queue_cls = match AnyClass::get("NSOperationQueue") {
+            Some(c) => c,
+            None => {
+                log::error!("[install_appearance_observer] NSOperationQueue class not found");
+                return;
+            }
+        };
+        let main_queue: *mut AnyObject = msg_send![main_queue_cls, mainQueue];
+
+        let nil: *const AnyObject = std::ptr::null();
+        let observer: Option<Retained<AnyObject>> = msg_send_id![
+            center,
+            addObserverForName: Retained::as_ptr(&notif_name)
+            object: nil
+            queue: main_queue
+            usingBlock: &*block as &block2::Block<dyn Fn(std::ptr::NonNull<NSNotification>)>
+        ];
+
+        match observer {
+            Some(obs) => {
+                // Intentional leak: observer must live for the app lifetime.
+                std::mem::forget(obs);
+            }
+            None => {
+                log::error!("[install_appearance_observer] addObserverForName returned nil");
+            }
+        }
+    }
 }
 
 pub fn register_cmdq_monitor(app_handle: AppHandle) {

--- a/src/lib/ipc/commands.ts
+++ b/src/lib/ipc/commands.ts
@@ -208,6 +208,10 @@ export async function updateShowMoreBarStyle(style: ShowMoreBarStyle): Promise<v
   return invoke('update_show_more_bar_style', { style });
 }
 
+export async function setPanelAppearance(pref: 'system' | 'light' | 'dark'): Promise<void> {
+  return invoke('set_panel_appearance', { pref });
+}
+
   export async function appRelaunch(): Promise<void> {
     return invoke('app_relaunch');
   }

--- a/src/services/theme/themeMode.test.ts
+++ b/src/services/theme/themeMode.test.ts
@@ -5,6 +5,12 @@ vi.mock('./nativeBarSync', () => ({
   syncNativeBarStyle: vi.fn(),
 }));
 
+vi.mock('../../lib/ipc/commands', () => ({
+  setPanelAppearance: vi.fn().mockResolvedValue(undefined),
+}));
+
+import type { setPanelAppearance as SetPanelAppearanceFn } from '../../lib/ipc/commands';
+
 import type { syncNativeBarStyle as SyncFn } from './nativeBarSync';
 
 type ChangeListener = (e: MediaQueryListEvent) => void;
@@ -34,7 +40,12 @@ function installMatchMedia(initialDark: boolean): FakeMediaQuery {
 async function loadModule() {
   const mod = await import('./themeMode');
   const { syncNativeBarStyle } = await import('./nativeBarSync');
-  return { mod, syncNativeBarStyle: vi.mocked(syncNativeBarStyle as typeof SyncFn) };
+  const { setPanelAppearance } = await import('../../lib/ipc/commands');
+  return {
+    mod,
+    syncNativeBarStyle: vi.mocked(syncNativeBarStyle as typeof SyncFn),
+    setPanelAppearance: vi.mocked(setPanelAppearance as typeof SetPanelAppearanceFn),
+  };
 }
 
 // rAF runs the callback synchronously in tests so we can assert side effects
@@ -135,5 +146,63 @@ describe('themeMode', () => {
     mod.applyThemePreference('system');
     mod.applyThemePreference('system');
     expect(mq.addEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  // ── set_panel_appearance IPC tests ──────────────────────────────────────────
+
+  it('applyThemePreference("dark") invokes setPanelAppearance with pref="dark"', async () => {
+    installMatchMedia(false);
+    const { mod, setPanelAppearance } = await loadModule();
+    mod.applyThemePreference('dark');
+    expect(setPanelAppearance).toHaveBeenCalledTimes(1);
+    expect(setPanelAppearance).toHaveBeenCalledWith('dark');
+  });
+
+  it('applyThemePreference("light") invokes setPanelAppearance with pref="light"', async () => {
+    installMatchMedia(false);
+    const { mod, setPanelAppearance } = await loadModule();
+    mod.applyThemePreference('light');
+    expect(setPanelAppearance).toHaveBeenCalledTimes(1);
+    expect(setPanelAppearance).toHaveBeenCalledWith('light');
+  });
+
+  it('applyThemePreference("system") invokes setPanelAppearance with pref="system" (Rust resolves)', async () => {
+    installMatchMedia(true);
+    const { mod, setPanelAppearance } = await loadModule();
+    mod.applyThemePreference('system');
+    expect(setPanelAppearance).toHaveBeenCalledTimes(1);
+    expect(setPanelAppearance).toHaveBeenCalledWith('system');
+  });
+
+  it('OS flip while pref=system invokes setPanelAppearance again with pref="system"', async () => {
+    const mq = installMatchMedia(false);
+    const { mod, setPanelAppearance } = await loadModule();
+    mod.applyThemePreference('system');
+    expect(setPanelAppearance).toHaveBeenCalledTimes(1);
+    expect(setPanelAppearance).toHaveBeenLastCalledWith('system');
+
+    mq.emit(true); // OS flipped to dark
+    expect(setPanelAppearance).toHaveBeenCalledTimes(2);
+    expect(setPanelAppearance).toHaveBeenLastCalledWith('system');
+  });
+
+  it('forced pref ignores OS flips for setPanelAppearance too', async () => {
+    const mq = installMatchMedia(false);
+    const { mod, setPanelAppearance } = await loadModule();
+    mod.applyThemePreference('system');
+    mod.applyThemePreference('dark'); // forces dark, removes listener
+    const callCountAfterForce = setPanelAppearance.mock.calls.length;
+
+    mq.emit(false); // OS flipped — listener should be gone
+    expect(setPanelAppearance).toHaveBeenCalledTimes(callCountAfterForce);
+  });
+
+  it('redundant same-preference apply does not re-invoke setPanelAppearance', async () => {
+    installMatchMedia(true); // OS=dark
+    const { mod, setPanelAppearance } = await loadModule();
+    mod.applyThemePreference('system'); // resolves to dark, sets attribute
+    const callsAfterFirst = setPanelAppearance.mock.calls.length;
+    mod.applyThemePreference('system'); // already dark — should be no-op
+    expect(setPanelAppearance).toHaveBeenCalledTimes(callsAfterFirst);
   });
 });

--- a/src/services/theme/themeMode.ts
+++ b/src/services/theme/themeMode.ts
@@ -1,4 +1,6 @@
 import { syncNativeBarStyle } from './nativeBarSync';
+import { setPanelAppearance } from '../../lib/ipc/commands';
+import { logService } from '../log/logService';
 
 // Resolves preference → <html data-theme>; under "system", a matchMedia
 // listener re-resolves so OS appearance toggles retint without a relaunch.
@@ -22,6 +24,11 @@ function write(resolved: ResolvedTheme): void {
   document.documentElement.dataset.theme = resolved;
   // rAF lets the style commit so getComputedStyle reads the new values.
   requestAnimationFrame(() => void syncNativeBarStyle());
+  // Keep NSVisualEffectView material in sync. Pass the preference so Rust
+  // re-resolves "system" the same way the OS-notification observer does.
+  setPanelAppearance(currentPreference).catch((e) => {
+    logService.debug(`[themeMode] setPanelAppearance failed: ${e}`);
+  });
 }
 
 export function applyThemePreference(pref: ThemePreference): void {


### PR DESCRIPTION
The macOS launcher panel's blur tint was decided once at window creation
and never updated. Switching Asyar's theme in Settings — or toggling the
OS appearance while Asyar was set to "system" — left the NSVisualEffectView
mismatched. Most visibly, Asyar=Dark on a light-mode system rendered as
washed-out grey instead of deep dark.