### PR TITLE
fix(clipboard): persist captures and resolve Asset-Catalog app icons

### DIFF
--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -361,7 +361,15 @@ fn get_app_icon_name(path: &Path) -> String {
         .and_then(|v| v.into_string()).unwrap_or_else(|| "AppIcon".to_string())
 }
 
+/// Returns a 128×128 PNG of the app's icon. Tries the discrete-`.icns` fast
+/// path first (sub-ms, no AppKit dependency), then falls back to AppKit's
+/// `NSWorkspace iconForFile:` for apps that ship icons via Asset Catalogs
+/// (`Assets.car`) or non-`.app` paths the .icns reader can't handle.
 pub fn extract_icon(path: &Path) -> Option<Vec<u8>> {
+    extract_icon_from_icns(path).or_else(|| extract_icon_via_nsworkspace(path))
+}
+
+fn extract_icon_from_icns(path: &Path) -> Option<Vec<u8>> {
     let icon_name = get_app_icon_name(path);
     let icon_filename = if icon_name.ends_with(".icns") { icon_name } else { format!("{}.icns", icon_name) };
     let icns_path = path.join("Contents/Resources").join(&icon_filename);
@@ -397,6 +405,91 @@ pub fn extract_icon(path: &Path) -> Option<Vec<u8>> {
         }
     }
     None
+}
+
+/// Renders the OS-resolved icon for `path` as a 128×128 PNG. Mirrors the
+/// AppKit pipeline already used by `sf_symbols::render_symbol_to_png`:
+/// `NSImage` → `CGImageForProposedRect:` → `NSBitmapImageRep` → PNG.
+///
+/// SAFETY: The AppKit pipeline is main-thread only. This is called from
+/// the sync `clipboard_record_capture` Tauri command and the application
+/// scanner, both of which are dispatched on the main thread.
+fn extract_icon_via_nsworkspace(path: &Path) -> Option<Vec<u8>> {
+    use std::ffi::CString;
+    use objc2::encode::{Encoding, RefEncode};
+    use objc2_foundation::NSData;
+
+    #[repr(C)]
+    struct CGImageStub { _private: [u8; 0] }
+    unsafe impl RefEncode for CGImageStub {
+        const ENCODING_REF: Encoding = Encoding::Pointer(&Encoding::Struct("CGImage", &[]));
+    }
+
+    let path_str = path.to_str()?;
+    let path_cstr = CString::new(path_str).ok()?;
+
+    unsafe {
+        let nsstring_cls = AnyClass::get("NSString")?;
+        let workspace_cls = AnyClass::get("NSWorkspace")?;
+        let nsbitmap_cls = AnyClass::get("NSBitmapImageRep")?;
+
+        let ns_path: *mut AnyObject =
+            msg_send![nsstring_cls, stringWithUTF8String: path_cstr.as_ptr()];
+
+        let workspace: *mut AnyObject = msg_send![workspace_cls, sharedWorkspace];
+        if workspace.is_null() {
+            log::warn!("[icon] NSWorkspace sharedWorkspace returned null");
+            return None;
+        }
+
+        let image: *mut AnyObject = msg_send![workspace, iconForFile: ns_path];
+        if image.is_null() {
+            log::warn!("[icon] NSWorkspace iconForFile returned null for {}", path_str);
+            return None;
+        }
+
+        // Match the .icns fast path's preferred 128px size so cached files
+        // are visually consistent regardless of which branch produced them.
+        let target = NSSize { width: 128.0, height: 128.0 };
+        let _: () = msg_send![image, setSize: target];
+
+        let mut proposed = NSRect {
+            origin: NSPoint { x: 0.0, y: 0.0 },
+            size: target,
+        };
+        let nil: *mut AnyObject = std::ptr::null_mut();
+        let cg_image: *const CGImageStub = msg_send![
+            image,
+            CGImageForProposedRect: &mut proposed as *mut NSRect
+            context: nil
+            hints: nil
+        ];
+        if cg_image.is_null() {
+            log::warn!("[icon] CGImageForProposedRect returned null for {}", path_str);
+            return None;
+        }
+
+        let bitmap: *mut AnyObject = msg_send![nsbitmap_cls, alloc];
+        let bitmap: *mut AnyObject = msg_send![bitmap, initWithCGImage: cg_image];
+        if bitmap.is_null() {
+            log::warn!("[icon] NSBitmapImageRep initWithCGImage returned null for {}", path_str);
+            return None;
+        }
+        let _: () = msg_send![bitmap, setSize: target];
+
+        // representationUsingType:4 == NSBitmapImageFileTypePNG
+        let png_data: Retained<NSData> = msg_send_id![
+            bitmap,
+            representationUsingType: 4u64
+            properties: nil
+        ];
+        let bytes = png_data.bytes();
+        if bytes.is_empty() {
+            log::warn!("[icon] NSBitmapImageRep produced empty PNG payload for {}", path_str);
+            return None;
+        }
+        Some(bytes.to_vec())
+    }
 }
 
 /// Sets the NSWindow's NSAppearance and the NSVisualEffectView material to
@@ -1273,6 +1366,44 @@ mod tests {
     /// Rust constants above must match — any drift in either direction
     /// breaks the compact-launcher invariant (webview pinned at MAX,
     /// window cropped to COMPACT).
+    /// `extract_icon` must succeed for app paths that ship icons via
+    /// Asset Catalog (`Assets.car`) instead of a discrete `.icns` —
+    /// otherwise launcher search and clipboard source-app icons render
+    /// the placeholder fallback for every modern macOS app. Drives the
+    /// NSWorkspace fallback added alongside this test.
+    ///
+    /// Strategy: build a fake `.app` bundle with no `.icns` anywhere
+    /// (so the fast path returns `None`) and assert `extract_icon`
+    /// still returns Some PNG bytes via the AppKit fallback.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn extract_icon_falls_back_to_nsworkspace_when_icns_missing() {
+        use std::fs;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "asyar_test_no_icns_{}.app",
+            std::process::id(),
+        ));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("Contents/Resources"))
+            .expect("setup: create fake app bundle");
+        // Intentionally NO .icns and NO Info.plist — guarantees the
+        // fast path returns None and exercises the fallback.
+
+        let bytes = extract_icon(&tmp);
+
+        let _ = fs::remove_dir_all(&tmp);
+
+        let bytes = bytes.expect("NSWorkspace fallback must yield PNG bytes");
+        assert!(!bytes.is_empty(), "PNG payload must be non-empty");
+        // PNG magic header: 89 50 4E 47 0D 0A 1A 0A
+        assert_eq!(
+            &bytes[..8],
+            &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A],
+            "fallback output must be a real PNG (got non-PNG header bytes)",
+        );
+    }
+
     #[test]
     fn heights_match_typescript_source() {
         const TS_SRC: &str =

--- a/src/services/clipboard/stores/clipboardHistoryStore.svelte.test.ts
+++ b/src/services/clipboard/stores/clipboardHistoryStore.svelte.test.ts
@@ -4,9 +4,11 @@ vi.mock('../../log/logService', () => ({
   logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 }))
 
-vi.mock('../../envService', () => ({
-  envService: { isTauri: true }
-}))
+// envService is intentionally NOT mocked — the launcher dropped its
+// browser-fallback shim in cad7759 (memory: feedback_no_browser_fallback)
+// and `envService.isTauri` no longer exists. Tests use the real module
+// so any code path that resurrects `envService.isTauri` short-circuits
+// to a wrong value and fails loudly here.
 
 // In-memory storage backing the mock invoke calls
 const mockDb = vi.hoisted(() => ({
@@ -118,5 +120,25 @@ describe('clipboardHistoryStore — Rust-backed', () => {
     expect(() => structuredClone(items)).not.toThrow()
     expect(items).toHaveLength(1)
     expect(items[0].content).toBe('hello')
+  })
+
+  it('addHistoryItem always persists via clipboard_record_capture (regression: cad7759 dead-guard)', async () => {
+    // Asserts the store routes captures into Rust persistence even though
+    // the post-cad7759 envService no longer exposes isTauri. Without this
+    // guarantee, source-app iconUrl enrichment (which only happens in
+    // Rust during record_capture) is dropped from every new capture.
+    const item = { id: 'persist-1', type: 'text' as any, content: 'flickr', createdAt: Date.now(), favorite: false }
+
+    await store.addHistoryItem(item)
+
+    // mockDb is the backing store for the clipboardRecordCapture mock —
+    // an item only lands here if Rust persistence ran. An in-memory-only
+    // fallback path would update store.items but leave mockDb empty.
+    expect(mockDb.items).toContainEqual(
+      expect.objectContaining({ id: 'persist-1', content: 'flickr' }),
+    )
+    expect(store.items).toContainEqual(
+      expect.objectContaining({ id: 'persist-1', content: 'flickr' }),
+    )
   })
 })

--- a/src/services/clipboard/stores/clipboardHistoryStore.svelte.ts
+++ b/src/services/clipboard/stores/clipboardHistoryStore.svelte.ts
@@ -8,10 +8,6 @@ import {
   clipboardRecordCapture,
   type StoredClipboardItem,
 } from "../../../lib/ipc/commands";
-import { envService } from "../../envService";
-
-// Constants
-const MAX_ITEMS = 1000;
 
 /**
  * Convert SDK type to Rust-compatible stored type.
@@ -69,8 +65,6 @@ export class ClipboardHistoryStoreClass {
     if (this.initialized) return;
     this.initialized = true;
 
-    if (!envService.isTauri) return;
-
     try {
       const stored = await clipboardGetAll();
       this.items = fromStored(stored);
@@ -81,16 +75,11 @@ export class ClipboardHistoryStoreClass {
 
   /**
    * Add an item to the clipboard history.
-   * Delegates all dedup / insert / cleanup logic to the Rust `clipboard_record_capture` command.
+   * Delegates all dedup / insert / cleanup logic — and source-app iconUrl
+   * enrichment — to the Rust `clipboard_record_capture` command. The
+   * returned list is the new source of truth.
    */
   async addHistoryItem(item: ClipboardHistoryItem): Promise<void> {
-    if (!envService.isTauri) {
-      // Non-Tauri fallback: in-memory only (no dedup, no cleanup)
-      this.items = [item, ...this.items.filter(i => i.id !== item.id)].slice(0, MAX_ITEMS);
-      this.#notify({ type: 'upsert', itemId: item.id });
-      return;
-    }
-
     try {
       const stored = await clipboardRecordCapture(toStored(item));
       this.items = fromStored(stored);
@@ -104,8 +93,6 @@ export class ClipboardHistoryStoreClass {
    * Get all clipboard history items.
    */
   async getHistoryItems(): Promise<ClipboardHistoryItem[]> {
-    if (!envService.isTauri) return $state.snapshot(this.items) as ClipboardHistoryItem[];
-
     try {
       const stored = await clipboardGetAll();
       this.items = fromStored(stored);
@@ -120,14 +107,6 @@ export class ClipboardHistoryStoreClass {
    * Toggle favorite status of an item.
    */
   async toggleFavorite(id: string): Promise<void> {
-    if (!envService.isTauri) {
-      this.items = this.items.map(item =>
-        item.id === id ? { ...item, favorite: !item.favorite } : item
-      );
-      this.#notify({ type: 'upsert', itemId: id });
-      return;
-    }
-
     try {
       const newFavorite = await clipboardToggleFavorite(id);
       // Update local state without a full reload
@@ -144,12 +123,6 @@ export class ClipboardHistoryStoreClass {
    * Delete an item from history.
    */
   async deleteHistoryItem(id: string): Promise<void> {
-    if (!envService.isTauri) {
-      this.items = this.items.filter(item => item.id !== id);
-      this.#notify({ type: 'delete', itemId: id });
-      return;
-    }
-
     try {
       await clipboardDeleteItem(id);
       this.items = this.items.filter(item => item.id !== id);
@@ -164,12 +137,6 @@ export class ClipboardHistoryStoreClass {
    */
   async clearHistory(): Promise<void> {
     const removedIds = this.items.filter(item => !item.favorite).map(item => item.id);
-    if (!envService.isTauri) {
-      this.items = this.items.filter(item => item.favorite);
-      removedIds.forEach((id) => this.#notify({ type: 'delete', itemId: id }));
-      return;
-    }
-
     try {
       await clipboardClearNonFavorites();
       this.items = this.items.filter(item => item.favorite);


### PR DESCRIPTION
Removed dead `envService.isTauri` guards that stranded every clipboard
write in an in-memory fallback after the browser-fallback shim was
deleted, so source-app `iconUrl` enrichment now reaches the DB again.
Added an `NSWorkspace iconForFile:` fallback in `extract_icon` so apps
that ship icons via `Assets.car` (UTM-style) no longer render the
placeholder in clipboard history and launcher search.