### PR TITLE
fix(theme): keep custom themes from breaking Settings and layout

### DIFF
--- a/asyar-launcher/src/lib/themeVariables.test.ts
+++ b/asyar-launcher/src/lib/themeVariables.test.ts
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { collectThemeVariables, THEME_VAR_NAMES } from './themeVariables';
+import { collectThemeVariables, THEME_VAR_NAMES, THEMEABLE_VAR_NAMES } from './themeVariables';
 
 describe('collectThemeVariables', () => {
   let element: HTMLElement;
@@ -42,5 +42,37 @@ describe('collectThemeVariables', () => {
     element.style.setProperty('--bg-primary', '  rgb(0, 0, 0)  ');
     const vars = collectThemeVariables(element);
     expect(vars['--bg-primary']).toBe('rgb(0, 0, 0)');
+  });
+});
+
+// A custom theme recolors the app; it must never resize its layout. The
+// spacing grid and type scale are design-system-owned, so they are collected
+// for iframe injection (THEME_VAR_NAMES) but NOT overridable by a theme
+// (THEMEABLE_VAR_NAMES).
+describe('THEMEABLE_VAR_NAMES', () => {
+  it('excludes the spacing scale (--space-*)', () => {
+    expect(THEMEABLE_VAR_NAMES.some((n) => n.startsWith('--space-'))).toBe(false);
+  });
+
+  it('excludes the type scale (--font-size-*)', () => {
+    expect(THEMEABLE_VAR_NAMES.some((n) => n.startsWith('--font-size-'))).toBe(false);
+  });
+
+  it('still allows core color tokens', () => {
+    expect(THEMEABLE_VAR_NAMES).toContain('--bg-primary');
+    expect(THEMEABLE_VAR_NAMES).toContain('--text-primary');
+    expect(THEMEABLE_VAR_NAMES).toContain('--accent-primary');
+  });
+
+  it('is a strict subset of THEME_VAR_NAMES (the iframe-injection list)', () => {
+    for (const name of THEMEABLE_VAR_NAMES) {
+      expect(THEME_VAR_NAMES).toContain(name);
+    }
+    expect(THEMEABLE_VAR_NAMES.length).toBeLessThan(THEME_VAR_NAMES.length);
+  });
+
+  it('keeps --space-* and --font-size-* in THEME_VAR_NAMES so iframes still receive them', () => {
+    expect(THEME_VAR_NAMES).toContain('--space-5');
+    expect(THEME_VAR_NAMES).toContain('--font-size-base');
   });
 });

--- a/asyar-launcher/src/lib/themeVariables.ts
+++ b/asyar-launcher/src/lib/themeVariables.ts
@@ -66,6 +66,21 @@ export const THEME_VAR_NAMES: readonly string[] = [
 ];
 
 /**
+ * The subset of design tokens a custom theme extension is allowed to override.
+ *
+ * A theme recolors the app — it must never resize its layout. The spacing
+ * scale (`--space-*`) and type scale (`--font-size-*`) are design-system-owned:
+ * a third-party theme shipping its own (larger, or incomplete) values would
+ * reflow and overflow real UI like the Settings tab row. Those tokens are
+ * still collected for iframe injection via `THEME_VAR_NAMES`, but `applyTheme`
+ * filters overrides through this narrower list so themes can only change
+ * color, shadow, radius, font family, and transition tokens.
+ */
+export const THEMEABLE_VAR_NAMES: readonly string[] = THEME_VAR_NAMES.filter(
+  (name) => !name.startsWith('--space-') && !name.startsWith('--font-size-'),
+);
+
+/**
  * Reads the current computed values of all Asyar design token CSS variables
  * from the given element (should be document.documentElement).
  * Returns a plain object mapping variable name → computed value string.

--- a/asyar-launcher/src/resources/styles/style.css
+++ b/asyar-launcher/src/resources/styles/style.css
@@ -186,6 +186,7 @@ html[data-platform='macos'] .app-root {
 
     --border-color: rgba(90, 90, 95, 0.5);
     --separator: rgba(90, 90, 95, 0.5);
+    --divider-soft: rgba(255, 255, 255, 0.04);
 
     --accent-primary: rgb(0, 122, 255);
     --accent-success: rgb(40, 205, 65);
@@ -233,7 +234,7 @@ html[data-platform='macos'] .app-root {
   /* Settings window: opaque surfaces. The launcher composites translucent
      vibrancy over the desktop; the settings window sits on macOS gray and
      needs solid elevation to read (matches System Settings). */
-  :root:not([data-theme]) .settings-page {
+  :root:not([data-theme]):not([data-custom-theme]) .settings-page {
     --bg-primary: rgb(30, 30, 32);
     --bg-secondary: rgb(37, 37, 40);
     --bg-tertiary: rgb(47, 47, 50);
@@ -264,6 +265,7 @@ html[data-platform='macos'] .app-root {
 
   --border-color: rgba(90, 90, 95, 0.5);
   --separator: rgba(90, 90, 95, 0.5);
+  --divider-soft: rgba(255, 255, 255, 0.04);
 
   --accent-primary: rgb(0, 122, 255);
   --accent-success: rgb(40, 205, 65);
@@ -307,7 +309,7 @@ html[data-platform='macos'] .app-root {
   color: rgba(160, 175, 190, 0.75);
 }
 
-:root[data-theme='dark'] .settings-page {
+:root[data-theme='dark']:not([data-custom-theme]) .settings-page {
   --bg-primary: rgb(30, 30, 32);
   --bg-secondary: rgb(37, 37, 40);
   --bg-tertiary: rgb(47, 47, 50);
@@ -383,7 +385,7 @@ html[data-platform='macos'] .app-root {
     color: rgba(55, 65, 80, 0.6);
   }
 
-  :root:not([data-theme]) .settings-page {
+  :root:not([data-theme]):not([data-custom-theme]) .settings-page {
     --bg-primary: rgb(240, 240, 245);
     --bg-secondary: rgb(230, 230, 235);
     --bg-tertiary: rgb(245, 245, 247);
@@ -458,7 +460,7 @@ html[data-platform='macos'] .app-root {
   color: rgba(55, 65, 80, 0.6);
 }
 
-:root[data-theme='light'] .settings-page {
+:root[data-theme='light']:not([data-custom-theme]) .settings-page {
   --bg-primary: rgb(240, 240, 245);
   --bg-secondary: rgb(230, 230, 235);
   --bg-tertiary: rgb(245, 245, 247);

--- a/asyar-launcher/src/services/theme/themeService.test.ts
+++ b/asyar-launcher/src/services/theme/themeService.test.ts
@@ -5,15 +5,23 @@ vi.mock('../../lib/ipc/commands', () => ({
   getThemeDefinition: vi.fn(),
 }));
 
-vi.mock('../../lib/themeVariables', () => ({
-  THEME_VAR_NAMES: [
+vi.mock('../../lib/themeVariables', () => {
+  const THEME_VAR_NAMES = [
     '--bg-primary',
     '--bg-secondary',
     '--text-primary',
     '--accent-primary',
     '--font-ui',
-  ],
-}));
+    '--space-5',
+    '--font-size-base',
+  ];
+  return {
+    THEME_VAR_NAMES,
+    THEMEABLE_VAR_NAMES: THEME_VAR_NAMES.filter(
+      (n) => !n.startsWith('--space-') && !n.startsWith('--font-size-'),
+    ),
+  };
+});
 
 import { applyTheme, removeTheme, THEME_STYLE_ID } from './themeService';
 import { getThemeDefinition } from '../../lib/ipc/commands';
@@ -52,6 +60,17 @@ describe('themeService', () => {
     await applyTheme('test-theme');
     expect(document.documentElement.style.getPropertyValue('--bg-primary')).toBe('red');
     expect(document.documentElement.style.getPropertyValue('--totally-unknown')).toBe('');
+  });
+
+  it('applyTheme ignores structural tokens so a theme cannot resize the layout', async () => {
+    vi.mocked(getThemeDefinition).mockResolvedValue({
+      variables: { '--bg-primary': 'red', '--space-5': '40px', '--font-size-base': '20px' },
+      fonts: [],
+    });
+    await applyTheme('bloated-theme');
+    expect(document.documentElement.style.getPropertyValue('--bg-primary')).toBe('red');
+    expect(document.documentElement.style.getPropertyValue('--space-5')).toBe('');
+    expect(document.documentElement.style.getPropertyValue('--font-size-base')).toBe('');
   });
 
   it('removeTheme clears all overridden CSS variables', async () => {
@@ -105,5 +124,37 @@ describe('themeService', () => {
     await applyTheme('theme-b');
     expect(document.documentElement.style.getPropertyValue('--bg-primary')).toBe('blue');
     expect(document.documentElement.style.getPropertyValue('--text-primary')).toBe('white');
+  });
+
+  // The marker lets CSS (.settings-page opaque overrides) step aside so a
+  // custom theme's full palette — text included — flows through coherently.
+  it('applyTheme marks documentElement with data-custom-theme = themeId', async () => {
+    vi.mocked(getThemeDefinition).mockResolvedValue({
+      variables: { '--bg-primary': 'blue' },
+      fonts: [],
+    });
+    await applyTheme('catppuccin');
+    expect(document.documentElement.dataset.customTheme).toBe('catppuccin');
+  });
+
+  it('removeTheme clears the data-custom-theme marker', async () => {
+    vi.mocked(getThemeDefinition).mockResolvedValue({
+      variables: { '--bg-primary': 'blue' },
+      fonts: [],
+    });
+    await applyTheme('catppuccin');
+    expect(document.documentElement.dataset.customTheme).toBe('catppuccin');
+    removeTheme();
+    expect(document.documentElement.dataset.customTheme).toBeUndefined();
+  });
+
+  it('applyTheme updates the marker when switching themes', async () => {
+    vi.mocked(getThemeDefinition)
+      .mockResolvedValueOnce({ variables: {}, fonts: [] })
+      .mockResolvedValueOnce({ variables: {}, fonts: [] });
+    await applyTheme('theme-a');
+    expect(document.documentElement.dataset.customTheme).toBe('theme-a');
+    await applyTheme('theme-b');
+    expect(document.documentElement.dataset.customTheme).toBe('theme-b');
   });
 });

--- a/asyar-launcher/src/services/theme/themeService.ts
+++ b/asyar-launcher/src/services/theme/themeService.ts
@@ -1,6 +1,6 @@
 import { getThemeDefinition } from '../../lib/ipc/commands';
 import type { ThemeDefinition } from '../../lib/ipc/commands';
-import { THEME_VAR_NAMES } from '../../lib/themeVariables';
+import { THEMEABLE_VAR_NAMES } from '../../lib/themeVariables';
 import { syncNativeBarStyle } from './nativeBarSync';
 
 export const THEME_STYLE_ID = 'asyar-theme-fonts';
@@ -30,7 +30,7 @@ export async function applyTheme(themeId: string): Promise<void> {
     throw new Error(`get_theme_definition failed for ${themeId}`);
   }
 
-  const allowedSet = new Set(THEME_VAR_NAMES);
+  const allowedSet = new Set(THEMEABLE_VAR_NAMES);
   for (const [name, value] of Object.entries(definition.variables)) {
     if (allowedSet.has(name)) {
       document.documentElement.style.setProperty(name, value);
@@ -56,6 +56,13 @@ export async function applyTheme(themeId: string): Promise<void> {
     document.head.appendChild(styleEl);
   }
 
+  // Marker for CSS: while a custom theme is active, the .settings-page opaque
+  // overrides (which force system light/dark surfaces) step aside so the
+  // theme's full palette — text and accents included — flows through. Without
+  // this the settings page keeps system backgrounds but inherits the theme's
+  // text colors, producing unreadable low-contrast text.
+  document.documentElement.dataset.customTheme = themeId;
+
   queueNativeBarResync();
 }
 
@@ -72,6 +79,8 @@ export function removeTheme(): void {
   if (existing) {
     existing.remove();
   }
+
+  delete document.documentElement.dataset.customTheme;
 
   queueNativeBarResync();
 }


### PR DESCRIPTION
Custom themes wrote their whole palette to :root, so the Settings page
kept system backgrounds but inherited theme text (unreadable), and their
spacing/type scales overflowed the tabs row. Let Settings adopt the active
theme's full palette, and restrict theme overrides to color/cosmetic
tokens so themes recolor without resizing the layout.