### PR TITLE
fix(launcher): mute notify file-watcher TRACE flood

### DIFF
--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -152,9 +152,11 @@ pub fn run() {
         .plugin(tauri_plugin_http::init())
         .plugin(
             // Silence verbose third-party crate logging (the browser-bridge axum
-            // server, the WebSocket layer, hyper, and the keychain) so a busy or
-            // reconnecting companion does not flood the console with connection
-            // TRACE lines. Asyar's own logs are unaffected.
+            // server, the WebSocket layer, hyper, the keychain, and the notify
+            // file-watcher behind the file index) so a busy companion or a burst
+            // of filesystem events does not flood the log with TRACE lines —
+            // the 40 kB delete-on-rotate file sink loses all history within
+            // minutes under a flood. Asyar's own logs are unaffected.
             tauri_plugin_log::Builder::new()
                 .level_for("axum", log::LevelFilter::Warn)
                 .level_for("hyper", log::LevelFilter::Warn)
@@ -164,6 +166,8 @@ pub fn run() {
                 .level_for("tungstenite", log::LevelFilter::Warn)
                 .level_for("keyring", log::LevelFilter::Warn)
                 .level_for("mio", log::LevelFilter::Warn)
+                .level_for("notify", log::LevelFilter::Warn)
+                .level_for("notify_debouncer_full", log::LevelFilter::Warn)
                 .build(),
         )
         .plugin(tauri_plugin_opener::init())


### PR DESCRIPTION
While debugging the [CPU issue](https://github.com/Xoshbin/asyar/pull/486), I struggled with asyar.log; 100s of notify::fsevent TRACE lines a second, with nothing helpful saved due to 40kb rotation.

The log plugin doesn't set a global level, so dependencies log at TRACE even in release builds.

This adds notify and notify-debouncer-full to the existing axum/hyper/tungstenite mutes. Warn and above still pass, and fs_watcher/file-index logging is unaffected. Not touching the global level or rotation strategy, just trying to targettedly clean.

Test:
- Run the app, save some files under a watched root, confirm asyar.log no longer fills with notify::fsevent lines
- Confirm asyar's own log lines still appear
- cargo test and the notifications suite green