### PR TITLE
fix(clipboard-history): respect HTML toggle for URLs #2

### DIFF
--- a/src/built-in-features/clipboard-history/DefaultView.svelte
+++ b/src/built-in-features/clipboard-history/DefaultView.svelte
@@ -114,7 +114,7 @@
   // Fetch URL content when a URL item is selected
   $effect(() => {
     const item = selectedItem;
-    if (!item || !isUrl(item.content)) {
+    if (!item || !isUrl(item.content) || !showRenderedHtml) {
       if (currentFetchedUrl) {
         if (urlBlobUrl) { URL.revokeObjectURL(urlBlobUrl); urlBlobUrl = ''; }
         urlLoading = false;
@@ -393,7 +393,7 @@
 
     {#snippet detail()}
       {#if selectedItem}
-        {#if isUrl(selectedItem.content) && urlBlobUrl && showRenderedHtml}
+        {#if showRenderedHtml && isUrl(selectedItem.content) && urlBlobUrl}
           <iframe
             src={urlBlobUrl}
             class="url-iframe"
@@ -466,7 +466,7 @@
                 </div>
               {/each}
             </div>
-          {:else if isUrl(selectedItem.content) && showRenderedHtml}
+          {:else if showRenderedHtml && isUrl(selectedItem.content)}
             {#if urlLoading}
               <div class="url-loading">
                 <div class="url-loading-header">


### PR DESCRIPTION
Gemini made a few suggestions, which were good! This doesn't fetch URLs when the toggle is off, which is sensible. I just focused on rendering and didn't think about this.