### PR TITLE
fix(deeplink): deliver cold-start and second-instance deep links

### DIFF
--- a/asyar-launcher/src-tauri/Cargo.lock
+++ b/asyar-launcher/src-tauri/Cargo.lock
@@ -7118,6 +7118,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
+ "tauri-plugin-deep-link",
  "thiserror 2.0.18",
  "tracing",
  "windows-sys 0.60.2",

--- a/asyar-launcher/src-tauri/Cargo.toml
+++ b/asyar-launcher/src-tauri/Cargo.toml
@@ -112,7 +112,7 @@ iana-time-zone = "0.1.65"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-autostart = "2"
 tauri-plugin-global-shortcut = "2"
-tauri-plugin-single-instance = "2"
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }  # deep-link feature forwards asyar:// argv to on_open_url on Windows/Linux
 
 
 [features]

--- a/asyar-launcher/src-tauri/src/deeplink.rs
+++ b/asyar-launcher/src-tauri/src/deeplink.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 use std::collections::HashMap;
-use tauri::AppHandle;
+use tauri::{AppHandle, Emitter, State};
 
 /// The custom URL scheme this running instance is registered for with the
 /// OS. Mirrors `plugins.deep-link.desktop.schemes` in the active tauri
@@ -18,7 +18,7 @@ pub fn deep_link_scheme(app: &AppHandle) -> &'static str {
 
 /// Typed payload emitted as `asyar:deeplink:extension` when a deep link
 /// targets an extension command: `{scheme}://extensions/{extensionId}/{commandId}?args`.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtensionDeeplinkPayload {
     pub extension_id: String,
@@ -93,6 +93,83 @@ pub fn parse_extension_deeplink(
         command_id: command_id.to_string(),
         args,
     })
+}
+
+/// Routing decision for an incoming deep link. Pure classification lives in
+/// [`classify_deeplink`]; [`dispatch_url`] performs the side-effecting emit.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DeeplinkRoute {
+    /// Targets an extension command → frontend event `asyar:deeplink:extension`.
+    Extension(ExtensionDeeplinkPayload),
+    /// Any other in-scheme URL (auth / OAuth) → frontend event `asyar:deep-link`.
+    Raw(String),
+}
+
+/// Classify an incoming URL into its route without touching the app. Returns
+/// `None` for URLs that are not this flavor's scheme, or malformed extension
+/// links (which must be dropped, never re-routed as raw).
+pub fn classify_deeplink(raw: &str, scheme: &str) -> Option<DeeplinkRoute> {
+    if !raw.starts_with(&format!("{scheme}://")) {
+        return None;
+    }
+    if raw.starts_with(&format!("{scheme}://extensions/")) {
+        // Malformed extension links must be dropped, not re-routed as raw.
+        return parse_extension_deeplink(raw, scheme).map(DeeplinkRoute::Extension);
+    }
+    Some(DeeplinkRoute::Raw(raw.to_string()))
+}
+
+/// Launch-time deep links captured before the frontend's listeners exist. The
+/// frontend drains these via `flush_pending_deeplinks` once ready, so the emit
+/// can't race listener registration (same reason `restore_workers` is pulled).
+#[derive(Default)]
+pub struct PendingDeeplinks(std::sync::Mutex<Vec<String>>);
+
+impl PendingDeeplinks {
+    /// Buffer a launch URL captured during setup.
+    pub fn push(&self, url: String) {
+        if let Ok(mut guard) = self.0.lock() {
+            guard.push(url);
+        }
+    }
+
+    /// Drain every buffered URL, leaving the buffer empty.
+    pub fn take(&self) -> Vec<String> {
+        self.0
+            .lock()
+            .map(|mut guard| std::mem::take(&mut *guard))
+            .unwrap_or_default()
+    }
+}
+
+/// Route a single incoming deep-link URL to the correct frontend event.
+/// Shared by the warm path (`on_open_url`) and the cold-start flush.
+pub fn dispatch_url(app: &AppHandle, scheme: &str, raw: &str) {
+    match classify_deeplink(raw, scheme) {
+        Some(DeeplinkRoute::Extension(payload)) => {
+            log::info!(
+                "[Deeplink] Extension trigger: {}/{}",
+                payload.extension_id,
+                payload.command_id
+            );
+            let _ = app.emit("asyar:deeplink:extension", payload);
+        }
+        Some(DeeplinkRoute::Raw(url)) => {
+            let _ = app.emit("asyar:deep-link", url);
+        }
+        None => log::warn!("[Deeplink] Ignoring unroutable deep link: {raw}"),
+    }
+}
+
+/// Drain deep links that launched the app and dispatch them now that the
+/// frontend's listeners are registered. Frontend-invoked from appInitializer
+/// so the emit can't race listener setup.
+#[tauri::command]
+pub fn flush_pending_deeplinks(app: AppHandle, pending: State<'_, PendingDeeplinks>) {
+    let scheme = deep_link_scheme(&app);
+    for url in pending.take() {
+        dispatch_url(&app, scheme, &url);
+    }
 }
 
 #[cfg(test)]
@@ -214,5 +291,57 @@ mod tests {
             parse_extension_deeplink("asyar://extensions/com.example.calc/run", "asyar-dev")
                 .is_none()
         );
+    }
+
+    #[test]
+    fn classifies_extension_link() {
+        match classify_deeplink("asyar://extensions/com.example/run?x=1", "asyar") {
+            Some(DeeplinkRoute::Extension(p)) => {
+                assert_eq!(p.extension_id, "com.example");
+                assert_eq!(p.command_id, "run");
+            }
+            other => panic!("expected Extension route, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classifies_raw_auth_link() {
+        assert_eq!(
+            classify_deeplink("asyar://auth/callback?code=abc", "asyar"),
+            Some(DeeplinkRoute::Raw(
+                "asyar://auth/callback?code=abc".to_string()
+            )),
+        );
+    }
+
+    #[test]
+    fn drops_malformed_extension_link() {
+        // Starts with the extensions prefix but has no commandId: must be
+        // dropped, never leaked to the raw auth listeners.
+        assert_eq!(
+            classify_deeplink("asyar://extensions/onlyext", "asyar"),
+            None
+        );
+    }
+
+    #[test]
+    fn ignores_foreign_scheme() {
+        assert_eq!(classify_deeplink("https://evil.example/x", "asyar"), None);
+        assert_eq!(classify_deeplink("asyar://auth/x", "asyar-dev"), None);
+    }
+
+    #[test]
+    fn pending_deeplinks_push_then_take_drains() {
+        let pending = PendingDeeplinks::default();
+        pending.push("asyar://extensions/a/b".to_string());
+        pending.push("asyar://auth/cb".to_string());
+        assert_eq!(
+            pending.take(),
+            vec![
+                "asyar://extensions/a/b".to_string(),
+                "asyar://auth/cb".to_string()
+            ]
+        );
+        assert!(pending.take().is_empty(), "second take must be empty");
     }
 }

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -182,8 +182,13 @@ pub fn run() {
     ));
 
     let builder = tauri::Builder::default()
-        .plugin(tauri_plugin_notification::init())
+        // Single-instance must be the FIRST plugin: it intercepts a second
+        // launch before other plugins initialize, and (with the "deep-link"
+        // feature) forwards that instance's asyar:// URL argv into on_open_url
+        // — the only way a deep link reaches an already-running app on
+        // Windows/Linux.
         .plugin(tauri_plugin_single_instance::init(|_app, _args, _cwd| {}))
+        .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_clipboard_x::init())
         .plugin(tauri_plugin_fs::init())
@@ -244,6 +249,7 @@ pub fn run() {
         .manage(auth::state::AuthState::default())
         .manage(auth::api_client::ApiClient::new())
         .manage(oauth::OAuthPendingFlowState::new())
+        .manage(deeplink::PendingDeeplinks::default())
         .manage(hud_window::HudState::default())
         .manage(shell::ShellProcessRegistry::new())
         .manage(extensions::scheduler::SchedulerState::new())
@@ -299,6 +305,7 @@ pub fn run() {
         )))
         .setup(setup_app)
         .invoke_handler(tauri::generate_handler![
+            deeplink::flush_pending_deeplinks,
             commands::set_focus_lock,
             commands::feedback_publish,
             commands::feedback_get_current,
@@ -1144,35 +1151,37 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // "asyar" for production or "asyar-dev" for the local dev flavor (see
     // deeplink::deep_link_scheme and tauri.dev.conf.json).
     // Extension deep links ({scheme}://extensions/{extId}/{cmdId}?args) are
-    // parsed in Rust and emitted as a typed "asyar:deeplink:extension" event.
-    // All other URLs (auth, OAuth) are emitted as raw "asyar:deep-link" strings.
+    // parsed in Rust and emitted as a typed "asyar:deeplink:extension" event;
+    // all other URLs (auth, OAuth) are emitted as raw "asyar:deep-link" strings.
+    // Both the warm path and the cold-start path funnel through
+    // deeplink::dispatch_url so classification lives in exactly one place.
     {
         use tauri_plugin_deep_link::DeepLinkExt;
+        let scheme = deeplink::deep_link_scheme(app.handle());
+
+        // Warm path: links arriving while the app runs. On Windows/Linux this
+        // only fires because tauri-plugin-single-instance carries the
+        // "deep-link" feature, which forwards the second instance's URL argv.
         let handle = app.handle().clone();
-        let scheme = deeplink::deep_link_scheme(&handle);
-        let extensions_prefix = format!("{scheme}://extensions/");
         app.deep_link().on_open_url(move |event| {
-            let urls: Vec<String> = event.urls().iter().map(|u| u.to_string()).collect();
-            for url in urls {
-                if url.starts_with(&extensions_prefix) {
-                    match deeplink::parse_extension_deeplink(&url, scheme) {
-                        Some(payload) => {
-                            log::info!(
-                                "[Deeplink] Extension trigger: {}/{}",
-                                payload.extension_id,
-                                payload.command_id
-                            );
-                            let _ = handle.emit("asyar:deeplink:extension", payload);
-                        }
-                        None => {
-                            log::warn!("[Deeplink] Failed to parse extension URL: {}", url);
-                        }
-                    }
-                } else {
-                    let _ = handle.emit("asyar:deep-link", url);
-                }
+            for url in event.urls() {
+                deeplink::dispatch_url(&handle, scheme, url.as_str());
             }
         });
+
+        // Cold-start path: a link that launched the app (Windows/Linux read it
+        // from argv). Buffer it; the frontend drains via flush_pending_deeplinks
+        // once its listeners exist, so the emit can't race listener setup.
+        match app.deep_link().get_current() {
+            Ok(Some(urls)) => {
+                let pending = app.state::<deeplink::PendingDeeplinks>();
+                for url in urls {
+                    pending.push(url.to_string());
+                }
+            }
+            Ok(None) => {}
+            Err(err) => log::warn!("[Deeplink] get_current failed: {err}"),
+        }
     }
 
     #[cfg(target_os = "macos")]

--- a/asyar-launcher/src/lib/ipc/commands.ts
+++ b/asyar-launcher/src/lib/ipc/commands.ts
@@ -7,6 +7,7 @@
 export * from './extensionPreferencesCommands';
 export * from './commandArgDefaultsCommands';
 export * from './iframeLifecycleCommands';
+export * from './deeplinkCommands';
 export * from './browserCommands';
 export * from './extensionLifecycleCommands';
 export * from './shortcodeCommands';

--- a/asyar-launcher/src/lib/ipc/deeplinkCommands.ts
+++ b/asyar-launcher/src/lib/ipc/deeplinkCommands.ts
@@ -1,0 +1,8 @@
+import { invokeSafe } from './invokeSafe';
+
+// Silent: appInitializer.ts is the sole caller. Drains any asyar:// link that
+// cold-started the app; Rust re-emits it through the normal deep-link events
+// now that the extension/auth/OAuth listeners are registered.
+export function flushPendingDeeplinks(): Promise<null> {
+  return invokeSafe('flush_pending_deeplinks', undefined, { silent: true });
+}

--- a/asyar-launcher/src/services/appInitializer.ts
+++ b/asyar-launcher/src/services/appInitializer.ts
@@ -276,6 +276,11 @@ export const appInitializer = {
       await deeplinkService.init();
       logService.info('Extension deeplink service initialized.');
 
+      // Deliver any asyar:// link that cold-started the app. Safe to call now:
+      // the extension (above), auth, and OAuth deep-link listeners are all
+      // registered, so Rust's re-emit can't race listener setup.
+      await commands.flushPendingDeeplinks();
+
       // Notification action dispatch bridge. Runs on every Tauri instance
       // so clicking a button on an OS notification fires the declared
       // extension command even when the launcher window is hidden.


### PR DESCRIPTION
Enable the single-instance "deep-link" feature so asyar:// links reach a
running app on Windows/Linux, and ingest launch URLs via get_current() —
buffered and drained by the frontend so the emit can't race listener setup.
Warm and cold paths share one unit-tested classify_deeplink/dispatch_url.