### PR TITLE
chore(deps): bump thiserror to 2, document the two HTTP stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,43 @@
 # Asyar
 
-**Local-First Cross platform open-source alternative to Raycast.**
+**Privacy-focused Local-First Cross platform open-source alternative to Raycast.**
 
-Asyar is a fast, extensible, **local-first** command launcher for macOS, Windows, and Linux. No account. No cloud. No subscription. Just a blazing-fast launcher that stays entirely on your machine.
+Asyar is a fast, extensible, **Privacy-focused local-first** command launcher for macOS, Windows, and Linux. No account. No cloud. No subscription. Just a blazing-fast launcher that stays entirely on your machine.
 
-Built with [Tauri v2](https://tauri.app/) + Rust and [Svelte 5](https://svelte.dev/) — not Electron.
+## Tiny Footprint. Native Performance.
+
+Asyar is built with **Tauri + Rust** instead of Electron. That means:
+
+- **Significantly less RAM** — no bundled Chromium, no V8 runtime sitting idle
+- **Instant startup** — the Rust backend initializes in milliseconds
+- **Real OS integration** — native APIs for app indexing, clipboard, global hotkeys, and accessibility
+- **Secure by default** — extensions run in isolated iframes; a broken extension can't crash the launcher
+
+> _Native performance, web flexibility — Rust does the heavy lifting, Svelte 5 keeps the UI snappy._
+
+### Measured against Raycast
+
+<!-- benchmarks:start -->
+
+| Metric                                 | Asyar 0.1.1-38 | Raycast 1.104.23 | Raycast Beta 0.69.0.0 |
+| -------------------------------------- | -------------: | ---------------: | --------------------: |
+| Hotkey → window visible (median of 15) |        12.0 ms |          21.7 ms |               17.1 ms |
+| Hotkey → window visible (p95)          |        14.7 ms |          24.0 ms |               27.0 ms |
+| Cold start → usable                    |         572 ms |           888 ms |               1012 ms |
+| Memory footprint, idle (all processes) |       435.6 MB |         272.6 MB |              463.9 MB |
+| CPU while idle (30s average)           |         3.20 % |           0.04 % |                1.45 % |
+| App size on disk                       |          64 MB |           209 MB |                179 MB |
+
+<sub>Measured 2026-07-17 on a Apple M4 Max (36 GB RAM), macOS 26.5.2, each app
+as installed, summoned by its own registered global hotkey, one at a time on a
+quiet machine. Black-box measurement: synthetic hotkey press → launcher window
+on screen. Reproduce with [`benchmarks/bench.sh`](benchmarks/README.md).</sub>
+
+<!-- benchmarks:end -->
+
+Don't take our word for it: [`benchmarks/bench.sh`](benchmarks/README.md) measures Asyar and Raycast (stable and beta) black-box on your own machine — hotkey-to-window latency, cold start, full-process-group memory, idle CPU, and disk size — and regenerates this table with `--update-readme`.
+
+---
 
 ![Asyar launcher](docs/images/getting-started-hero.png)
 
@@ -69,41 +102,6 @@ brew install --cask asyar
 | Background Scheduling (native Rust daemon)                   |    ✅     |        ❌         |       ❌       |
 | Reactive Live Subtitles (real-time root list updates)        |    ✅     |        ❌         |       ❌       |
 | **Silent AI Commands** (no-window in-place text replacement) |    ✅     |        ❌         |       ❌       |
-
----
-
-## Tiny Footprint. Native Performance.
-
-Asyar is built with **Tauri + Rust** instead of Electron. That means:
-
-- **Significantly less RAM** — no bundled Chromium, no V8 runtime sitting idle
-- **Instant startup** — the Rust backend initializes in milliseconds
-- **Real OS integration** — native APIs for app indexing, clipboard, global hotkeys, and accessibility
-- **Secure by default** — extensions run in isolated iframes; a broken extension can't crash the launcher
-
-> _Native performance, web flexibility — Rust does the heavy lifting, Svelte 5 keeps the UI snappy._
-
-### Measured against Raycast
-
-<!-- benchmarks:start -->
-
-| Metric                                 | Asyar 0.1.1-38 | Raycast 1.104.23 | Raycast Beta 0.69.0.0 |
-| -------------------------------------- | -------------: | ---------------: | --------------------: |
-| Hotkey → window visible (median of 15) |        12.0 ms |          21.7 ms |               17.1 ms |
-| Hotkey → window visible (p95)          |        14.7 ms |          24.0 ms |               27.0 ms |
-| Cold start → usable                    |         572 ms |           888 ms |               1012 ms |
-| Memory footprint, idle (all processes) |       435.6 MB |         272.6 MB |              463.9 MB |
-| CPU while idle (30s average)           |         3.20 % |           0.04 % |                1.45 % |
-| App size on disk                       |          64 MB |           209 MB |                179 MB |
-
-<sub>Measured 2026-07-17 on a Apple M4 Max (36 GB RAM), macOS 26.5.2, each app
-as installed, summoned by its own registered global hotkey, one at a time on a
-quiet machine. Black-box measurement: synthetic hotkey press → launcher window
-on screen. Reproduce with [`benchmarks/bench.sh`](benchmarks/README.md).</sub>
-
-<!-- benchmarks:end -->
-
-Don't take our word for it: [`benchmarks/bench.sh`](benchmarks/README.md) measures Asyar and Raycast (stable and beta) black-box on your own machine — hotkey-to-window latency, cold start, full-process-group memory, idle CPU, and disk size — and regenerates this table with `--update-readme`.
 
 ---
 

--- a/asyar-launcher/src-tauri/Cargo.lock
+++ b/asyar-launcher/src-tauri/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.21.0",
  "tokio-util",

--- a/asyar-launcher/src-tauri/Cargo.toml
+++ b/asyar-launcher/src-tauri/Cargo.toml
@@ -34,7 +34,7 @@ tauri-plugin-log = "2"
 log = "0.4"
 tauri-plugin-fs = "2"
 tauri-plugin-store = "2"
-thiserror = "1.0.63"
+thiserror = "2"
 enigo = "0.1.3"
 rusqlite = { version = "0.31", features = ["bundled"] }
 plist = "1.7"
@@ -58,7 +58,10 @@ bip39 = { version = "2.0", default-features = false, features = ["std"] }
 rand = "0.10"
 zeroize = "1"
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
-reqwest = { version = "0.12", features = ["json", "stream"] } # For downloading
+# Two HTTP stacks coexist on purpose — do NOT unify them:
+# reqwest is host-side Rust HTTP (downloads, the auth/API client, sidecar
+# fetches) that runs in the Rust process with no webview origin.
+reqwest = { version = "0.12", features = ["json", "stream"] } # host-side Rust HTTP
 zip = { version = "2.1", default-features = false, features = ["deflate"] } # For extracting zip files
 futures-util = "0.3" # For stream handling
 tokio-util = { version = "0.7", features = ["codec"] } # For async file I/O helpers
@@ -72,6 +75,11 @@ async_zip = { version = "0.0.17", features = ["full", "tokio"] } # Enable tokio 
 # Homebrew. See issue #345. Direct dep + `static` feature wins via Cargo's
 # feature unification.
 liblzma-sys = { version = "0.4", features = ["static"] }
+# The other HTTP stack (see reqwest above): the fetch client exposed to the
+# webview/extensions. Host network calls from JS MUST route through this, not
+# the WebView's own fetch(), which breaks CORS on Windows (the tauri:// origin
+# mismatches the target). Drives the SDK's network:fetch. Kept separate from
+# reqwest on purpose — unifying them would reintroduce the Windows CORS break.
 tauri-plugin-http = { version = "2", features = ["unsafe-headers"] }
 tauri-plugin-dialog = "2.7"
 tauri-plugin-shell = "2.3.5"


### PR DESCRIPTION
thiserror 1 → 2 — all 7 deriving modules use standard #[derive(Error)] /
#[error] / #[from] patterns, so no code changes; clippy + full test suite green.
Document in Cargo.toml why reqwest and tauri-plugin-http coexist (host-side Rust
HTTP vs the webview/extension fetch client that needs the plugin's CORS handling
on Windows) so neither gets "unified" away.