### PR TITLE
refactor(scheduler): consolidate copy-pasted daemons into one registry

### DIFF
--- a/asyar-launcher/src-tauri/src/app_updater/scheduler.rs
+++ b/asyar-launcher/src-tauri/src/app_updater/scheduler.rs
@@ -1,5 +1,6 @@
 use log::{error, info};
-use tauri::{async_runtime, AppHandle, Emitter};
+use std::time::Duration;
+use tauri::{AppHandle, Emitter};
 
 const STARTUP_DELAY_SECS: u64 = 60;
 const CHECK_INTERVAL_SECS: u64 = 6 * 3600; // 6 hours
@@ -47,35 +48,38 @@ fn read_update_settings(app: &AppHandle) -> UpdateSettings {
     }
 }
 
-/// Spawn a background tokio task that periodically checks for app updates.
-/// The task respects the user's `autoCheck` and `channel` settings from `settings.dat`.
-pub fn start(app: AppHandle) {
-    async_runtime::spawn(async move {
-        // Wait a bit after launch before the first check, so startup isn't slowed down.
-        tokio::time::sleep(tokio::time::Duration::from_secs(STARTUP_DELAY_SECS)).await;
+/// Run one scheduled update check, respecting the user's `autoCheck` and
+/// `channel` settings from `settings.dat`.
+async fn run_check(app: &AppHandle) {
+    let settings = read_update_settings(app);
 
-        loop {
-            let settings = read_update_settings(&app);
-
-            if settings.auto_check {
-                info!("app_updater: scheduled check running...");
-                if let Err(e) =
-                    crate::app_updater::service::check_and_maybe_download(&app, &settings.channel)
-                        .await
-                {
-                    error!("app_updater: scheduled check failed: {}", e);
-                    let _ = app.emit(
-                        "asyar:app-update:error",
-                        serde_json::json!({ "message": e }),
-                    );
-                }
-            } else {
-                info!("app_updater: auto-check is disabled, skipping scheduled check");
-            }
-
-            tokio::time::sleep(tokio::time::Duration::from_secs(CHECK_INTERVAL_SECS)).await;
+    if settings.auto_check {
+        info!("app_updater: scheduled check running...");
+        if let Err(e) =
+            crate::app_updater::service::check_and_maybe_download(app, &settings.channel).await
+        {
+            error!("app_updater: scheduled check failed: {}", e);
+            let _ = app.emit(
+                "asyar:app-update:error",
+                serde_json::json!({ "message": e }),
+            );
         }
-    });
+    } else {
+        info!("app_updater: auto-check is disabled, skipping scheduled check");
+    }
+}
+
+/// Scheduler job: check for app updates 60s after launch, then every 6h.
+pub fn job(app: AppHandle) -> crate::scheduler::Job {
+    crate::scheduler::Job::fixed_interval(
+        "app-update-check",
+        Duration::from_secs(STARTUP_DELAY_SECS),
+        Duration::from_secs(CHECK_INTERVAL_SECS),
+        move || {
+            let app = app.clone();
+            async move { run_check(&app).await }
+        },
+    )
 }
 
 #[cfg(test)]

--- a/asyar-launcher/src-tauri/src/extensions/update_scheduler.rs
+++ b/asyar-launcher/src-tauri/src/extensions/update_scheduler.rs
@@ -1,5 +1,6 @@
 use log::info;
-use tauri::{async_runtime, AppHandle, Emitter};
+use std::time::Duration;
+use tauri::{AppHandle, Emitter};
 
 const STARTUP_DELAY_SECS: u64 = 60;
 const CHECK_INTERVAL_SECS: u64 = 3600; // 1 hour
@@ -23,27 +24,28 @@ fn read_auto_update_setting(app: &AppHandle) -> bool {
         .unwrap_or(DEFAULT_AUTO_UPDATE)
 }
 
-/// Spawn a background tokio task that periodically emits `asyar:extension-update:tick`
-/// so the frontend's `ExtensionUpdateService` can run `checkAndAutoApply`.
-///
-/// Fires once after `STARTUP_DELAY_SECS`, then every `CHECK_INTERVAL_SECS`,
-/// but only when `settings.extensions.autoUpdate` is enabled.
-pub fn start(app: AppHandle) {
-    async_runtime::spawn(async move {
-        // Wait a bit after launch before the first tick, so startup isn't slowed down.
-        tokio::time::sleep(tokio::time::Duration::from_secs(STARTUP_DELAY_SECS)).await;
+/// Emit `asyar:extension-update:tick` so the frontend's `ExtensionUpdateService`
+/// can run `checkAndAutoApply`, when `settings.extensions.autoUpdate` is on.
+fn run_tick(app: &AppHandle) {
+    if read_auto_update_setting(app) {
+        info!("extension_updater: scheduled check running...");
+        let _ = app.emit("asyar:extension-update:tick", serde_json::json!({}));
+    } else {
+        info!("extension_updater: auto-update is disabled, skipping scheduled tick");
+    }
+}
 
-        loop {
-            if read_auto_update_setting(&app) {
-                info!("extension_updater: scheduled check running...");
-                let _ = app.emit("asyar:extension-update:tick", serde_json::json!({}));
-            } else {
-                info!("extension_updater: auto-update is disabled, skipping scheduled tick");
-            }
-
-            tokio::time::sleep(tokio::time::Duration::from_secs(CHECK_INTERVAL_SECS)).await;
-        }
-    });
+/// Scheduler job: emit the extension-update tick 60s after launch, then hourly.
+pub fn job(app: AppHandle) -> crate::scheduler::Job {
+    crate::scheduler::Job::fixed_interval(
+        "extension-update-check",
+        Duration::from_secs(STARTUP_DELAY_SECS),
+        Duration::from_secs(CHECK_INTERVAL_SECS),
+        move || {
+            let app = app.clone();
+            async move { run_tick(&app) }
+        },
+    )
 }
 
 #[cfg(test)]

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -125,6 +125,7 @@ pub mod profile;
 pub mod raycast_import;
 pub mod runs;
 pub mod runtimes;
+mod scheduler;
 pub mod scripts;
 mod search_engine;
 pub mod secret_detection;
@@ -259,6 +260,7 @@ pub fn run() {
         )))
         .manage(extensions::onboarding_intercept::StashRegistry::default())
         .manage(app_updater::AppUpdaterState::new())
+        .manage(scheduler::Scheduler::new())
         .manage(power::PowerRegistry::new(power::default_backend()))
         .manage(std::sync::Arc::new(
             system_actions::SystemActionsState::new(system_actions::default_backend()),
@@ -306,6 +308,7 @@ pub fn run() {
         .setup(setup_app)
         .invoke_handler(tauri::generate_handler![
             deeplink::flush_pending_deeplinks,
+            scheduler::get_scheduler_snapshot,
             commands::set_focus_lock,
             commands::feedback_publish,
             commands::feedback_get_current,
@@ -1126,9 +1129,6 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             app.handle().clone(),
             Arc::clone(&registry),
         );
-        // Hourly GC for entries whose owning notification the OS closed
-        // without telling us. Same shape as app_updater::scheduler::start.
-        crate::notifications::scheduler::start(Arc::clone(&registry));
         app.manage(registry);
         app.manage(backend);
     }
@@ -1799,19 +1799,25 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // Setup global shortcut with default configuration
     setup_global_shortcut(handle);
 
-    // Spawn background app update scheduler
-    crate::app_updater::scheduler::start(app.handle().clone());
-
-    // Spawn background shell-registry GC. Drops finished entries older than
-    // PRUNE_AGE_MILLIS so reattach-right-after-exit still resolves the
-    // stored exit_code within the window.
+    // Central background scheduler: one registry of fixed-interval jobs,
+    // replacing the per-feature copy-pasted spawn-loop daemons. Adding a
+    // periodic job is one register() call with a cadence + work closure.
     {
-        let registry: tauri::State<'_, shell::ShellProcessRegistry> = app.state();
-        crate::shell::scheduler::start(registry.inner().clone());
+        let sched = app.state::<crate::scheduler::Scheduler>();
+        let handle = app.handle();
+        sched.register(crate::app_updater::scheduler::job(handle.clone()));
+        sched.register(crate::extensions::update_scheduler::job(handle.clone()));
+        sched.register(crate::shell::scheduler::job(
+            app.state::<crate::shell::ShellProcessRegistry>()
+                .inner()
+                .clone(),
+        ));
+        sched.register(crate::notifications::scheduler::job(
+            app.state::<std::sync::Arc<crate::notifications::NotificationActionRegistry>>()
+                .inner()
+                .clone(),
+        ));
     }
-
-    // Spawn background extension update scheduler (emits asyar:extension-update:tick hourly)
-    crate::extensions::update_scheduler::start(app.handle().clone());
 
     // Wire the system-events hub emitter to Tauri's AppHandle and start the
     // per-platform watcher. The hub is a singleton for the app lifetime.

--- a/asyar-launcher/src-tauri/src/notifications/scheduler.rs
+++ b/asyar-launcher/src-tauri/src/notifications/scheduler.rs
@@ -10,27 +10,30 @@ use crate::notifications::NotificationActionRegistry;
 use log::info;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tauri::async_runtime;
 
 const STARTUP_DELAY_SECS: u64 = 60;
 const PURGE_INTERVAL_SECS: u64 = 3600; // 1 hour
 const TTL_SECS: u64 = 86_400; // 24 h — matches NotificationActionRegistry::DEFAULT_TTL
 
-/// Spawn a background tokio task that drops action entries older than the
-/// registry TTL every hour. Fires once after `STARTUP_DELAY_SECS`, then
-/// every `PURGE_INTERVAL_SECS`.
-pub fn start(registry: Arc<NotificationActionRegistry>) {
-    async_runtime::spawn(async move {
-        tokio::time::sleep(Duration::from_secs(STARTUP_DELAY_SECS)).await;
+/// Drop action entries older than the registry TTL. One tick of the GC job.
+fn run_purge(registry: &NotificationActionRegistry) {
+    let removed = registry.purge_expired(Instant::now(), Duration::from_secs(TTL_SECS));
+    if removed > 0 {
+        info!("[notifications] purged {removed} expired action entries");
+    }
+}
 
-        loop {
-            let removed = registry.purge_expired(Instant::now(), Duration::from_secs(TTL_SECS));
-            if removed > 0 {
-                info!("[notifications] purged {removed} expired action entries");
-            }
-            tokio::time::sleep(Duration::from_secs(PURGE_INTERVAL_SECS)).await;
-        }
-    });
+/// Scheduler job: purge expired action entries 60s after launch, then hourly.
+pub fn job(registry: Arc<NotificationActionRegistry>) -> crate::scheduler::Job {
+    crate::scheduler::Job::fixed_interval(
+        "notification-gc",
+        Duration::from_secs(STARTUP_DELAY_SECS),
+        Duration::from_secs(PURGE_INTERVAL_SECS),
+        move || {
+            let registry = Arc::clone(&registry);
+            async move { run_purge(&registry) }
+        },
+    )
 }
 
 #[cfg(test)]

--- a/asyar-launcher/src-tauri/src/scheduler.rs
+++ b/asyar-launcher/src-tauri/src/scheduler.rs
@@ -1,0 +1,150 @@
+//! Central scheduler for long-lived background jobs.
+//!
+//! Replaces the per-feature copy-pasted spawn-loop daemons (app-update check,
+//! shell/notification GC, extension auto-update) with one registry. A job is a
+//! stable id + a [`Cadence`] strategy + a command closure; the registry owns one
+//! supervisor task per job so they can be enumerated and cancelled from a single
+//! place. Adding a periodic job is one [`Scheduler::register`] call.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use tauri::async_runtime::{self, JoinHandle};
+
+/// How often a job runs. A strategy — extend with cron/one-shot variants as
+/// new cadences are needed without touching the supervisor loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Cadence {
+    /// Wait `startup_delay` after launch, then run every `period`.
+    FixedInterval {
+        startup_delay: Duration,
+        period: Duration,
+    },
+}
+
+type BoxFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+type JobFn = Box<dyn Fn() -> BoxFuture + Send + Sync>;
+
+/// A registered background job: a stable id, a cadence, and the work to run
+/// each tick.
+pub struct Job {
+    id: &'static str,
+    cadence: Cadence,
+    run: JobFn,
+}
+
+impl Job {
+    /// Build a fixed-interval job. `run` is invoked once per tick; it captures
+    /// whatever state the work needs (an `AppHandle`, a registry clone, …).
+    pub fn fixed_interval<F, Fut>(
+        id: &'static str,
+        startup_delay: Duration,
+        period: Duration,
+        run: F,
+    ) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        Self {
+            id,
+            cadence: Cadence::FixedInterval {
+                startup_delay,
+                period,
+            },
+            run: Box::new(move || Box::pin(run())),
+        }
+    }
+}
+
+/// Registry of background jobs. One supervisor task per job, tracked by id.
+#[derive(Default)]
+pub struct Scheduler {
+    tasks: Mutex<HashMap<&'static str, JoinHandle<()>>>,
+}
+
+impl Scheduler {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Spawn a job's supervisor. Idempotent per id: re-registering the same id
+    /// aborts the previous supervisor first.
+    pub fn register(&self, job: Job) {
+        let Job { id, cadence, run } = job;
+        let handle = match cadence {
+            Cadence::FixedInterval {
+                startup_delay,
+                period,
+            } => {
+                // tauri's runtime (not raw tokio::spawn): setup_app can run
+                // before a Tokio reactor is attached.
+                async_runtime::spawn(async move {
+                    tokio::time::sleep(startup_delay).await;
+                    loop {
+                        run().await;
+                        tokio::time::sleep(period).await;
+                    }
+                })
+            }
+        };
+        if let Ok(mut tasks) = self.tasks.lock() {
+            if let Some(previous) = tasks.insert(id, handle) {
+                previous.abort();
+            }
+        }
+    }
+
+    /// Sorted ids of all currently-registered jobs (observability / tests).
+    pub fn snapshot(&self) -> Vec<&'static str> {
+        match self.tasks.lock() {
+            Ok(tasks) => {
+                let mut ids: Vec<&'static str> = tasks.keys().copied().collect();
+                ids.sort_unstable();
+                ids
+            }
+            Err(_) => Vec::new(),
+        }
+    }
+}
+
+/// Debug/observability command: the ids of all registered background jobs.
+#[tauri::command]
+pub fn get_scheduler_snapshot(scheduler: tauri::State<'_, Scheduler>) -> Vec<String> {
+    scheduler.snapshot().into_iter().map(String::from).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A job whose first tick is an hour out, so the work never runs during a
+    /// unit test — we only assert the registry bookkeeping.
+    fn idle_job(id: &'static str) -> Job {
+        Job::fixed_interval(
+            id,
+            Duration::from_secs(3600),
+            Duration::from_secs(3600),
+            || async {},
+        )
+    }
+
+    #[test]
+    fn register_tracks_job_ids_sorted() {
+        let scheduler = Scheduler::new();
+        scheduler.register(idle_job("b-job"));
+        scheduler.register(idle_job("a-job"));
+        assert_eq!(scheduler.snapshot(), vec!["a-job", "b-job"]);
+    }
+
+    #[test]
+    fn re_registering_same_id_keeps_one_entry() {
+        let scheduler = Scheduler::new();
+        scheduler.register(idle_job("dup"));
+        scheduler.register(idle_job("dup"));
+        assert_eq!(scheduler.snapshot(), vec!["dup"]);
+    }
+}

--- a/asyar-launcher/src-tauri/src/shell/scheduler.rs
+++ b/asyar-launcher/src-tauri/src/shell/scheduler.rs
@@ -9,7 +9,6 @@
 use crate::shell::{now_millis, ShellProcessRegistry};
 use log::info;
 use std::time::Duration;
-use tauri::async_runtime;
 
 const STARTUP_DELAY_SECS: u64 = 60;
 const PRUNE_INTERVAL_SECS: u64 = 60;
@@ -17,19 +16,26 @@ const PRUNE_INTERVAL_SECS: u64 = 60;
 /// resolve the stored exit_code before the GC collects them.
 pub const PRUNE_AGE_MILLIS: u64 = 10 * 60 * 1000;
 
-pub fn start(registry: ShellProcessRegistry) {
-    async_runtime::spawn(async move {
-        tokio::time::sleep(Duration::from_secs(STARTUP_DELAY_SECS)).await;
+/// Prune finished shell entries past their linger window. One tick of the GC.
+fn run_prune(registry: &ShellProcessRegistry) {
+    match registry.prune_finished(PRUNE_AGE_MILLIS, now_millis()) {
+        Ok(n) if n > 0 => info!("[shell] pruned {n} finished entries"),
+        Ok(_) => {}
+        Err(e) => log::warn!("[shell] prune error: {e}"),
+    }
+}
 
-        loop {
-            match registry.prune_finished(PRUNE_AGE_MILLIS, now_millis()) {
-                Ok(n) if n > 0 => info!("[shell] pruned {n} finished entries"),
-                Ok(_) => {}
-                Err(e) => log::warn!("[shell] prune error: {e}"),
-            }
-            tokio::time::sleep(Duration::from_secs(PRUNE_INTERVAL_SECS)).await;
-        }
-    });
+/// Scheduler job: prune finished shell entries 60s after launch, then every 60s.
+pub fn job(registry: ShellProcessRegistry) -> crate::scheduler::Job {
+    crate::scheduler::Job::fixed_interval(
+        "shell-gc",
+        Duration::from_secs(STARTUP_DELAY_SECS),
+        Duration::from_secs(PRUNE_INTERVAL_SECS),
+        move || {
+            let registry = registry.clone();
+            async move { run_prune(&registry) }
+        },
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Introduce a central Scheduler — a registry of jobs, each an id + a Cadence strategy + a work closure — and migrate the four identical fixed-interval spawn-loop daemons onto it: app-update check, extension auto-update, shell GC, and notification GC. The spawn/sleep/loop logic now lives once; adding a periodic job is a single register() call. Adds a get_scheduler_snapshot command for observability. The dynamic extension scheduler, the 1s timer poll, and the runtime ticker keep their own shapes.