### PR TITLE
fix(extensions): make the act_<ext>_ action id idempotent

### DIFF
--- a/asyar-launcher/src/services/action/actionId.test.ts
+++ b/asyar-launcher/src/services/action/actionId.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { toFullActionId } from './actionId';
+
+describe('toFullActionId', () => {
+  it('prefixes a short action id', () => {
+    expect(toFullActionId('org.x', 'run')).toBe('act_org.x_run');
+  });
+
+  it('is idempotent for an already-prefixed id (no double-prefix)', () => {
+    expect(toFullActionId('org.x', 'act_org.x_run')).toBe('act_org.x_run');
+  });
+
+  it('only strips its own extension prefix', () => {
+    // Starts with "act_" but for a different extension → still prefixed.
+    expect(toFullActionId('org.x', 'act_org.y_run')).toBe('act_org.x_act_org.y_run');
+  });
+});

--- a/asyar-launcher/src/services/action/actionId.ts
+++ b/asyar-launcher/src/services/action/actionId.ts
@@ -1,0 +1,10 @@
+/**
+ * Build the canonical `act_<extensionId>_<actionId>` id, idempotently: an
+ * already-prefixed id is returned unchanged so a caller passing the full id
+ * can't double-prefix it. Mirrors the SDK's builder in ExtensionBridge so the
+ * host and the extension iframe always agree on the dispatch key.
+ */
+export function toFullActionId(extensionId: string, actionId: string): string {
+  const prefix = `act_${extensionId}_`;
+  return actionId.startsWith(prefix) ? actionId : `${prefix}${actionId}`;
+}

--- a/asyar-launcher/src/services/action/actionService.svelte.ts
+++ b/asyar-launcher/src/services/action/actionService.svelte.ts
@@ -1,4 +1,5 @@
 import { logService } from '../log/logService';
+import { toFullActionId } from './actionId';
 import type { ExtensionAction, IActionService } from 'asyar-sdk/contracts';
 import { ActionContext } from 'asyar-sdk/contracts';
 import * as commands from '../../lib/ipc/commands';
@@ -128,7 +129,7 @@ export class ActionService implements IActionService {
    * `act_<extensionId>_<actionId>` so lookups on dispatch are direct.
    */
   recordActionHandlerRole(extensionId: string, actionId: string, role: 'view' | 'worker'): void {
-    this.handlerRoles.set(`act_${extensionId}_${actionId}`, role);
+    this.handlerRoles.set(toFullActionId(extensionId, actionId), role);
   }
 
   getActionHandlerRole(fullActionId: string): 'view' | 'worker' | undefined {
@@ -353,7 +354,7 @@ export class ActionService implements IActionService {
     // The SDK's action registry keys handlers on the full `act_<ext>_<short>`
     // id (both registerActionHandler and the asyar:action:execute receiver),
     // so the envelope must carry the full id — callers pass the short id.
-    const fullActionId = `act_${extensionId}_${actionId}`;
+    const fullActionId = toFullActionId(extensionId, actionId);
     const role = this.handlerRoles.get(fullActionId);
     this.sendToExtension?.(extensionId, fullActionId, role ?? 'worker', payload);
     return true;

--- a/asyar-sdk/src/ExtensionBridge.test.ts
+++ b/asyar-sdk/src/ExtensionBridge.test.ts
@@ -300,6 +300,24 @@ describe('ExtensionBridge registerActionHandler', () => {
     expect(found!.extensionId).toBe('com.example.github');
   });
 
+  it('does not double-prefix when given an already-full action id', async () => {
+    const { extensionBridge: bridge } = await import('./ExtensionBridge');
+    const handler = vi.fn();
+
+    // A caller passing the already-prefixed id must still key on the single
+    // full id (not act_<ext>_act_<ext>_...), or dispatch — which sends the
+    // single full id — can never find the handler.
+    bridge.registerActionHandler(
+      'com.example.github',
+      'act_com.example.github_open-browser',
+      handler,
+    );
+
+    const ids = bridge.getActions().map((a) => a.id);
+    expect(ids).toContain('act_com.example.github_open-browser');
+    expect(ids).not.toContain('act_com.example.github_act_com.example.github_open-browser');
+  });
+
   it('handler is invoked when asyar:action:execute message arrives', async () => {
     const { extensionBridge: bridge } = await import('./ExtensionBridge');
     const handler = vi.fn();

--- a/asyar-sdk/src/ExtensionBridge.ts
+++ b/asyar-sdk/src/ExtensionBridge.ts
@@ -14,6 +14,18 @@ import type { IPCMessage, IPCResponse } from './ipc/MessageBroker';
 // `ExtensionIpcRouter` rejects them as untrusted-frame messages.
 
 // Define the bridge that will be used to communicate between extensions and the base app
+/**
+ * Build the canonical `act_<extensionId>_<actionId>` key, idempotently: if
+ * `actionId` is already prefixed it is returned unchanged, so a caller that
+ * passes the full id can't double-prefix it (which would make dispatch — which
+ * sends the single full id — miss the handler). Kept in sync with the host's
+ * builder in actionService.
+ */
+function toFullActionId(extensionId: string, actionId: string): string {
+  const prefix = `act_${extensionId}_`;
+  return actionId.startsWith(prefix) ? actionId : `${prefix}${actionId}`;
+}
+
 export class ExtensionBridge {
   private extensionManifests: Map<string, ExtensionManifest> = new Map();
   private extensionImplementations: Map<string, Extension> = new Map();
@@ -274,7 +286,7 @@ export class ExtensionBridge {
     actionId: string,
     handler: (payload?: unknown) => Promise<void> | void,
   ): void {
-    const fullActionId = `act_${extensionId}_${actionId}`;
+    const fullActionId = toFullActionId(extensionId, actionId);
     this.actionRegistry.set(fullActionId, {
       id: fullActionId,
       title: actionId,


### PR DESCRIPTION
registerActionHandler and the host's role/dispatch builders prefixed the
action id unconditionally, so passing an already-full id produced
act_<ext>_act_<ext>_<id> — the SDK registry key and the host's handlerRoles /
dispatch id diverged and the handler became unreachable (a shipped extension
carried this). Build the full id idempotently in the SDK and the host so short
and full inputs converge on one key. The raw registerAction scheme is untouched.