### PR TITLE
refactor(agents): stream runner events over a Tauri Channel

### DIFF
--- a/asyar-launcher/src-tauri/src/agents/runner.rs
+++ b/asyar-launcher/src-tauri/src/agents/runner.rs
@@ -58,13 +58,6 @@ pub enum AgentStreamEvent {
     Cancelled,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
-#[serde(rename_all = "camelCase")]
-pub struct AgentStreamEventPayload {
-    pub stream_id: String,
-    pub event: AgentStreamEvent,
-}
-
 /// Everything Rust needs to resolve *and* validate an agent's provider for a
 /// run, without owning the settings store itself: the frontend still owns
 /// `settings.ai.providers`/`defaultAgentId` and passes them through as data

--- a/asyar-launcher/src-tauri/src/agents/tool_executor.rs
+++ b/asyar-launcher/src-tauri/src/agents/tool_executor.rs
@@ -1,11 +1,11 @@
-use crate::agents::runner::{ExternalToolRequest, McpPermissionChoice};
+use crate::agents::runner::{AgentStreamEvent, ExternalToolRequest, McpPermissionChoice};
 use crate::agents::tools::{ToolRegistry, ToolSource};
 use crate::error::AppError;
 use crate::mcp::McpSupervisor;
 use crate::storage::DataStore;
 use std::sync::Arc;
 use std::time::Duration;
-use tauri::{AppHandle, Emitter};
+use tauri::ipc::Channel;
 use tokio::sync::oneshot;
 
 const BROWSER_BRIDGE_TIMEOUT: Duration = Duration::from_secs(120);
@@ -139,39 +139,33 @@ async fn await_bridge_response<T>(
 
 #[derive(Clone)]
 pub struct TauriAgentToolRuntime {
-    app: AppHandle,
     runner_state: crate::agents::runner::AgentRunnerState,
     stream_id: String,
+    on_event: Channel<AgentStreamEvent>,
     supervisor: Arc<McpSupervisor>,
     store: DataStore,
 }
 
 impl TauriAgentToolRuntime {
     pub fn new(
-        app: AppHandle,
         runner_state: crate::agents::runner::AgentRunnerState,
         stream_id: String,
+        on_event: Channel<AgentStreamEvent>,
         supervisor: Arc<McpSupervisor>,
         store: DataStore,
     ) -> Self {
         Self {
-            app,
             runner_state,
             stream_id,
+            on_event,
             supervisor,
             store,
         }
     }
 
-    fn emit(&self, event: crate::agents::runner::AgentStreamEvent) -> Result<(), AppError> {
-        self.app
-            .emit(
-                "agent-stream-event",
-                &crate::agents::runner::AgentStreamEventPayload {
-                    stream_id: self.stream_id.clone(),
-                    event,
-                },
-            )
+    fn emit(&self, event: AgentStreamEvent) -> Result<(), AppError> {
+        self.on_event
+            .send(event)
             .map_err(|error| AppError::Other(error.to_string()))
     }
 }

--- a/asyar-launcher/src-tauri/src/commands/agents.rs
+++ b/asyar-launcher/src-tauri/src/commands/agents.rs
@@ -1,6 +1,5 @@
 use crate::agents::runner::{
-    AgentRunConfig, AgentRunnerState, AgentStreamEvent, AgentStreamEventPayload,
-    ExternalToolRequest, McpPermissionChoice,
+    AgentRunConfig, AgentRunnerState, AgentStreamEvent, ExternalToolRequest, McpPermissionChoice,
 };
 use crate::agents::tool_executor::{execute_agent_tool, TauriAgentToolRuntime};
 use crate::agents::tools::ToolRegistryState;
@@ -16,6 +15,7 @@ use crate::storage::DataStore;
 use rusqlite::Connection;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tauri::ipc::Channel;
 use tauri::{AppHandle, Emitter, State};
 
 fn now_ms() -> i64 {
@@ -463,22 +463,20 @@ pub async fn agents_run_thread(
     run_id: Option<String>,
     config: AgentRunConfig,
     stream_id: String,
+    on_event: Channel<AgentStreamEvent>,
 ) -> Result<(), AppError> {
     let cancellation = runner_state.begin_run(&stream_id)?;
-    let app_clone = app.clone();
-    let stream_id_clone = stream_id.clone();
 
-    let on_event = move |event: AgentStreamEvent| {
-        let payload = AgentStreamEventPayload {
-            stream_id: stream_id_clone.clone(),
-            event,
-        };
-        let _ = app_clone.emit("agent-stream-event", &payload);
+    // Per-caller event sink: the channel is scoped to the invoking view,
+    // replacing the broadcast "agent-stream-event" bus + streamId filter.
+    let events = on_event.clone();
+    let emit_event = move |event: AgentStreamEvent| {
+        let _ = events.send(event);
     };
     let tool_runtime = TauriAgentToolRuntime::new(
-        app.clone(),
         runner_state.inner().clone(),
         stream_id.clone(),
+        on_event,
         supervisor.inner().clone(),
         store.inner().clone(),
     );
@@ -499,7 +497,7 @@ pub async fn agents_run_thread(
         user_text,
         run_id,
         config,
-        on_event,
+        emit_event,
         dispatch_external,
         Some(cancellation),
     )
@@ -523,6 +521,7 @@ pub async fn agents_run_silent(
     user_text: String,
     config: AgentRunConfig,
     stream_id: String,
+    on_event: Channel<AgentStreamEvent>,
 ) -> Result<String, AppError> {
     let agent = {
         let conn = store.conn()?;
@@ -550,22 +549,17 @@ pub async fn agents_run_silent(
 
     let cache_key = user_text.clone();
     let cancellation = runner_state.begin_run(&stream_id)?;
-    let app_for_events = app.clone();
-    let event_stream_id = stream_id.clone();
-    let on_event = move |event: AgentStreamEvent| {
-        let _ = app_for_events.emit(
-            "agent-stream-event",
-            &AgentStreamEventPayload {
-                stream_id: event_stream_id.clone(),
-                event,
-            },
-        );
+
+    // Per-caller event sink (see agents_run_thread).
+    let events = on_event.clone();
+    let emit_event = move |event: AgentStreamEvent| {
+        let _ = events.send(event);
     };
 
     let tool_runtime = TauriAgentToolRuntime::new(
-        app.clone(),
         runner_state.inner().clone(),
         stream_id.clone(),
+        on_event,
         supervisor.inner().clone(),
         store.inner().clone(),
     );
@@ -583,7 +577,7 @@ pub async fn agents_run_silent(
         &registry,
         user_text,
         config,
-        on_event,
+        emit_event,
         dispatch_external,
         Some(cancellation),
     )

--- a/asyar-launcher/src-tauri/src/search_engine/models.rs
+++ b/asyar-launcher/src-tauri/src/search_engine/models.rs
@@ -428,7 +428,6 @@ mod bindings_export {
             .register::<crate::agents::editor::AgentProviderDescriptor>()
             .register::<crate::agents::runner::AgentRunConfig>()
             .register::<crate::agents::runner::AgentStreamEvent>()
-            .register::<crate::agents::runner::AgentStreamEventPayload>()
             .register::<crate::system_actions::SystemAction>();
 
         Typescript::default()

--- a/asyar-launcher/src/bindings.ts
+++ b/asyar-launcher/src/bindings.ts
@@ -28,11 +28,6 @@ export type AgentRunConfig = {
 
 export type AgentStreamEvent = { type: "user_message_persisted" } | { type: "text_delta"; delta: string; accumulated: string } | { type: "status"; status: string | null } | { type: "assistant_turn_persisted" } | { type: "tool_dispatch"; tool_call_id: string; extension_id: string; tool_id: string; arguments: any } | { type: "tool_dispatch_cancelled"; tool_call_id: string } | { type: "mcp_permission_request"; tool_call_id: string; server_id: string; tool_id: string; agent_id: string } | { type: "mcp_permission_cancelled"; tool_call_id: string } | { type: "error"; message: string } | { type: "completed" } | { type: "cancelled" };
 
-export type AgentStreamEventPayload = {
-	streamId: string,
-	event: AgentStreamEvent,
-};
-
 export type AliasConflict = {
 	objectId: string,
 	itemName: string,

--- a/asyar-launcher/src/built-in-features/agents/agentLoop.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentLoop.test.ts
@@ -34,13 +34,13 @@ const streamMock = vi.hoisted(() => ({
         onBridgeError?: (error: Error) => void;
       }
     | undefined,
-  unlisten: vi.fn(),
+  dispose: vi.fn(),
 }));
 
 vi.mock('./agentStreamBridge', () => ({
-  listenToAgentStream: vi.fn(async (options) => {
+  createAgentStreamChannel: vi.fn((options) => {
     streamMock.options = options;
-    return streamMock.unlisten;
+    return { channel: {}, dispose: streamMock.dispose };
   }),
 }));
 
@@ -158,6 +158,7 @@ describe('runAgent', () => {
       'run-1',
       runConfig,
       expect.any(String),
+      expect.anything(),
     );
     expect(onUserMessagePersisted).toHaveBeenCalledOnce();
     expect(onAssistantStatus).toHaveBeenNthCalledWith(1, 'searching');
@@ -166,7 +167,7 @@ describe('runAgent', () => {
     expect(onAssistantTurnPersisted).toHaveBeenCalledOnce();
     expect(handle.write).toHaveBeenCalledWith('Hi');
     expect(handle.done).toHaveBeenCalledOnce();
-    expect(streamMock.unlisten).toHaveBeenCalledOnce();
+    expect(streamMock.dispose).toHaveBeenCalledOnce();
   });
 
   it('fails the tracked run and rethrows a Rust command error', async () => {
@@ -178,7 +179,7 @@ describe('runAgent', () => {
 
     expect(handle.fail).toHaveBeenCalledWith('provider unavailable');
     expect(handle.done).not.toHaveBeenCalled();
-    expect(streamMock.unlisten).toHaveBeenCalledOnce();
+    expect(streamMock.dispose).toHaveBeenCalledOnce();
   });
 
   it('cancels Rust and marks the run cancelled when the caller aborts', async () => {
@@ -251,6 +252,7 @@ describe('runAgent', () => {
       'run-1',
       runConfig,
       expect.any(String),
+      expect.anything(),
     );
   });
 });

--- a/asyar-launcher/src/built-in-features/agents/agentLoop.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentLoop.ts
@@ -11,7 +11,7 @@ import type { ChatStreamStatus } from '../../services/ai/IProviderPlugin';
 import { runService } from '../../services/run/runService.svelte';
 import { settingsService } from '../../services/settings/settingsService.svelte';
 import { agentService } from './agentService.svelte';
-import { listenToAgentStream } from './agentStreamBridge';
+import { createAgentStreamChannel } from './agentStreamBridge';
 import type { AgentDef } from './types';
 
 export interface RunAgentInput {
@@ -102,9 +102,9 @@ export async function runAgent(input: RunAgentInput): Promise<void> {
   });
   input.abortSignal?.addEventListener('abort', onAbort, { once: true });
 
-  let unlisten: (() => void) | undefined;
+  let dispose: (() => void) | undefined;
   try {
-    unlisten = await listenToAgentStream({
+    const stream = createAgentStreamChannel({
       streamId,
       agentId: input.agentId,
       onEvent: (event) => {
@@ -118,6 +118,7 @@ export async function runAgent(input: RunAgentInput): Promise<void> {
         streamFailure.current = error;
       },
     });
+    dispose = stream.dispose;
 
     await agentsRunThread(
       input.agentId,
@@ -126,6 +127,7 @@ export async function runAgent(input: RunAgentInput): Promise<void> {
       handle.id,
       runConfig,
       streamId,
+      stream.channel,
     );
 
     if (streamFailure.current) throw streamFailure.current;
@@ -149,6 +151,6 @@ export async function runAgent(input: RunAgentInput): Promise<void> {
   } finally {
     input.abortSignal?.removeEventListener('abort', onAbort);
     unsubscribeCancel();
-    unlisten?.();
+    dispose?.();
   }
 }

--- a/asyar-launcher/src/built-in-features/agents/agentStreamBridge.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentStreamBridge.test.ts
@@ -1,17 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Event } from '@tauri-apps/api/event';
-import type { AgentStreamEventPayload } from '../../bindings';
+import type { AgentStreamEvent } from '../../bindings';
 
-const eventMock = vi.hoisted(() => ({
-  handler: undefined as ((event: Event<AgentStreamEventPayload>) => void) | undefined,
-  unlisten: vi.fn(),
-}));
-
-vi.mock('@tauri-apps/api/event', () => ({
-  listen: vi.fn(async (_name: string, handler: (event: Event<AgentStreamEventPayload>) => void) => {
-    eventMock.handler = handler;
-    return eventMock.unlisten;
-  }),
+// The bridge builds a Tauri Channel; mock it so a test can invoke `onmessage`
+// directly (a real Channel needs the Tauri IPC runtime).
+vi.mock('@tauri-apps/api/core', () => ({
+  Channel: class {
+    onmessage: ((message: AgentStreamEvent) => void) | undefined;
+  },
 }));
 
 vi.mock('../../lib/ipc/commands', () => ({
@@ -26,7 +21,7 @@ vi.mock('../mcp/mcpService.svelte', () => ({
   mcpService: { requestPermission: vi.fn() },
 }));
 
-import { listenToAgentStream } from './agentStreamBridge';
+import { createAgentStreamChannel } from './agentStreamBridge';
 import {
   agentsCancelRun,
   agentsReportMcpPermission,
@@ -35,28 +30,33 @@ import {
 import { invokeExtensionTool } from './toolDispatch';
 import { mcpService } from '../mcp/mcpService.svelte';
 
-function emit(payload: AgentStreamEventPayload): void {
-  eventMock.handler?.({ payload } as Event<AgentStreamEventPayload>);
+interface StreamOptions {
+  streamId: string;
+  agentId: string;
+  onEvent?: (event: AgentStreamEvent) => void;
+  onBridgeError?: (error: Error) => void;
 }
 
-describe('listenToAgentStream', () => {
+/** Build a stream and return an `emit` that simulates Rust sending on the channel. */
+function start(options: StreamOptions) {
+  const { channel, dispose } = createAgentStreamChannel(options);
+  const sink = channel as unknown as { onmessage?: (event: AgentStreamEvent) => void };
+  return { dispose, emit: (event: AgentStreamEvent) => sink.onmessage?.(event) };
+}
+
+describe('createAgentStreamChannel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    eventMock.handler = undefined;
     vi.mocked(agentsReportToolResult).mockResolvedValue(undefined);
     vi.mocked(agentsReportMcpPermission).mockResolvedValue(undefined);
     vi.mocked(agentsCancelRun).mockResolvedValue(undefined);
   });
 
-  it('filters events by stream id and forwards presentation events', async () => {
+  it('forwards presentation events straight through the channel', () => {
     const onEvent = vi.fn();
-    await listenToAgentStream({ streamId: 'stream-1', agentId: 'agent-1', onEvent });
+    const { emit } = start({ streamId: 'stream-1', agentId: 'agent-1', onEvent });
 
-    emit({ streamId: 'other', event: { type: 'text_delta', delta: 'x', accumulated: 'x' } });
-    emit({
-      streamId: 'stream-1',
-      event: { type: 'text_delta', delta: 'hello', accumulated: 'hello' },
-    });
+    emit({ type: 'text_delta', delta: 'hello', accumulated: 'hello' });
 
     expect(onEvent).toHaveBeenCalledOnce();
     expect(onEvent).toHaveBeenCalledWith({
@@ -68,18 +68,15 @@ describe('listenToAgentStream', () => {
 
   it('executes a dispatched iframe tool and reports the result to Rust', async () => {
     vi.mocked(invokeExtensionTool).mockResolvedValue({ answer: 42 });
-    await listenToAgentStream({ streamId: 'stream-1', agentId: 'agent-1' });
+    const { emit } = start({ streamId: 'stream-1', agentId: 'agent-1' });
 
     emit({
-      streamId: 'stream-1',
-      event: {
-        type: 'tool_dispatch',
-        tool_call_id: 'call-1',
-        extension_id: 'org.example',
-        tool_id: 'lookup',
-        arguments: { query: 'x' },
-      },
-    } as AgentStreamEventPayload);
+      type: 'tool_dispatch',
+      tool_call_id: 'call-1',
+      extension_id: 'org.example',
+      tool_id: 'lookup',
+      arguments: { query: 'x' },
+    });
     await vi.waitFor(() => expect(agentsReportToolResult).toHaveBeenCalledOnce());
 
     expect(invokeExtensionTool).toHaveBeenCalledWith(
@@ -93,18 +90,15 @@ describe('listenToAgentStream', () => {
 
   it('reports tool errors so the suspended Rust runner is unblocked', async () => {
     vi.mocked(invokeExtensionTool).mockRejectedValue(new Error('extension failed'));
-    await listenToAgentStream({ streamId: 'stream-1', agentId: 'agent-1' });
+    const { emit } = start({ streamId: 'stream-1', agentId: 'agent-1' });
 
     emit({
-      streamId: 'stream-1',
-      event: {
-        type: 'tool_dispatch',
-        tool_call_id: 'call-1',
-        extension_id: 'org.example',
-        tool_id: 'lookup',
-        arguments: {},
-      },
-    } as AgentStreamEventPayload);
+      type: 'tool_dispatch',
+      tool_call_id: 'call-1',
+      extension_id: 'org.example',
+      tool_id: 'lookup',
+      arguments: {},
+    });
     await vi.waitFor(() => expect(agentsReportToolResult).toHaveBeenCalledOnce());
 
     expect(agentsReportToolResult).toHaveBeenCalledWith(
@@ -119,22 +113,15 @@ describe('listenToAgentStream', () => {
     const onBridgeError = vi.fn();
     vi.mocked(invokeExtensionTool).mockResolvedValue('ok');
     vi.mocked(agentsReportToolResult).mockRejectedValue(new Error('resume failed'));
-    await listenToAgentStream({
-      streamId: 'stream-1',
-      agentId: 'agent-1',
-      onBridgeError,
-    });
+    const { emit } = start({ streamId: 'stream-1', agentId: 'agent-1', onBridgeError });
 
     emit({
-      streamId: 'stream-1',
-      event: {
-        type: 'tool_dispatch',
-        tool_call_id: 'call-1',
-        extension_id: 'org.example',
-        tool_id: 'lookup',
-        arguments: {},
-      },
-    } as AgentStreamEventPayload);
+      type: 'tool_dispatch',
+      tool_call_id: 'call-1',
+      extension_id: 'org.example',
+      tool_id: 'lookup',
+      arguments: {},
+    });
     await vi.waitFor(() => expect(agentsCancelRun).toHaveBeenCalledWith('stream-1'));
 
     expect(onBridgeError).toHaveBeenCalledWith(
@@ -144,18 +131,15 @@ describe('listenToAgentStream', () => {
 
   it('reports MCP permission decisions to Rust without invoking MCP in TypeScript', async () => {
     vi.mocked(mcpService.requestPermission).mockResolvedValue('allow_once');
-    await listenToAgentStream({ streamId: 'stream-1', agentId: 'agent-1' });
+    const { emit } = start({ streamId: 'stream-1', agentId: 'agent-1' });
 
     emit({
-      streamId: 'stream-1',
-      event: {
-        type: 'mcp_permission_request',
-        tool_call_id: 'call-1',
-        server_id: 'linear',
-        tool_id: 'create_issue',
-        agent_id: 'agent-1',
-      },
-    } as AgentStreamEventPayload);
+      type: 'mcp_permission_request',
+      tool_call_id: 'call-1',
+      server_id: 'linear',
+      tool_id: 'create_issue',
+      agent_id: 'agent-1',
+    });
 
     await vi.waitFor(() => expect(agentsReportMcpPermission).toHaveBeenCalledOnce());
     expect(mcpService.requestPermission).toHaveBeenCalledWith(
@@ -167,7 +151,7 @@ describe('listenToAgentStream', () => {
     expect(agentsReportMcpPermission).toHaveBeenCalledWith('stream-1', 'call-1', 'allow_once');
   });
 
-  it('aborts a pending iframe invocation when Rust cancels that dispatch', async () => {
+  it('aborts a pending iframe invocation when Rust cancels that dispatch', () => {
     let dispatchSignal: AbortSignal | undefined;
     vi.mocked(invokeExtensionTool).mockImplementation(
       async (_extensionId, _toolId, _args, signal) => {
@@ -175,22 +159,16 @@ describe('listenToAgentStream', () => {
         return new Promise(() => undefined);
       },
     );
-    await listenToAgentStream({ streamId: 'stream-1', agentId: 'agent-1' });
+    const { emit } = start({ streamId: 'stream-1', agentId: 'agent-1' });
 
     emit({
-      streamId: 'stream-1',
-      event: {
-        type: 'tool_dispatch',
-        tool_call_id: 'call-1',
-        extension_id: 'org.example',
-        tool_id: 'lookup',
-        arguments: {},
-      },
-    } as AgentStreamEventPayload);
-    emit({
-      streamId: 'stream-1',
-      event: { type: 'tool_dispatch_cancelled', tool_call_id: 'call-1' },
-    } as AgentStreamEventPayload);
+      type: 'tool_dispatch',
+      tool_call_id: 'call-1',
+      extension_id: 'org.example',
+      tool_id: 'lookup',
+      arguments: {},
+    });
+    emit({ type: 'tool_dispatch_cancelled', tool_call_id: 'call-1' });
 
     expect(dispatchSignal?.aborted).toBe(true);
   });

--- a/asyar-launcher/src/built-in-features/agents/agentStreamBridge.ts
+++ b/asyar-launcher/src/built-in-features/agents/agentStreamBridge.ts
@@ -1,5 +1,5 @@
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-import type { AgentStreamEvent, AgentStreamEventPayload } from '../../bindings';
+import { Channel } from '@tauri-apps/api/core';
+import type { AgentStreamEvent } from '../../bindings';
 import { extractErrorMessage } from '../../lib/errors';
 import {
   agentsCancelRun,
@@ -14,6 +14,13 @@ export interface AgentStreamListenerOptions {
   agentId: string;
   onEvent?: (event: AgentStreamEvent) => void;
   onBridgeError?: (error: Error) => void;
+}
+
+export interface AgentStreamChannel {
+  /** Pass to agentsRunThread/agentsRunSilent so Rust streams events to it. */
+  channel: Channel<AgentStreamEvent>;
+  /** Abort any in-flight tool/permission dispatches. Call when the run ends. */
+  dispose: () => void;
 }
 
 async function reportToolDispatch(
@@ -64,15 +71,17 @@ async function reportMcpPermission(
 }
 
 /**
- * Browser-bound adapter for Rust runner events.
+ * Per-run event channel for a Rust agent run.
  *
- * The Rust runner owns the loop and tool-result sequencing. This module only
- * forwards presentation events and performs the one browser-only operation:
- * invoking a Tier 2 extension tool in its worker iframe.
+ * The Rust runner owns the loop and tool-result sequencing. Each run gets its
+ * own Tauri Channel — scoped to this caller, so there is no broadcast bus and
+ * no streamId filtering. This module forwards presentation events and performs
+ * the one browser-only operation: invoking a Tier 2 extension tool in its
+ * worker iframe. Pass `channel` to agentsRunThread/agentsRunSilent; call
+ * `dispose` when the run ends to abort any in-flight dispatches. (streamId is
+ * still supplied for the return commands — cancel / report tool result.)
  */
-export async function listenToAgentStream(
-  options: AgentStreamListenerOptions,
-): Promise<UnlistenFn> {
+export function createAgentStreamChannel(options: AgentStreamListenerOptions): AgentStreamChannel {
   const activeToolDispatches = new Map<string, AbortController>();
   const activePermissionRequests = new Map<string, AbortController>();
   const abortAll = (): void => {
@@ -81,36 +90,34 @@ export async function listenToAgentStream(
     activeToolDispatches.clear();
     activePermissionRequests.clear();
   };
-  const unlisten = await listen<AgentStreamEventPayload>('agent-stream-event', ({ payload }) => {
-    if (payload.streamId !== options.streamId) return;
 
-    options.onEvent?.(payload.event);
-    if (payload.event.type === 'tool_dispatch') {
-      const toolCallId = payload.event.tool_call_id;
+  const channel = new Channel<AgentStreamEvent>();
+  channel.onmessage = (event) => {
+    options.onEvent?.(event);
+    if (event.type === 'tool_dispatch') {
+      const toolCallId = event.tool_call_id;
       const controller = new AbortController();
       activeToolDispatches.set(toolCallId, controller);
-      void reportToolDispatch(options, payload.event, controller.signal).finally(() => {
+      void reportToolDispatch(options, event, controller.signal).finally(() => {
         activeToolDispatches.delete(toolCallId);
       });
-    } else if (payload.event.type === 'mcp_permission_request') {
-      const toolCallId = payload.event.tool_call_id;
+    } else if (event.type === 'mcp_permission_request') {
+      const toolCallId = event.tool_call_id;
       const controller = new AbortController();
       activePermissionRequests.set(toolCallId, controller);
-      void reportMcpPermission(options, payload.event, controller.signal).finally(() => {
+      void reportMcpPermission(options, event, controller.signal).finally(() => {
         activePermissionRequests.delete(toolCallId);
       });
-    } else if (payload.event.type === 'tool_dispatch_cancelled') {
-      activeToolDispatches.get(payload.event.tool_call_id)?.abort();
-      activeToolDispatches.delete(payload.event.tool_call_id);
-    } else if (payload.event.type === 'mcp_permission_cancelled') {
-      activePermissionRequests.get(payload.event.tool_call_id)?.abort();
-      activePermissionRequests.delete(payload.event.tool_call_id);
-    } else if (payload.event.type === 'cancelled') {
+    } else if (event.type === 'tool_dispatch_cancelled') {
+      activeToolDispatches.get(event.tool_call_id)?.abort();
+      activeToolDispatches.delete(event.tool_call_id);
+    } else if (event.type === 'mcp_permission_cancelled') {
+      activePermissionRequests.get(event.tool_call_id)?.abort();
+      activePermissionRequests.delete(event.tool_call_id);
+    } else if (event.type === 'cancelled') {
       abortAll();
     }
-  });
-  return () => {
-    abortAll();
-    unlisten();
   };
+
+  return { channel, dispose: abortAll };
 }

--- a/asyar-launcher/src/built-in-features/agents/silentDispatch.test.ts
+++ b/asyar-launcher/src/built-in-features/agents/silentDispatch.test.ts
@@ -60,13 +60,13 @@ vi.mock('../../services/log/logService', () => ({
 const bridgeMock = vi.hoisted(() => ({
   options: undefined as
     { streamId: string; agentId: string; onBridgeError?: (error: Error) => void } | undefined,
-  unlisten: vi.fn(),
+  dispose: vi.fn(),
 }));
 
 vi.mock('./agentStreamBridge', () => ({
-  listenToAgentStream: vi.fn(async (options) => {
+  createAgentStreamChannel: vi.fn((options) => {
     bridgeMock.options = options;
-    return bridgeMock.unlisten;
+    return { channel: {}, dispose: bridgeMock.dispose };
   }),
 }));
 
@@ -155,6 +155,7 @@ describe('dispatchSilentAgentCommand', () => {
       'helo',
       runConfig,
       expect.any(String),
+      expect.anything(),
     );
     expect(bridgeMock.options).toEqual(
       expect.objectContaining({ agentId: 'agent-1', streamId: expect.any(String) }),
@@ -162,7 +163,7 @@ describe('dispatchSilentAgentCommand', () => {
     expect(agentService.insertMessage).not.toHaveBeenCalled();
     expect(agentService.createThread).not.toHaveBeenCalled();
     expect(agentService.listMessages).not.toHaveBeenCalled();
-    expect(bridgeMock.unlisten).toHaveBeenCalledOnce();
+    expect(bridgeMock.dispose).toHaveBeenCalledOnce();
   });
 
   it('captures selected text in Svelte before invoking Rust', async () => {
@@ -176,6 +177,7 @@ describe('dispatchSilentAgentCommand', () => {
       'selected words',
       runConfig,
       expect.any(String),
+      expect.anything(),
     );
   });
 
@@ -243,6 +245,7 @@ describe('dispatchSilentAgentCommand', () => {
       'party',
       runConfig,
       expect.any(String),
+      expect.anything(),
     );
   });
 

--- a/asyar-launcher/src/built-in-features/agents/silentDispatch.ts
+++ b/asyar-launcher/src/built-in-features/agents/silentDispatch.ts
@@ -24,7 +24,7 @@ import { selectionService } from '../../services/selection/selectionService';
 import { settingsService } from '../../services/settings/settingsService.svelte';
 import { windowService } from '../../services/window/windowService';
 import { agentService } from './agentService.svelte';
-import { listenToAgentStream } from './agentStreamBridge';
+import { createAgentStreamChannel } from './agentStreamBridge';
 import type { AgentDef, SilentInputSource, SilentOutputAction } from './types';
 
 const CLIPBOARD_RESTORE_DELAY_MS = 200;
@@ -80,7 +80,7 @@ async function runSilentAgentCommand(input: SilentDispatchInput): Promise<void> 
 
   let resolvedAgent: AgentDef | null = null;
   let spinner: HudSpinnerHandle | null = null;
-  let unlisten: (() => void) | undefined;
+  let dispose: (() => void) | undefined;
   let removeAbortListener: (() => void) | undefined;
 
   try {
@@ -105,13 +105,14 @@ async function runSilentAgentCommand(input: SilentDispatchInput): Promise<void> 
       maxTokens: settings.ai.maxTokens,
     };
     let bridgeError: Error | null = null;
-    unlisten = await listenToAgentStream({
+    const stream = createAgentStreamChannel({
       streamId,
       agentId: agent.id,
       onBridgeError: (error) => {
         bridgeError = error;
       },
     });
+    dispose = stream.dispose;
 
     const onAbort = (): void => {
       void agentsCancelRun(streamId).catch(() => undefined);
@@ -125,7 +126,7 @@ async function runSilentAgentCommand(input: SilentDispatchInput): Promise<void> 
       return;
     }
 
-    const result = await agentsRunSilent(agent.id, userText, runConfig, streamId);
+    const result = await agentsRunSilent(agent.id, userText, runConfig, streamId, stream.channel);
     if (bridgeError) throw bridgeError;
     if (input.abortSignal?.aborted) {
       await spinner.dismiss();
@@ -175,7 +176,7 @@ async function runSilentAgentCommand(input: SilentDispatchInput): Promise<void> 
     await reportFailure(errorTarget, detail);
   } finally {
     removeAbortListener?.();
-    unlisten?.();
+    dispose?.();
   }
 }
 

--- a/asyar-launcher/src/lib/ipc/agentCommands.test.ts
+++ b/asyar-launcher/src/lib/ipc/agentCommands.test.ts
@@ -25,6 +25,8 @@ import {
 } from './commands';
 import type { AgentDef } from '../../built-in-features/agents/types';
 import type { AgentRunConfig } from './commands';
+import type { Channel } from '@tauri-apps/api/core';
+import type { AgentStreamEvent } from '../../bindings';
 
 const config: AgentRunConfig = {
   provider: { enabled: true, apiKey: 'test-key' },
@@ -54,7 +56,8 @@ describe('agent runner commands', () => {
   });
 
   it('starts a persistent Rust agent run with the complete contract', async () => {
-    await agentsRunThread('agent-1', 'thread-1', 'hello', 'run-1', config, 'stream-1');
+    const onEvent = {} as Channel<AgentStreamEvent>;
+    await agentsRunThread('agent-1', 'thread-1', 'hello', 'run-1', config, 'stream-1', onEvent);
 
     expect(invokeRaw).toHaveBeenCalledWith('agents_run_thread', {
       agentId: 'agent-1',
@@ -63,18 +66,23 @@ describe('agent runner commands', () => {
       runId: 'run-1',
       config,
       streamId: 'stream-1',
+      onEvent,
     });
   });
 
   it('starts an ephemeral Rust run using the stored agent id', async () => {
     vi.mocked(invokeRaw).mockResolvedValueOnce('answer');
 
-    await expect(agentsRunSilent('agent-1', 'hello', config, 'stream-2')).resolves.toBe('answer');
+    const onEvent = {} as Channel<AgentStreamEvent>;
+    await expect(agentsRunSilent('agent-1', 'hello', config, 'stream-2', onEvent)).resolves.toBe(
+      'answer',
+    );
     expect(invokeRaw).toHaveBeenCalledWith('agents_run_silent', {
       agentId: 'agent-1',
       userText: 'hello',
       config,
       streamId: 'stream-2',
+      onEvent,
     });
   });
 

--- a/asyar-launcher/src/lib/ipc/systemActionCommands.ts
+++ b/asyar-launcher/src/lib/ipc/systemActionCommands.ts
@@ -1,8 +1,13 @@
 // asyar-launcher/src/lib/ipc/systemActionCommands.ts
 // Tauri command wrappers, re-exported through ./commands (the barrel).
+import type { Channel } from '@tauri-apps/api/core';
 import { invokeSafe, invokeSafeVoid, invokeRaw } from './invokeSafe';
 import type { ProviderConfig } from '../../services/ai/IProviderPlugin';
-import type { AgentRunConfig as AgentRunConfigContract, SystemAction } from '../../bindings';
+import type {
+  AgentRunConfig as AgentRunConfigContract,
+  AgentStreamEvent,
+  SystemAction,
+} from '../../bindings';
 
 // ── System actions ────────────────────────────────────────────────────────────
 
@@ -29,8 +34,17 @@ export async function agentsRunThread(
   runId: string | null,
   config: AgentRunConfig,
   streamId: string,
+  onEvent: Channel<AgentStreamEvent>,
 ): Promise<void> {
-  await invokeRaw('agents_run_thread', { agentId, threadId, userText, runId, config, streamId });
+  await invokeRaw('agents_run_thread', {
+    agentId,
+    threadId,
+    userText,
+    runId,
+    config,
+    streamId,
+    onEvent,
+  });
 }
 
 export async function agentsRunSilent(
@@ -38,12 +52,14 @@ export async function agentsRunSilent(
   userText: string,
   config: AgentRunConfig,
   streamId: string,
+  onEvent: Channel<AgentStreamEvent>,
 ): Promise<string> {
   return invokeRaw<string>('agents_run_silent', {
     agentId,
     userText,
     config,
     streamId,
+    onEvent,
   });
 }
 


### PR DESCRIPTION
Replace the broadcast "agent-stream-event" bus + client-side streamId filtering with a per-run Channel<AgentStreamEvent>: agents_run_thread, agents_run_silent, and the tool executor now send on the caller's channel, so concurrent runs no longer fan every event to every listener. streamId is kept only for the return path (cancel / report tool result). Deletes the now-dead AgentStreamEventPayload wrapper and regenerates bindings. This is the first use of Tauri's Channel API — the substrate for high-frequency feeds like Live Subtitles.