### PR TITLE
fix(macos): match window corner mask to shell radius

### DIFF
--- a/asyar-launcher/src-tauri/src/platform/macos.rs
+++ b/asyar-launcher/src-tauri/src/platform/macos.rs
@@ -779,13 +779,18 @@ pub fn pin_launcher_webview<R: Runtime>(window: &WebviewWindow<R>) {
         let content_view: *mut AnyObject = msg_send![nsw, contentView];
         let content_frame: NSRect = msg_send![content_view, frame];
 
-        // Clip contentView to a 15px rounded rect so all subviews share the
-        // same mask — window_vibrancy only rounds the vibrancy view, and once
-        // the webview is pinned on top its square corners cover vibrancy's.
+        // Clip contentView to a rounded rect so all subviews share the same
+        // mask — window_vibrancy only rounds the vibrancy view, and once the
+        // webview is pinned on top its square corners cover vibrancy's.
+        //
+        // Must match the CSS shell radius (`--radius` shell / `:root`
+        // border-radius in style.css). The webview paints the dark fill rounded
+        // at that radius; if this clip is smaller, the fill recedes inside the
+        // mask and each corner leaks a wallpaper crescent.
         let _: () = msg_send![content_view, setWantsLayer: true];
         let layer: *mut AnyObject = msg_send![content_view, layer];
         if !layer.is_null() {
-            let _: () = msg_send![layer, setCornerRadius: 15.0_f64];
+            let _: () = msg_send![layer, setCornerRadius: 20.0_f64];
             let _: () = msg_send![layer, setMasksToBounds: Bool::YES];
         }
 

--- a/asyar-launcher/src/resources/styles/style.css
+++ b/asyar-launcher/src/resources/styles/style.css
@@ -50,7 +50,10 @@
   --radius-xl: 12px;
   --radius-full: 9999px;
   /* Launcher shell corner — intentionally larger than --radius-xl so the
-     outer window reads more pronounced than inner surfaces. */
+     outer window reads more pronounced than inner surfaces. On macOS this
+     MUST match the native contentView mask (pin_launcher_webview in
+     platform/macos.rs); a smaller native clip leaks a wallpaper crescent
+     at each corner. */
   border-radius: 20px;
 
   /* Typography */


### PR DESCRIPTION
The native contentView mask clipped at 15px while the CSS fill
painted at 20px, leaving a wallpaper crescent in the top corners.
Raise the native mask to 20px so it matches the intended shell radius.