### PR TITLE
refactor(ipc): decouple invokeSafe from the diagnostics store

### DIFF
--- a/asyar-launcher/src/lib/ipc/invokeSafe.test.ts
+++ b/asyar-launcher/src/lib/ipc/invokeSafe.test.ts
@@ -1,33 +1,35 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
-vi.mock('../../services/feedback/feedbackService.svelte', () => ({
-  feedbackService: {
-    report: vi.fn(),
-    registerRetry: vi.fn(() => 'retry-x'),
-  },
-}));
 vi.mock('../../services/log/logService', () => ({
   logService: { error: vi.fn() },
 }));
 
 import { invoke } from '@tauri-apps/api/core';
-import { feedbackService } from '../../services/feedback/feedbackService.svelte';
 import { logService } from '../../services/log/logService';
-import { invokeSafe } from './invokeSafe';
+import { invokeSafe, setInvokeFailureReporter, type InvokeFailureReporter } from './invokeSafe';
+
+// The transport reports failures to an injected sink, not the feedback store.
+const reporter = {
+  report: vi.fn(),
+  registerRetry: vi.fn(() => 'retry-x'),
+} satisfies InvokeFailureReporter;
 
 describe('invokeSafe', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setInvokeFailureReporter(reporter);
+  });
 
   it('passes through a successful result', async () => {
-    (invoke as any).mockResolvedValue({ ok: true });
+    vi.mocked(invoke).mockResolvedValue({ ok: true });
     const r = await invokeSafe<{ ok: boolean }>('foo');
     expect(r).toEqual({ ok: true });
-    expect(feedbackService.report).not.toHaveBeenCalled();
+    expect(reporter.report).not.toHaveBeenCalled();
   });
 
   it('on Diagnostic-shaped rejection: logs + reports + returns null', async () => {
-    (invoke as any).mockRejectedValue({
+    vi.mocked(invoke).mockRejectedValue({
       source: 'rust',
       kind: 'permission_denied',
       severity: 'warning',
@@ -36,32 +38,41 @@ describe('invokeSafe', () => {
     });
     const r = await invokeSafe('foo');
     expect(r).toBeNull();
-    expect(feedbackService.report).toHaveBeenCalled();
+    expect(reporter.report).toHaveBeenCalled();
     expect(logService.error).toHaveBeenCalled();
   });
 
   it('on string rejection: wraps as kind=invoke_unknown', async () => {
-    (invoke as any).mockRejectedValue('boom');
+    vi.mocked(invoke).mockRejectedValue('boom');
     await invokeSafe('foo');
-    const arg = (feedbackService.report as any).mock.calls[0][0];
+    const arg = reporter.report.mock.calls[0][0];
     expect(arg.kind).toBe('invoke_unknown');
     expect(arg.severity).toBe('error');
     expect(arg.developerDetail).toContain('boom');
   });
 
   it('silent: true skips report but still logs', async () => {
-    (invoke as any).mockRejectedValue('boom');
+    vi.mocked(invoke).mockRejectedValue('boom');
     await invokeSafe('foo', undefined, { silent: true });
-    expect(feedbackService.report).not.toHaveBeenCalled();
+    expect(reporter.report).not.toHaveBeenCalled();
     expect(logService.error).toHaveBeenCalled();
   });
 
   it('retry: registers callback and stamps retryActionId + retryable', async () => {
-    (invoke as any).mockRejectedValue('boom');
+    vi.mocked(invoke).mockRejectedValue('boom');
     const retry = vi.fn().mockResolvedValue(undefined);
     await invokeSafe('foo', undefined, { retry });
-    const arg = (feedbackService.report as any).mock.calls[0][0];
+    const arg = reporter.report.mock.calls[0][0];
     expect(arg.retryActionId).toBe('retry-x');
     expect(arg.retryable).toBe(true);
+  });
+
+  it('without a registered reporter: still logs and returns null, no throw', async () => {
+    setInvokeFailureReporter(null);
+    vi.mocked(invoke).mockRejectedValue('boom');
+    const r = await invokeSafe('foo');
+    expect(r).toBeNull();
+    expect(logService.error).toHaveBeenCalled();
+    expect(reporter.report).not.toHaveBeenCalled();
   });
 });

--- a/asyar-launcher/src/lib/ipc/invokeSafe.ts
+++ b/asyar-launcher/src/lib/ipc/invokeSafe.ts
@@ -1,11 +1,40 @@
 import { invoke } from '@tauri-apps/api/core';
-import { feedbackService } from '../../services/feedback/feedbackService.svelte';
 import { logService } from '../../services/log/logService';
 import type { Feedback } from 'asyar-sdk/contracts';
 
 interface InvokeSafeOpts {
   silent?: boolean;
   retry?: () => Promise<void>;
+}
+
+/**
+ * Sink for invoke failures. The diagnostics UI registers itself via
+ * {@link setInvokeFailureReporter}, so this transport layer depends on an
+ * abstraction rather than importing the feedback store directly.
+ */
+export interface InvokeFailureReporter {
+  report(feedback: Feedback): void;
+  registerRetry(retry: () => Promise<void>): string;
+}
+
+let reporter: InvokeFailureReporter | null = null;
+
+/** Wire the diagnostics sink. Called once from the app's composition root. */
+export function setInvokeFailureReporter(next: InvokeFailureReporter | null): void {
+  reporter = next;
+}
+
+/** Log a failed invoke and route it to the registered diagnostics reporter. */
+function reportInvokeFailure(cmd: string, raw: unknown, opts?: InvokeSafeOpts): void {
+  const d: Feedback = isFeedbackShape(raw) ? { ...raw } : fallback(cmd, raw);
+  logService.error(`[invokeSafe] ${cmd}: ${d.developerDetail ?? String(raw)}`);
+  if (opts?.retry && reporter) {
+    d.retryActionId = reporter.registerRetry(opts.retry);
+    d.retryable = true;
+  }
+  if (!opts?.silent) {
+    reporter?.report(d);
+  }
 }
 
 export function isFeedbackShape(raw: unknown): raw is Feedback {
@@ -33,16 +62,7 @@ export async function invokeSafe<T>(
   try {
     return await invoke<T>(cmd, args);
   } catch (raw) {
-    const d: Feedback = isFeedbackShape(raw) ? { ...raw } : fallback(cmd, raw);
-    logService.error(`[invokeSafe] ${cmd}: ${d.developerDetail ?? String(raw)}`);
-    if (opts?.retry) {
-      const id = feedbackService.registerRetry(opts.retry);
-      d.retryActionId = id;
-      d.retryable = true;
-    }
-    if (!opts?.silent) {
-      void feedbackService.report(d);
-    }
+    reportInvokeFailure(cmd, raw, opts);
     return null;
   }
 }
@@ -64,16 +84,7 @@ export async function invokeSafeVoid(
     await invoke(cmd, args);
     return true;
   } catch (raw) {
-    const d: Feedback = isFeedbackShape(raw) ? { ...raw } : fallback(cmd, raw);
-    logService.error(`[invokeSafe] ${cmd}: ${d.developerDetail ?? String(raw)}`);
-    if (opts?.retry) {
-      const id = feedbackService.registerRetry(opts.retry);
-      d.retryActionId = id;
-      d.retryable = true;
-    }
-    if (!opts?.silent) {
-      void feedbackService.report(d);
-    }
+    reportInvokeFailure(cmd, raw, opts);
     return false;
   }
 }
@@ -108,16 +119,7 @@ export async function invokeSafeOption<T>(
     const value = await invoke<T | null>(cmd, args);
     return { ok: true, value };
   } catch (raw) {
-    const d: Feedback = isFeedbackShape(raw) ? { ...raw } : fallback(cmd, raw);
-    logService.error(`[invokeSafe] ${cmd}: ${d.developerDetail ?? String(raw)}`);
-    if (opts?.retry) {
-      const id = feedbackService.registerRetry(opts.retry);
-      d.retryActionId = id;
-      d.retryable = true;
-    }
-    if (!opts?.silent) {
-      void feedbackService.report(d);
-    }
+    reportInvokeFailure(cmd, raw, opts);
     return { ok: false };
   }
 }

--- a/asyar-launcher/src/services/appInitializer.ts
+++ b/asyar-launcher/src/services/appInitializer.ts
@@ -51,6 +51,7 @@ import { extensionReadinessListener } from './extension/extensionReadinessListen
 import { iframeDeliveryListener } from './extension/iframeDeliveryListener.svelte';
 import { restoreWorkers } from '../lib/ipc/iframeLifecycleCommands';
 import { feedbackService } from './feedback/feedbackService.svelte';
+import { setInvokeFailureReporter } from '../lib/ipc/invokeSafe';
 
 // Flag to prevent multiple initializations
 let isInitialized = false;
@@ -82,6 +83,10 @@ export const appInitializer = {
 
     try {
       logService.info(`Application starting initialization...`);
+
+      // Route invoke failures to the diagnostics UI. Wired here (composition
+      // root) so the IPC transport doesn't import the feedback store.
+      setInvokeFailureReporter(feedbackService);
 
       // Register AI provider descriptors before any settings view reads the registry.
       initProviders();

--- a/asyar-launcher/src/services/application/scanPathsSync.test.ts
+++ b/asyar-launcher/src/services/application/scanPathsSync.test.ts
@@ -38,6 +38,8 @@ vi.mock('../settings/settingsService.svelte', () => ({
 
 import { invoke } from '@tauri-apps/api/core';
 import { initScanPathsSync, __resetScanPathsSyncForTest } from './scanPathsSync.svelte';
+import { feedbackService } from '../feedback/feedbackService.svelte';
+import { setInvokeFailureReporter } from '../../lib/ipc/invokeSafe';
 
 async function flush(): Promise<void> {
   // Let microtasks drain so the fire-and-forget `invoke` call resolves.
@@ -48,6 +50,7 @@ async function flush(): Promise<void> {
 describe('scanPathsSync', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setInvokeFailureReporter(feedbackService);
     subscribedCallbacks = [];
     settingsStateHolder.current = {
       search: { additionalScanPaths: [] },

--- a/asyar-launcher/src/services/fileIndex/fileIndexConfigSync.test.ts
+++ b/asyar-launcher/src/services/fileIndex/fileIndexConfigSync.test.ts
@@ -38,6 +38,8 @@ vi.mock('../settings/settingsService.svelte', () => ({
 }));
 
 import { invoke } from '@tauri-apps/api/core';
+import { feedbackService } from '../feedback/feedbackService.svelte';
+import { setInvokeFailureReporter } from '../../lib/ipc/invokeSafe';
 import {
   initFileIndexConfigSync,
   __resetFileIndexConfigSyncForTest,
@@ -61,6 +63,7 @@ function cfg(overrides: Partial<typeof settingsStateHolder.current.fileSearch> =
 describe('fileIndexConfigSync', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setInvokeFailureReporter(feedbackService);
     subscribedCallbacks = [];
     settingsStateHolder.current = { fileSearch: cfg() };
     __resetFileIndexConfigSyncForTest();

--- a/asyar-launcher/src/services/onboarding/onboardingService.svelte.test.ts
+++ b/asyar-launcher/src/services/onboarding/onboardingService.svelte.test.ts
@@ -10,6 +10,8 @@ vi.mock('../feedback/feedbackService.svelte', () => ({
 
 import { onboardingService } from './onboardingService.svelte';
 import { invoke } from '@tauri-apps/api/core';
+import { feedbackService } from '../feedback/feedbackService.svelte';
+import { setInvokeFailureReporter } from '../../lib/ipc/invokeSafe';
 import type { MockedFunction } from 'vitest';
 
 const mockInvoke = invoke as MockedFunction<typeof invoke>;
@@ -24,6 +26,7 @@ const initialState = {
 describe('onboardingService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setInvokeFailureReporter(feedbackService);
     onboardingService.reset();
   });
 
@@ -81,6 +84,7 @@ describe('onboardingService', () => {
 describe('skipAiSetup', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setInvokeFailureReporter(feedbackService);
     onboardingService.reset();
   });
 
@@ -102,6 +106,7 @@ describe('skipAiSetup', () => {
 describe('AI onboarding', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setInvokeFailureReporter(feedbackService);
     onboardingService.reset();
   });
 

--- a/asyar-launcher/src/services/search/searchBarAccessoryService.test.ts
+++ b/asyar-launcher/src/services/search/searchBarAccessoryService.test.ts
@@ -15,6 +15,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { searchBarAccessoryService } from './searchBarAccessoryService.svelte';
 import { extensionIframeManager } from '../extension/extensionIframeManager.svelte';
 import { feedbackService } from '../feedback/feedbackService.svelte';
+import { setInvokeFailureReporter } from '../../lib/ipc/invokeSafe';
 
 const EXT = 'org.test.ext';
 const CMD = 'show';
@@ -22,6 +23,7 @@ const CMD = 'show';
 describe('searchBarAccessoryService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setInvokeFailureReporter(feedbackService);
     searchBarAccessoryService.clear();
   });
 


### PR DESCRIPTION
Invert the dependency: invokeSafe now reports failures to an injected
InvokeFailureReporter instead of importing feedbackService, and the app wires
feedbackService as the reporter at its composition root (appInitializer). The
IPC transport no longer depends on the UI store, and the three duplicated
catch blocks collapse into one helper. Downstream service tests wire the
reporter in setup, matching production.