### PR TITLE
refactor(sdk): give proxy handles a structural invoke()

### DIFF
--- a/asyar-sdk/src/services/BaseServiceProxy.test.ts
+++ b/asyar-sdk/src/services/BaseServiceProxy.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BaseServiceProxy } from './BaseServiceProxy';
+import { messageBroker } from '../ipc/MessageBroker';
+import type { WireCommand } from '../ipc/namespaces';
+
+vi.mock('../ipc/MessageBroker', () => ({
+  messageBroker: { invoke: vi.fn().mockResolvedValue(undefined), on: vi.fn(), off: vi.fn() },
+}));
+
+// Minimal concrete proxy exposing the protected invoke() for testing. Returned
+// handles use this.invoke() so extensionId is injected structurally — no need
+// to capture the (patched) broker, which is the footgun this replaces.
+class TestProxy extends BaseServiceProxy {
+  call(command: WireCommand, payload?: Record<string, unknown>, timeoutMs?: number) {
+    return this.invoke(command, payload, timeoutMs);
+  }
+}
+
+describe('BaseServiceProxy.invoke', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('stamps the proxy extensionId as the third arg, without capturing the broker', () => {
+    const proxy = new TestProxy();
+    proxy.setExtensionId('ext.test');
+    proxy.call('runs:start', { id: 'r1' });
+    expect(messageBroker.invoke).toHaveBeenCalledWith(
+      'runs:start',
+      { id: 'r1' },
+      'ext.test',
+      undefined,
+    );
+  });
+
+  it('forwards a per-call timeout to the broker', () => {
+    const proxy = new TestProxy();
+    proxy.setExtensionId('ext.test');
+    proxy.call('feedback:confirmAlert', { options: {} }, 5000);
+    expect(messageBroker.invoke).toHaveBeenCalledWith(
+      'feedback:confirmAlert',
+      { options: {} },
+      'ext.test',
+      5000,
+    );
+  });
+});

--- a/asyar-sdk/src/services/BaseServiceProxy.ts
+++ b/asyar-sdk/src/services/BaseServiceProxy.ts
@@ -16,6 +16,21 @@ export abstract class BaseServiceProxy {
     this.broker = messageBroker;
   }
 
+  /**
+   * Invoke a wire command, always stamping this proxy's extensionId from
+   * `this.extensionId`. Prefer this in returned handles over capturing
+   * `this.broker`: the id is injected structurally, so a handle can't ship
+   * without it or bind the wrong (global) broker. `this.broker` remains for
+   * event subscriptions (`on`/`off`), which don't need the id.
+   */
+  protected invoke<T>(
+    command: WireCommand,
+    payload?: Record<string, unknown> | unknown[],
+    timeoutMs?: number,
+  ): Promise<T> {
+    return messageBroker.invoke<T>(command, payload, this.extensionId, timeoutMs);
+  }
+
   setExtensionId(id: string): void {
     this.extensionId = id;
     const originalInvoke = this.broker.invoke.bind(this.broker);

--- a/asyar-sdk/src/services/FeedbackServiceProxy.ts
+++ b/asyar-sdk/src/services/FeedbackServiceProxy.ts
@@ -31,22 +31,21 @@ export class FeedbackServiceProxy extends BaseServiceProxy implements IFeedbackS
   }
 
   async showProgress(options: FeedbackProgressOptions): Promise<FeedbackProgressHandle> {
-    const broker = this.broker;
-    const feedbackId = await broker.invoke<string>('feedback:showProgress', { options });
+    const feedbackId = await this.invoke<string>('feedback:showProgress', { options });
 
     return {
-      update: (update) => broker.invoke<void>('feedback:updateProgress', { feedbackId, update }),
+      update: (update) => this.invoke<void>('feedback:updateProgress', { feedbackId, update }),
       succeed: (title) =>
-        broker.invoke<void>('feedback:finishProgress', {
+        this.invoke<void>('feedback:finishProgress', {
           feedbackId,
           outcome: { severity: 'success', title },
         }),
       fail: (title, developerDetail) =>
-        broker.invoke<void>('feedback:finishProgress', {
+        this.invoke<void>('feedback:finishProgress', {
           feedbackId,
           outcome: { severity: 'error', title, developerDetail },
         }),
-      dismiss: () => broker.invoke<void>('feedback:dismiss', { feedbackId }),
+      dismiss: () => this.invoke<void>('feedback:dismiss', { feedbackId }),
     };
   }
 

--- a/asyar-sdk/src/services/RunServiceProxy.test.ts
+++ b/asyar-sdk/src/services/RunServiceProxy.test.ts
@@ -27,6 +27,8 @@ describe('RunServiceProxy', () => {
         label: 'My Script',
         cancellable: expect.any(Boolean),
       }),
+      '',
+      undefined,
     );
   });
 
@@ -54,6 +56,8 @@ describe('RunServiceProxy', () => {
     expect(invokeSpy).toHaveBeenCalledWith(
       'runs:start',
       expect.objectContaining({ cancellable: false }),
+      '',
+      undefined,
     );
   });
 
@@ -63,6 +67,8 @@ describe('RunServiceProxy', () => {
     expect(invokeSpy).toHaveBeenCalledWith(
       'runs:start',
       expect.objectContaining({ cancellable: true }),
+      '',
+      undefined,
     );
   });
 
@@ -89,6 +95,8 @@ describe('RunServiceProxy', () => {
       expect(invokeSpy).toHaveBeenCalledWith(
         'runs:write',
         expect.objectContaining({ id: handle!.id, line: 'line one' }),
+        '',
+        undefined,
       );
     });
 
@@ -99,6 +107,8 @@ describe('RunServiceProxy', () => {
       expect(invokeSpy).toHaveBeenCalledWith(
         'runs:done',
         expect.objectContaining({ id: handle!.id }),
+        '',
+        undefined,
       );
     });
 
@@ -109,6 +119,8 @@ describe('RunServiceProxy', () => {
       expect(invokeSpy).toHaveBeenCalledWith(
         'runs:fail',
         expect.objectContaining({ id: handle!.id, error: 'boom' }),
+        '',
+        undefined,
       );
     });
 
@@ -119,6 +131,8 @@ describe('RunServiceProxy', () => {
       expect(invokeSpy).toHaveBeenCalledWith(
         'runs:cancel',
         expect.objectContaining({ id: handle!.id }),
+        '',
+        undefined,
       );
     });
 
@@ -190,35 +204,28 @@ describe('RunServiceProxy', () => {
 });
 
 describe('RunServiceProxy with setExtensionId', () => {
-  it('handle methods use the per-instance broker (not global) after setExtensionId', async () => {
-    const globalInvokeSpy = vi.spyOn(messageBroker, 'invoke').mockResolvedValue(undefined);
+  it('handle methods inject the extensionId structurally after setExtensionId', async () => {
+    const invokeSpy = vi.spyOn(messageBroker, 'invoke').mockResolvedValue(undefined);
     vi.spyOn(messageBroker, 'on').mockImplementation(() => {});
 
     const proxy = new RunServiceProxy();
     proxy.setExtensionId('test.extension');
 
-    // After setExtensionId, this.broker is a clone — spy on the clone instead
-    const instanceBroker = (proxy as unknown as { broker: typeof messageBroker }).broker;
-    const instanceInvokeSpy = vi.spyOn(instanceBroker, 'invoke').mockResolvedValue(undefined);
-    vi.spyOn(instanceBroker, 'on').mockImplementation(() => {});
-    vi.spyOn(instanceBroker, 'off').mockImplementation(() => {});
-
-    // Reset global spy AFTER start() (because start() may call invoke; we only care about handle methods)
-    globalInvokeSpy.mockClear();
-
     const handle = await proxy.start({ label: 'X', kind: 'shell-script' });
-    instanceInvokeSpy.mockClear();
-    globalInvokeSpy.mockClear();
+    invokeSpy.mockClear();
 
     await handle.write('line');
 
-    expect(instanceInvokeSpy).toHaveBeenCalledWith(
+    // The handle stamps the proxy's extensionId even though it was created and
+    // called after setExtensionId — this.invoke() injects it structurally, so
+    // there is no broker to capture (correctly or incorrectly).
+    expect(invokeSpy).toHaveBeenCalledWith(
       'runs:write',
       expect.objectContaining({ id: handle.id, line: 'line' }),
+      'test.extension',
+      undefined,
     );
-    expect(globalInvokeSpy).not.toHaveBeenCalled();
 
-    instanceInvokeSpy.mockRestore();
-    globalInvokeSpy.mockRestore();
+    invokeSpy.mockRestore();
   });
 });

--- a/asyar-sdk/src/services/RunServiceProxy.ts
+++ b/asyar-sdk/src/services/RunServiceProxy.ts
@@ -12,12 +12,15 @@ export class RunServiceProxy extends BaseServiceProxy implements IRunService {
     const label = input.label;
     const cancellable = input.cancellable ?? false;
 
-    await this.broker.invoke('runs:start', { id, kind, label, cancellable });
+    await this.invoke('runs:start', { id, kind, label, cancellable });
 
     return this.buildHandle(id);
   }
 
   private buildHandle(id: string): RunHandle {
+    // invoke() injects extensionId structurally, so the handle can't ship
+    // without it. broker is captured only for on/off event subscriptions.
+    const invoke = this.invoke.bind(this);
     const broker = this.broker;
     let cancelled = false;
     const callbacks = new Set<() => void>();
@@ -46,25 +49,25 @@ export class RunServiceProxy extends BaseServiceProxy implements IRunService {
 
       /** Write a line of output to this run. */
       async write(line: string) {
-        await broker.invoke('runs:write', { id, line });
+        await invoke('runs:write', { id, line });
       },
 
       /** Signal that the run completed successfully. */
       async done() {
-        await broker.invoke('runs:done', { id });
+        await invoke('runs:done', { id });
         unsubscribeAll();
       },
 
       /** Signal that the run failed with the given error message. */
       async fail(error: string) {
-        await broker.invoke('runs:fail', { id, error });
+        await invoke('runs:fail', { id, error });
         unsubscribeAll();
       },
 
       /** Request cancellation of this run. */
       async cancel() {
         try {
-          await broker.invoke('runs:cancel', { id });
+          await invoke('runs:cancel', { id });
         } finally {
           // Release the cancel-event subscription regardless of whether the
           // broker call resolved. On success the launcher emits

--- a/asyar-sdk/src/services/SnippetsServiceProxy.test.ts
+++ b/asyar-sdk/src/services/SnippetsServiceProxy.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SnippetsServiceProxy } from './SnippetsServiceProxy';
+import { messageBroker } from '../ipc/MessageBroker';
 import type { ShortcodeMap } from '../contracts/snippets';
 
-function buildProxyWithMockBroker() {
+vi.mock('../ipc/MessageBroker', () => ({
+  messageBroker: { invoke: vi.fn().mockResolvedValue(undefined), on: vi.fn(), off: vi.fn() },
+}));
+
+function makeProxy() {
   const invoke = vi.fn().mockResolvedValue(undefined);
+  Object.assign(messageBroker, { invoke, on: vi.fn(), off: vi.fn() });
   const proxy = new SnippetsServiceProxy();
-  (proxy as unknown as { broker: { invoke: typeof invoke } }).broker = { invoke } as never;
+  proxy.setExtensionId('ext.test');
   return { proxy, invoke };
 }
 
@@ -14,18 +20,25 @@ describe('SnippetsServiceProxy', () => {
   let invoke: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    ({ proxy, invoke } = buildProxyWithMockBroker());
+    vi.clearAllMocks();
+    ({ proxy, invoke } = makeProxy());
   });
 
   it('dispatches registerShortcodes via snippets:registerShortcodes topic', async () => {
     const map: ShortcodeMap = { ':party:': '🎉', ':fire:': '🔥' };
     await proxy.registerShortcodes(map);
-    expect(invoke).toHaveBeenCalledWith('snippets:registerShortcodes', { map });
+    // this.invoke stamps the extensionId structurally as the third arg.
+    expect(invoke).toHaveBeenCalledWith(
+      'snippets:registerShortcodes',
+      { map },
+      'ext.test',
+      undefined,
+    );
   });
 
   it('dispatches unregisterShortcodes via snippets:unregisterShortcodes topic', async () => {
     await proxy.unregisterShortcodes();
-    expect(invoke).toHaveBeenCalledWith('snippets:unregisterShortcodes', {});
+    expect(invoke).toHaveBeenCalledWith('snippets:unregisterShortcodes', {}, 'ext.test', undefined);
   });
 
   it('rejects malformed keys without dispatching', async () => {
@@ -42,6 +55,11 @@ describe('SnippetsServiceProxy', () => {
 
   it('accepts an empty map (replaces previous contribution with nothing)', async () => {
     await proxy.registerShortcodes({});
-    expect(invoke).toHaveBeenCalledWith('snippets:registerShortcodes', { map: {} });
+    expect(invoke).toHaveBeenCalledWith(
+      'snippets:registerShortcodes',
+      { map: {} },
+      'ext.test',
+      undefined,
+    );
   });
 });

--- a/asyar-sdk/src/services/SnippetsServiceProxy.ts
+++ b/asyar-sdk/src/services/SnippetsServiceProxy.ts
@@ -17,12 +17,10 @@ export class SnippetsServiceProxy extends BaseServiceProxy implements ISnippetsS
         );
       }
     }
-    const broker = this.broker;
-    await broker.invoke('snippets:registerShortcodes', { map });
+    await this.invoke('snippets:registerShortcodes', { map });
   }
 
   async unregisterShortcodes(): Promise<void> {
-    const broker = this.broker;
-    await broker.invoke('snippets:unregisterShortcodes', {});
+    await this.invoke('snippets:unregisterShortcodes', {});
   }
 }


### PR DESCRIPTION
Add BaseServiceProxy.invoke(), which stamps this.extensionId onto every call, and convert the return-handle sites (RunServiceProxy, FeedbackServiceProxy, SnippetsServiceProxy) to use it. Handles no longer capture `this.broker` — the footgun where a handle could bind the wrong broker and ship without an extensionId. Non-breaking: wire protocol and service interfaces are unchanged; the setExtensionId monkey-patch stays for the in-method calls it still serves.