### PR TITLE
fix(extensions): stop the permission gate denying working extension calls

### DIFF
--- a/asyar-launcher/scripts/permission-coverage.test.mjs
+++ b/asyar-launcher/scripts/permission-coverage.test.mjs
@@ -32,12 +32,16 @@ function walkTs(dir, out = []) {
   return out;
 }
 
-// Every extension→host call the SDK can make. Each proxy calls
-// `broker.invoke('service:action')`; the MessageBroker prepends `asyar:api:`.
-// (Verified: the SDK uses only static string literals here — no dynamically
-// built call types — so this static scan is complete.)
+// Every extension→host call the SDK can make. A proxy reaches the gate three
+// ways: `broker.invoke('service:action')`, the structural `this.invoke(...)`,
+// and a captured `const invoke = this.invoke.bind(this)` inside a returned
+// handle. Any of them may carry an explicit return generic (`invoke<T>(...)`).
+// The pattern MUST therefore allow an optional `<...>` and match `invoke` with
+// or without a leading dot — missing the generic form is exactly how the whole
+// `state:*` family slipped past the gate. The first arg is always a static
+// `'service:action'` literal (no dynamically built call types).
 function sdkCallTypes() {
-  const re = /\.invoke\(\s*['"`]([a-zA-Z]+:[a-zA-Z]+)['"`]/g;
+  const re = /\binvoke\s*(?:<[^>]*>)?\s*\(\s*['"`]([a-zA-Z]+:[a-zA-Z]+)['"`]/g;
   const set = new Set();
   for (const file of walkTs(SDK_SRC)) {
     for (const m of readFileSync(file, 'utf8').matchAll(re)) set.add(`asyar:api:${m[1]}`);
@@ -65,16 +69,67 @@ function rustClassifiedCallTypes() {
   return set;
 }
 
+// Call types the SDK's ExtensionContext constructs but that are host-realm
+// operations — the fail-closed gate DENIES them for sandboxed (Tier-2)
+// extensions, which is correct (before #567's fail-closed change these were
+// silently ALLOWED — e.g. an extension could uninstall other extensions). They
+// are listed here so coverage knows they are *intentionally* unclassified
+// (denied), not forgotten. Marking any of these public/gated would hand a
+// sandboxed extension a privileged host API — the guards below enforce that.
+const HOST_REALM_ONLY = new Set([
+  'asyar:api:extensions:getAllExtensions',
+  'asyar:api:extensions:getAllExtensionsWithState',
+  'asyar:api:extensions:handleViewSearch',
+  'asyar:api:extensions:handleViewSubmit',
+  'asyar:api:extensions:init',
+  'asyar:api:extensions:loadExtensions',
+  'asyar:api:extensions:reloadExtensions',
+  'asyar:api:extensions:searchAll',
+  'asyar:api:extensions:toggleExtensionState',
+  'asyar:api:extensions:uninstallExtension',
+  'asyar:api:settings:get',
+  'asyar:api:settings:set',
+  'asyar:api:clipboard:hideWindow',
+  'asyar:api:clipboard:initialize',
+  'asyar:api:commands:executeCommand',
+  'asyar:api:onboarding:complete',
+]);
+
 describe('extension permission gate coverage', () => {
-  it('classifies every call type an extension can invoke (fail-closed gate must be exhaustive)', () => {
+  it('classifies every Tier-2-callable type (fail-closed gate must be exhaustive)', () => {
     const classified = rustClassifiedCallTypes();
-    const unclassified = [...sdkCallTypes()].filter((c) => !classified.has(c)).sort();
+    const unclassified = [...sdkCallTypes()]
+      .filter((c) => !classified.has(c) && !HOST_REALM_ONLY.has(c))
+      .sort();
     expect(
       unclassified,
       'These SDK call types reach check_extension_permission but are in neither ' +
         'get_required_permission nor is_public_call, so the fail-closed gate would DENY them. ' +
-        'Classify each in asyar-launcher/src-tauri/src/permissions.rs:\n  ' +
+        'EITHER classify each in asyar-launcher/src-tauri/src/permissions.rs (if a sandboxed ' +
+        'extension should be able to call it) OR add it to HOST_REALM_ONLY here (if it is a ' +
+        'host-only op that must stay denied for extensions):\n  ' +
         unclassified.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('never both classifies AND host-realm-flags a call (that would grant a privileged API)', () => {
+    const classified = rustClassifiedCallTypes();
+    const wronglyAllowed = [...HOST_REALM_ONLY].filter((c) => classified.has(c)).sort();
+    expect(
+      wronglyAllowed,
+      'These are on HOST_REALM_ONLY yet ALSO classified in permissions.rs, so a sandboxed ' +
+        'extension can now reach a host-only API. Remove them from is_public_call / ' +
+        'get_required_permission (or from HOST_REALM_ONLY if genuinely safe):\n  ' +
+        wronglyAllowed.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('keeps HOST_REALM_ONLY free of stale entries (each must still be a real SDK call)', () => {
+    const calls = sdkCallTypes();
+    const stale = [...HOST_REALM_ONLY].filter((c) => !calls.has(c)).sort();
+    expect(
+      stale,
+      `HOST_REALM_ONLY lists call types the SDK no longer emits:\n  ${stale.join('\n  ')}`,
     ).toEqual([]);
   });
 

--- a/asyar-launcher/src-tauri/src/permissions.rs
+++ b/asyar-launcher/src-tauri/src/permissions.rs
@@ -348,6 +348,7 @@ fn is_public_call(call_type: &str) -> bool {
             | "asyar:api:actions:registerAction"
             | "asyar:api:actions:unregisterAction"
             | "asyar:api:actions:setContext"
+            | "asyar:api:actions:executeAction"
             | "asyar:api:extensions:navigateToView"
             | "asyar:api:extensions:goBack"
             | "asyar:api:extensions:forwardKeyToActiveView"
@@ -365,6 +366,26 @@ fn is_public_call(call_type: &str) -> bool {
             | "asyar:api:commands:replaceDynamicCommands"
             | "asyar:api:commands:updateCommandMetadata"
             | "asyar:api:commands:clearCommandsForExtension"
+        // Worker<->view shared state + RPC, scoped to the calling extension
+        // (state is in INJECTS_EXTENSION_ID) — internal plumbing, no host data
+        // read, nothing persisted host-side, no cross-extension reach.
+            | "asyar:api:state:get"
+            | "asyar:api:state:set"
+            | "asyar:api:state:subscribe"
+            | "asyar:api:state:unsubscribe"
+            | "asyar:api:state:rpcRequest"
+            | "asyar:api:state:rpcReply"
+            | "asyar:api:state:rpcAbort"
+        // Ephemeral, extension-scoped feedback UI — toast / progress / HUD /
+        // confirm dialog. Transient, scoped to the caller; nothing persisted.
+        // (Notification-like feedback — announce / sendBackground — stays gated.)
+            | "asyar:api:feedback:report"
+            | "asyar:api:feedback:showProgress"
+            | "asyar:api:feedback:updateProgress"
+            | "asyar:api:feedback:finishProgress"
+            | "asyar:api:feedback:showHUD"
+            | "asyar:api:feedback:dismiss"
+            | "asyar:api:feedback:confirmAlert"
         // Pure compute — caller supplies its own input, gets a transform back.
             | "asyar:api:search:rank"
             | "asyar:api:clipboard:stripHtml"
@@ -876,6 +897,53 @@ mod tests {
                 gate_decision(call),
                 GateDecision::AllowPublic,
                 "{call} should be permission-free"
+            );
+        }
+    }
+
+    #[test]
+    fn gate_decision_allows_worker_view_state_rpc() {
+        // The state:* family is worker<->view shared-state plumbing, scoped to
+        // the calling extension (state is in INJECTS_EXTENSION_ID) — so it is
+        // permission-free like actions:* and extensions:navigateToView. Omitting
+        // these made the fail-closed gate deny any extension using shared state.
+        for call in [
+            "asyar:api:state:get",
+            "asyar:api:state:set",
+            "asyar:api:state:subscribe",
+            "asyar:api:state:unsubscribe",
+            "asyar:api:state:rpcRequest",
+            "asyar:api:state:rpcReply",
+            "asyar:api:state:rpcAbort",
+        ] {
+            assert_eq!(
+                gate_decision(call),
+                GateDecision::AllowPublic,
+                "{call} should be permission-free (worker<->view state, scoped per extension)"
+            );
+        }
+    }
+
+    #[test]
+    fn gate_decision_allows_scoped_feedback_and_action_exec() {
+        // Ephemeral, extension-scoped feedback UI (toast/progress/HUD/confirm)
+        // and the extension triggering its own action are transient and scoped
+        // to the caller — permission-free, like statusBar:* and actions:register*.
+        // (Notification-like feedback — announce/sendBackground — stays gated.)
+        for call in [
+            "asyar:api:feedback:report",
+            "asyar:api:feedback:showProgress",
+            "asyar:api:feedback:updateProgress",
+            "asyar:api:feedback:finishProgress",
+            "asyar:api:feedback:showHUD",
+            "asyar:api:feedback:dismiss",
+            "asyar:api:feedback:confirmAlert",
+            "asyar:api:actions:executeAction",
+        ] {
+            assert_eq!(
+                gate_decision(call),
+                GateDecision::AllowPublic,
+                "{call} should be permission-free (ephemeral, extension-scoped UI)"
             );
         }
     }

--- a/asyar-launcher/src/services/extension/ExtensionIpcRouter.test.ts
+++ b/asyar-launcher/src/services/extension/ExtensionIpcRouter.test.ts
@@ -28,6 +28,8 @@ import * as commands from '../../lib/ipc/commands';
 import { ExtensionIpcRouter } from './ExtensionIpcRouter';
 import type { ServiceRegistry } from './defineServiceRegistry';
 import { logService } from '../log/logService';
+import { extensionPreferencesService } from './extensionPreferencesService.svelte';
+import { streamDispatcher } from './streamDispatcher.svelte';
 
 describe('ExtensionIpcRouter — externally consumed responses', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -641,5 +643,218 @@ describe('ExtensionIpcRouter — AppError-shaped rejection messages', () => {
     );
 
     postMessage.mockRestore();
+  });
+});
+
+describe('ExtensionIpcRouter — protocol frames bypass the permission gate', () => {
+  // Regression: the gate ran on EVERY `asyar:*` message from an iframe, but the
+  // Rust gate only classifies the `asyar:api:*` call surface. Once it became
+  // fail-closed, transport/lifecycle frames — which are not API calls and have
+  // no permission to declare — started being denied with
+  // `Permission denied: "asyar:extension:loaded" is required but not declared
+  // in manifest.json`, so no extension ever got its preferences bundle.
+  let iframeEl: HTMLIFrameElement;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.querySelectorAll('iframe[data-extension-id]').forEach((el) => el.remove());
+    // Every previously registered router shares this listener, so make the gate
+    // deny — exactly what fail-closed Rust does for a non-`asyar:api:` type.
+    vi.mocked(commands.checkExtensionPermission).mockResolvedValue({
+      allowed: false,
+      reason: 'Call is not a recognized extension API — refusing by default (fail closed).',
+    } as any);
+
+    iframeEl = document.createElement('iframe');
+    iframeEl.setAttribute('data-extension-id', 'org.asyar.demo');
+    iframeEl.setAttribute('data-role', 'view');
+    document.body.appendChild(iframeEl);
+  });
+
+  afterEach(() => iframeEl?.remove());
+
+  const getManifestById = (id: string) => (id === 'org.asyar.demo' ? ({ id } as any) : undefined);
+
+  it('answers asyar:extension:loaded with the preferences bundle instead of denying it', async () => {
+    vi.mocked(extensionPreferencesService.getEffectivePreferences).mockResolvedValue({
+      extension: { theme: 'dark' },
+      commands: {},
+    } as any);
+    const framePostMessage = vi
+      .spyOn(iframeEl.contentWindow as Window, 'postMessage')
+      .mockImplementation(() => {});
+
+    const router = new ExtensionIpcRouter(
+      {} as ServiceRegistry,
+      getManifestById as any,
+      vi.fn(),
+      vi.fn(),
+    );
+    router.setup();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'asyar:extension:loaded', extensionId: 'org.asyar.demo', role: 'view' },
+        source: iframeEl.contentWindow,
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // Routers from earlier describes share this window listener and reply
+    // "Unknown extension" (their own getManifestById mocks know nothing about
+    // org.asyar.demo), so assert on this router's reply, not on "no errors".
+    const sent = framePostMessage.mock.calls.map(
+      (call) => call[0] as { type?: string; error?: string },
+    );
+    expect(sent.some((msg) => msg?.type === 'asyar:event:preferences:set-all')).toBe(true);
+    expect(sent.some((msg) => msg?.error?.includes('Permission denied'))).toBe(false);
+    // A lifecycle frame is not an API call, so the gate must not be consulted.
+    expect(commands.checkExtensionPermission).not.toHaveBeenCalledWith(
+      'org.asyar.demo',
+      'asyar:extension:loaded',
+    );
+
+    framePostMessage.mockRestore();
+  });
+
+  it('lets asyar:stream:abort reach the stream dispatcher instead of denying it', async () => {
+    const router = new ExtensionIpcRouter(
+      {} as ServiceRegistry,
+      getManifestById as any,
+      vi.fn(),
+      vi.fn(),
+    );
+    router.setup();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'asyar:stream:abort', payload: { streamId: 'stream-7' } },
+        source: iframeEl.contentWindow,
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(streamDispatcher.abort).toHaveBeenCalledWith('stream-7');
+    expect(commands.checkExtensionPermission).not.toHaveBeenCalledWith(
+      'org.asyar.demo',
+      'asyar:stream:abort',
+    );
+  });
+
+  it('reports a fail-closed denial by its reason, not as a missing manifest permission', async () => {
+    // A call type is not a permission name, so "declare it in manifest.json" is
+    // unfollowable advice for an unrecognized call — that is what a stale
+    // extension bundle calling a DELETED api (e.g. the removed
+    // snippets:setInlineFallbackEnabled) hits. Rust sends `reason` and no
+    // `requiredPermission` in that case; surface it.
+    vi.mocked(commands.checkExtensionPermission).mockResolvedValue({
+      allowed: false,
+      reason:
+        'Call "asyar:api:snippets:setInlineFallbackEnabled" is not a recognized extension API — refusing by default (fail closed).',
+    } as any);
+    const framePostMessage = vi
+      .spyOn(iframeEl.contentWindow as Window, 'postMessage')
+      .mockImplementation(() => {});
+
+    const router = new ExtensionIpcRouter(
+      {} as ServiceRegistry,
+      getManifestById as any,
+      vi.fn(),
+      vi.fn(),
+    );
+    router.setup();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          type: 'asyar:api:snippets:setInlineFallbackEnabled',
+          payload: { enabled: true },
+          messageId: 'gone-1',
+        },
+        source: iframeEl.contentWindow,
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const errors = framePostMessage.mock.calls
+      .map((call) => call[0] as { messageId?: string; error?: string })
+      .filter((msg) => msg?.messageId === 'gone-1' && msg?.error);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.every((msg) => !msg.error?.includes('manifest.json'))).toBe(true);
+    expect(errors.some((msg) => msg.error?.includes('not a recognized extension API'))).toBe(true);
+    // The reason already names the call, and the toast header shows it too —
+    // don't echo it a second time.
+    for (const msg of errors) {
+      const mentions = msg.error?.split('asyar:api:snippets:setInlineFallbackEnabled').length ?? 1;
+      expect(mentions - 1).toBeLessThanOrEqual(1);
+    }
+
+    framePostMessage.mockRestore();
+  });
+
+  it('still names the missing permission when one is genuinely undeclared', async () => {
+    vi.mocked(commands.checkExtensionPermission).mockResolvedValue({
+      allowed: false,
+      requiredPermission: 'clipboard:read',
+      reason: 'Extension "org.asyar.demo" has not declared "clipboard:read".',
+    } as any);
+    const framePostMessage = vi
+      .spyOn(iframeEl.contentWindow as Window, 'postMessage')
+      .mockImplementation(() => {});
+
+    const router = new ExtensionIpcRouter(
+      {} as ServiceRegistry,
+      getManifestById as any,
+      vi.fn(),
+      vi.fn(),
+    );
+    router.setup();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'asyar:api:clipboard:readText', messageId: 'gated-2' },
+        source: iframeEl.contentWindow,
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const errors = framePostMessage.mock.calls
+      .map((call) => call[0] as { messageId?: string; error?: string })
+      .filter((msg) => msg?.messageId === 'gated-2' && msg?.error);
+
+    expect(
+      errors.some(
+        (msg) =>
+          msg.error?.includes('clipboard:read') && msg.error?.includes('not declared in manifest'),
+      ),
+    ).toBe(true);
+
+    framePostMessage.mockRestore();
+  });
+
+  it('still gates asyar:api:* calls from the same iframe', async () => {
+    const storageGet = vi.fn(async () => 'value');
+    const registry = { storage: { get: storageGet } } as unknown as ServiceRegistry;
+    const router = new ExtensionIpcRouter(registry, getManifestById as any, vi.fn(), vi.fn());
+    router.setup();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          type: 'asyar:api:storage:get',
+          payload: { key: 'secret' },
+          messageId: 'gated-1',
+        },
+        source: iframeEl.contentWindow,
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(commands.checkExtensionPermission).toHaveBeenCalledWith(
+      'org.asyar.demo',
+      'asyar:api:storage:get',
+    );
+    expect(storageGet).not.toHaveBeenCalled();
   });
 });

--- a/asyar-launcher/src/services/extension/ExtensionIpcRouter.ts
+++ b/asyar-launcher/src/services/extension/ExtensionIpcRouter.ts
@@ -209,31 +209,51 @@ export class ExtensionIpcRouter {
         }
 
         // --- Permission Gate ---
-        // Fail closed: a failed permission check (null) must deny, not crash
-        // or silently let the call through.
-        const permissionResult = await commands.checkExtensionPermission(extensionId, type);
-        if (!permissionResult?.allowed) {
-          logService.warn(
-            `[PermissionGate] BLOCKED: ${permissionResult?.reason ?? 'permission check failed'}`,
-          );
-          const permError = `Permission denied: "${permissionResult?.requiredPermission ?? type}" is required but not declared in manifest.json`;
-          (event.source as Window)?.postMessage(
-            {
-              type: 'asyar:response',
-              messageId,
-              error: permError,
-            },
-            '*',
-          );
-          void feedbackService.report({
-            source: 'extension',
-            kind: classifyProxyError(type, permError),
-            severity: 'warning',
-            retryable: false,
-            context: { method: type, error: permError },
-            extensionId,
-          });
-          return;
+        // Only `asyar:api:*` is a permission-bearing call surface, and it is the
+        // only surface the Rust gate classifies. Everything else on the `asyar:`
+        // channel is transport/lifecycle plumbing (`asyar:extension:loaded`,
+        // `asyar:stream:abort`, the frames other listeners consume) — it has no
+        // permission to declare and reaches no service dispatch, so running the
+        // now-fail-closed gate on it denied every one of them.
+        // Dispatch stays fail-closed regardless: the only path into a service is
+        // the `asyar:api:` branch below, which is always gated here.
+        if (type.startsWith('asyar:api:')) {
+          // Fail closed: a failed permission check (null) must deny, not crash
+          // or silently let the call through.
+          const permissionResult = await commands.checkExtensionPermission(extensionId, type);
+          if (!permissionResult?.allowed) {
+            logService.warn(
+              `[PermissionGate] BLOCKED: ${permissionResult?.reason ?? 'permission check failed'}`,
+            );
+            // Rust sets `requiredPermission` only when the call is gated on a
+            // real manifest permission. The fail-closed path (unrecognized call
+            // type — typically a stale extension bundle calling a deleted API)
+            // sends only `reason`, and a call type is not a permission name, so
+            // telling the author to declare it in manifest.json is unfollowable.
+            // The reason is already self-describing (and the call type travels
+            // separately in `context.method`), so it is surfaced verbatim —
+            // prefixing it with the type printed the same string twice.
+            const permError = permissionResult?.requiredPermission
+              ? `Permission denied: "${permissionResult.requiredPermission}" is required but not declared in manifest.json`
+              : (permissionResult?.reason ?? `Blocked "${type}": permission check failed`);
+            (event.source as Window)?.postMessage(
+              {
+                type: 'asyar:response',
+                messageId,
+                error: permError,
+              },
+              '*',
+            );
+            void feedbackService.report({
+              source: 'extension',
+              kind: classifyProxyError(type, permError),
+              severity: 'warning',
+              retryable: false,
+              context: { method: type, error: permError },
+              extensionId,
+            });
+            return;
+          }
         }
       }
 


### PR DESCRIPTION
Classify the state, feedback, and executeAction surfaces as permission-free,
and run the gate only on asyar:api:* — lifecycle and transport frames like
asyar:extension:loaded have no permission to declare, so gating them left
extensions without their preferences bundle. Report a fail-closed denial by
its reason instead of naming the call type as a missing manifest permission.