### PR TITLE
fix(clipboard-history): respect HTML toggle for URLs

### DIFF
--- a/src/built-in-features/clipboard-history/DefaultView.svelte
+++ b/src/built-in-features/clipboard-history/DefaultView.svelte
@@ -393,7 +393,7 @@
 
     {#snippet detail()}
       {#if selectedItem}
-        {#if isUrl(selectedItem.content) && urlBlobUrl}
+        {#if isUrl(selectedItem.content) && urlBlobUrl && showRenderedHtml}
           <iframe
             src={urlBlobUrl}
             class="url-iframe"
@@ -466,7 +466,7 @@
                 </div>
               {/each}
             </div>
-          {:else if isUrl(selectedItem.content)}
+          {:else if isUrl(selectedItem.content) && showRenderedHtml}
             {#if urlLoading}
               <div class="url-loading">
                 <div class="url-loading-header">


### PR DESCRIPTION
Even with "Toggle HTML Rendered/Source" enabled, URLS rendered.

Now, urls render in normal mode, but show as plain-text when off.