### PR TITLE
refactor(storage): serve asyar_data.db from a connection pool

### DIFF
--- a/asyar-launcher/src-tauri/Cargo.lock
+++ b/asyar-launcher/src-tauri/Cargo.lock
@@ -250,6 +250,8 @@ dependencies = [
  "png 0.17.16",
  "procfs",
  "proptest",
+ "r2d2",
+ "r2d2_sqlite",
  "rand 0.10.2",
  "rdev",
  "regex",
@@ -5220,6 +5222,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
+name = "r2d2_sqlite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a982edf65c129796dba72f8775b292ef482b40d035e827a9825b3bc07ccc5f2"
+dependencies = [
+ "r2d2",
+ "rusqlite",
+ "uuid",
+]
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5878,6 +5902,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -7989,6 +8022,7 @@ checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "rand 0.10.2",
  "serde_core",
  "wasm-bindgen",
 ]

--- a/asyar-launcher/src-tauri/Cargo.toml
+++ b/asyar-launcher/src-tauri/Cargo.toml
@@ -37,6 +37,10 @@ tauri-plugin-store = "2"
 thiserror = "2"
 enigo = "0.1.3"
 rusqlite = { version = "0.31", features = ["bundled"] }
+r2d2 = "0.8"
+# 0.24 is the r2d2_sqlite line built against rusqlite 0.31 — later releases
+# track newer rusqlite majors and will not link against the pin above.
+r2d2_sqlite = "0.24"
 plist = "1.7"
 tauri-plugin-notification = "2"
 tokio = { version = "1.0", features = ["full"] }

--- a/asyar-launcher/src-tauri/src/agents/builtin_tools/notes_test.rs
+++ b/asyar-launcher/src-tauri/src/agents/builtin_tools/notes_test.rs
@@ -5,7 +5,6 @@ use crate::agents::tools::BuiltinTool;
 use crate::storage::notes::{self, Note};
 use crate::storage::notes_fts::NotesFts;
 use crate::storage::DataStore;
-use rusqlite::Connection;
 use serde_json::json;
 use std::sync::Arc;
 
@@ -18,9 +17,7 @@ fn test_key() -> [u8; 32] {
 }
 
 fn test_store() -> (DataStore, [u8; 32], Arc<NotesFts>) {
-    let conn = Connection::open_in_memory().unwrap();
-    notes::init_table(&conn).unwrap();
-    let store = DataStore::from_conn(conn);
+    let store = crate::storage::create_test_store();
     let fts = Arc::new(NotesFts::new_in_memory().unwrap());
     (store, test_key(), fts)
 }

--- a/asyar-launcher/src-tauri/src/agents/runner_test.rs
+++ b/asyar-launcher/src-tauri/src/agents/runner_test.rs
@@ -8,17 +8,13 @@ use crate::error::AppError;
 use crate::storage::agents::{
     insert_agent, insert_thread, list_messages_for_thread, AgentRow, MessageRole, ThreadRow,
 };
-use rusqlite::Connection;
 use serde_json::json;
 use std::sync::Arc;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 
-fn make_conn() -> Connection {
-    let conn = Connection::open_in_memory().expect("in-memory db");
-    conn.execute("PRAGMA foreign_keys = ON", []).unwrap();
-    crate::storage::agents::init_table(&conn).unwrap();
-    conn
+fn make_store() -> crate::storage::DataStore {
+    crate::storage::create_test_store_with_foreign_keys()
 }
 
 fn chat_message(role: &str, content: &str) -> crate::ai::types::ChatMessage {
@@ -307,11 +303,11 @@ async fn test_silent_runner_passes_through_a_single_emoji_for_shortcode_miss() {
 
 #[tokio::test]
 async fn test_thread_runner_rejects_thread_owned_by_another_agent() {
-    let conn = make_conn();
+    let store = make_store();
     let now = chrono::Utc::now().timestamp_millis();
     for id in ["agent-1", "agent-2"] {
         insert_agent(
-            &conn,
+            &store.conn().unwrap(),
             &AgentRow {
                 id: id.to_string(),
                 name: id.to_string(),
@@ -332,7 +328,7 @@ async fn test_thread_runner_rejects_thread_owned_by_another_agent() {
         .unwrap();
     }
     insert_thread(
-        &conn,
+        &store.conn().unwrap(),
         &ThreadRow {
             id: "thread-2".to_string(),
             agent_id: "agent-2".to_string(),
@@ -351,7 +347,6 @@ async fn test_thread_runner_rejects_thread_owned_by_another_agent() {
         hosted_web_search: None,
         reasoning_effort: None,
     };
-    let store = crate::storage::DataStore::from_conn(conn);
 
     let error = run_thread_loop_impl(
         &store,
@@ -398,7 +393,7 @@ async fn test_run_thread_loop_text_only() {
         socket.write_all(response.as_bytes()).await.unwrap();
     });
 
-    let conn = make_conn();
+    let store = make_store();
 
     // Insert mock agent & thread
     let agent_id = "agent-1".to_string();
@@ -406,7 +401,7 @@ async fn test_run_thread_loop_text_only() {
     let now = chrono::Utc::now().timestamp_millis();
 
     insert_agent(
-        &conn,
+        &store.conn().unwrap(),
         &AgentRow {
             id: agent_id.clone(),
             name: "Test Agent".to_string(),
@@ -427,7 +422,7 @@ async fn test_run_thread_loop_text_only() {
     .unwrap();
 
     insert_thread(
-        &conn,
+        &store.conn().unwrap(),
         &ThreadRow {
             id: thread_id.clone(),
             agent_id: agent_id.clone(),
@@ -459,8 +454,6 @@ async fn test_run_thread_loop_text_only() {
             }
         }
     };
-
-    let store = crate::storage::DataStore::from_conn(conn);
 
     run_thread_loop_impl(
         &store,
@@ -534,13 +527,13 @@ data: {\"choices\":[{\"delta\":{\"content\":\"Final result!\"}}]}\n\ndata: [DONE
         socket2.write_all(response_turn_1.as_bytes()).await.unwrap();
     });
 
-    let conn = make_conn();
+    let store = make_store();
     let agent_id = "agent-tool".to_string();
     let thread_id = "thread-tool".to_string();
     let now = chrono::Utc::now().timestamp_millis();
 
     insert_agent(
-        &conn,
+        &store.conn().unwrap(),
         &AgentRow {
             id: agent_id.clone(),
             name: "Tool Agent".to_string(),
@@ -561,7 +554,7 @@ data: {\"choices\":[{\"delta\":{\"content\":\"Final result!\"}}]}\n\ndata: [DONE
     .unwrap();
 
     insert_thread(
-        &conn,
+        &store.conn().unwrap(),
         &ThreadRow {
             id: thread_id.clone(),
             agent_id: agent_id.clone(),
@@ -607,8 +600,6 @@ data: {\"choices\":[{\"delta\":{\"content\":\"Final result!\"}}]}\n\ndata: [DONE
     let on_event = move |event| {
         e_clone.lock().unwrap().push(event);
     };
-
-    let store = crate::storage::DataStore::from_conn(conn);
 
     run_thread_loop_impl(
         &store,
@@ -678,13 +669,13 @@ data: {\"choices\":[{\"delta\":{\"content\":\"Extension result used\"}}]}\n\ndat
         socket2.write_all(response_turn_1.as_bytes()).await.unwrap();
     });
 
-    let conn = make_conn();
+    let store = make_store();
     let agent_id = "agent-suspend".to_string();
     let thread_id = "thread-suspend".to_string();
     let now = chrono::Utc::now().timestamp_millis();
 
     insert_agent(
-        &conn,
+        &store.conn().unwrap(),
         &AgentRow {
             id: agent_id.clone(),
             name: "Suspend Agent".to_string(),
@@ -705,7 +696,7 @@ data: {\"choices\":[{\"delta\":{\"content\":\"Extension result used\"}}]}\n\ndat
     .unwrap();
 
     insert_thread(
-        &conn,
+        &store.conn().unwrap(),
         &ThreadRow {
             id: thread_id.clone(),
             agent_id: agent_id.clone(),
@@ -748,8 +739,6 @@ data: {\"choices\":[{\"delta\":{\"content\":\"Extension result used\"}}]}\n\ndat
     let dispatched = Arc::new(std::sync::Mutex::new(Vec::new()));
     let dispatched_clone = dispatched.clone();
     let events_for_dispatch = events.clone();
-
-    let store = crate::storage::DataStore::from_conn(conn);
 
     run_thread_loop_impl(
         &store,
@@ -827,11 +816,11 @@ data: {\"choices\":[{\"delta\":{\"content\":\"Corrected text\"}}]}\n\ndata: [DON
         socket.write_all(response.as_bytes()).await.unwrap();
     });
 
-    let conn = make_conn();
+    let store = make_store();
     let agent_id = "silent-agent".to_string();
     let now = chrono::Utc::now().timestamp_millis();
     insert_agent(
-        &conn,
+        &store.conn().unwrap(),
         &AgentRow {
             id: agent_id.clone(),
             name: "Silent Agent".to_string(),
@@ -851,7 +840,6 @@ data: {\"choices\":[{\"delta\":{\"content\":\"Corrected text\"}}]}\n\ndata: [DON
     )
     .unwrap();
 
-    let store = crate::storage::DataStore::from_conn(conn);
     let registry = Arc::new(ToolRegistry::new());
     let config = crate::ai::types::ProviderConfig {
         enabled: true,

--- a/asyar-launcher/src-tauri/src/aliases/mod.rs
+++ b/asyar-launcher/src-tauri/src/aliases/mod.rs
@@ -3,8 +3,9 @@ pub mod models;
 
 pub use models::{validate_alias, AliasError, ItemAlias};
 
+use crate::storage::DataStore;
 use rusqlite::{params, Connection};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::RwLock;
 
 pub fn init_table(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(
@@ -32,28 +33,28 @@ fn is_unique_alias_violation(err: &rusqlite::Error) -> bool {
 
 pub struct AliasState {
     pub items: RwLock<Vec<ItemAlias>>,
-    pub db: Arc<Mutex<Connection>>,
+    /// The shared store, not a connection: this state is alive for the whole
+    /// run, so it checks out a connection per query and gives it straight back.
+    pub store: DataStore,
 }
 
 impl AliasState {
-    /// Open an in-memory SQLite DB (used by tests) with the schema applied.
+    /// A throwaway file-backed store with the schema applied (used by tests).
     #[cfg(test)]
-    pub fn new_in_memory() -> Self {
-        let conn = Connection::open_in_memory().expect("open in-memory db");
-        init_table(&conn).expect("init schema");
+    pub fn new_for_test() -> Self {
         Self {
             items: RwLock::new(Vec::new()),
-            db: Arc::new(Mutex::new(conn)),
+            store: crate::storage::create_test_store(),
         }
     }
 
-    /// Build an `AliasState` sharing the DataStore SQLite connection.
+    /// Build an `AliasState` sharing the app's `DataStore`.
     /// The schema must already be initialised by `DataStore::initialize`
     /// calling `aliases::init_table`; this constructor only loads cached rows.
-    pub fn new_with_db(db: Arc<Mutex<Connection>>) -> Result<Self, AliasError> {
+    pub fn new_with_db(store: DataStore) -> Result<Self, AliasError> {
         let state = Self {
             items: RwLock::new(Vec::new()),
-            db,
+            store,
         };
         state.load_from_db()?;
         Ok(state)
@@ -61,9 +62,9 @@ impl AliasState {
 
     fn load_from_db(&self) -> Result<(), AliasError> {
         let conn = self
-            .db
-            .lock()
-            .map_err(|_| AliasError::Storage("db mutex poisoned in load_from_db".into()))?;
+            .store
+            .conn()
+            .map_err(|e| AliasError::Storage(e.to_string()))?;
         let mut stmt = conn
             .prepare("SELECT object_id, alias, item_name, item_type, created_at FROM item_aliases")
             .map_err(|e| AliasError::Storage(e.to_string()))?;
@@ -128,9 +129,9 @@ impl AliasState {
         // Persist (UPSERT semantics: replace any existing row for this object_id).
         {
             let conn = self
-                .db
-                .lock()
-                .map_err(|_| AliasError::Storage("db mutex poisoned in set_alias".into()))?;
+                .store
+                .conn()
+                .map_err(|e| AliasError::Storage(e.to_string()))?;
             let exec_result = conn.execute(
                 "INSERT INTO item_aliases (object_id, alias, item_name, item_type, created_at)
                  VALUES (?1, ?2, ?3, ?4, ?5)
@@ -180,9 +181,9 @@ impl AliasState {
     pub fn unset_alias(&self, alias: &str) -> Result<(), AliasError> {
         let normalized = alias.trim().to_lowercase();
         let conn = self
-            .db
-            .lock()
-            .map_err(|_| AliasError::Storage("db mutex poisoned in unset_alias".into()))?;
+            .store
+            .conn()
+            .map_err(|e| AliasError::Storage(e.to_string()))?;
         let affected = conn
             .execute(
                 "DELETE FROM item_aliases WHERE alias = ?1",
@@ -203,9 +204,9 @@ impl AliasState {
 
     pub fn unset_for_object_id(&self, object_id: &str) -> Result<(), AliasError> {
         let conn = self
-            .db
-            .lock()
-            .map_err(|_| AliasError::Storage("db mutex poisoned in unset_for_object_id".into()))?;
+            .store
+            .conn()
+            .map_err(|e| AliasError::Storage(e.to_string()))?;
         conn.execute(
             "DELETE FROM item_aliases WHERE object_id = ?1",
             params![object_id],
@@ -287,9 +288,9 @@ impl AliasState {
         }
         {
             let conn = self
-                .db
-                .lock()
-                .map_err(|_| AliasError::Storage("db mutex poisoned in prune_orphans".into()))?;
+                .store
+                .conn()
+                .map_err(|e| AliasError::Storage(e.to_string()))?;
             for id in &to_remove {
                 conn.execute("DELETE FROM item_aliases WHERE object_id = ?1", params![id])
                     .map_err(|e| AliasError::Storage(e.to_string()))?;
@@ -321,9 +322,10 @@ impl AliasState {
             return Ok(0);
         }
         {
-            let conn = self.db.lock().map_err(|_| {
-                AliasError::Storage("db mutex poisoned in clear_for_extension".into())
-            })?;
+            let conn = self
+                .store
+                .conn()
+                .map_err(|e| AliasError::Storage(e.to_string()))?;
             for id in &to_remove {
                 conn.execute("DELETE FROM item_aliases WHERE object_id = ?1", params![id])
                     .map_err(|e| AliasError::Storage(e.to_string()))?;
@@ -345,15 +347,15 @@ mod state_tests {
 
     #[test]
     fn new_in_memory_starts_empty() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         let items = state.items.read().unwrap();
         assert!(items.is_empty());
     }
 
     #[test]
     fn schema_creates_table() {
-        let state = AliasState::new_in_memory();
-        let conn = state.db.lock().unwrap();
+        let state = AliasState::new_for_test();
+        let conn = state.store.conn().unwrap();
         let count: i64 = conn
             .query_row(
                 "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='item_aliases'",
@@ -366,8 +368,8 @@ mod state_tests {
 
     #[test]
     fn schema_enforces_alias_uniqueness() {
-        let state = AliasState::new_in_memory();
-        let conn = state.db.lock().unwrap();
+        let state = AliasState::new_for_test();
+        let conn = state.store.conn().unwrap();
         conn.execute(
             "INSERT INTO item_aliases (object_id, alias, item_name, item_type, created_at) VALUES ('id1','a','Name','application',0)",
             [],
@@ -391,7 +393,7 @@ mod state_tests {
 
     #[test]
     fn set_alias_persists_and_caches() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state
             .set_alias("app_finder", "f", "Finder", "application", now_ms())
             .unwrap();
@@ -400,7 +402,7 @@ mod state_tests {
         assert_eq!(items[0].object_id, "app_finder");
         assert_eq!(items[0].alias, "f");
         // verify in DB too
-        let conn = state.db.lock().unwrap();
+        let conn = state.store.conn().unwrap();
         let alias: String = conn
             .query_row(
                 "SELECT alias FROM item_aliases WHERE object_id = ?1",
@@ -413,7 +415,7 @@ mod state_tests {
 
     #[test]
     fn set_alias_replaces_existing_for_same_object_id() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state
             .set_alias("app_finder", "f", "Finder", "application", now_ms())
             .unwrap();
@@ -424,7 +426,7 @@ mod state_tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].alias, "fi");
         // Confirm UPSERT replaced rather than duplicated in the DB.
-        let conn = state.db.lock().unwrap();
+        let conn = state.store.conn().unwrap();
         let count: i64 = conn
             .query_row(
                 "SELECT count(*) FROM item_aliases WHERE object_id = 'app_finder'",
@@ -445,7 +447,7 @@ mod state_tests {
 
     #[test]
     fn set_alias_validates_input() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         let err = state
             .set_alias("app_x", "no spaces", "X", "application", now_ms())
             .unwrap_err();
@@ -454,7 +456,7 @@ mod state_tests {
 
     #[test]
     fn set_alias_rejects_conflict() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state
             .set_alias("app_finder", "f", "Finder", "application", now_ms())
             .unwrap();
@@ -466,14 +468,14 @@ mod state_tests {
 
     #[test]
     fn unset_alias_removes_from_cache_and_db() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state
             .set_alias("app_finder", "f", "Finder", "application", now_ms())
             .unwrap();
         state.unset_alias("f").unwrap();
         let items = state.items.read().unwrap();
         assert!(items.is_empty());
-        let conn = state.db.lock().unwrap();
+        let conn = state.store.conn().unwrap();
         let count: i64 = conn
             .query_row("SELECT count(*) FROM item_aliases", [], |r| r.get(0))
             .unwrap();
@@ -482,14 +484,14 @@ mod state_tests {
 
     #[test]
     fn unset_alias_returns_not_found_for_missing() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         let err = state.unset_alias("nope").unwrap_err();
         assert!(matches!(err, AliasError::NotFound(_)));
     }
 
     #[test]
     fn unset_for_object_id_removes_when_present() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state
             .set_alias("app_finder", "f", "Finder", "application", now_ms())
             .unwrap();
@@ -499,11 +501,11 @@ mod state_tests {
 
     #[test]
     fn unset_for_object_id_is_noop_when_absent() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state.unset_for_object_id("app_missing").unwrap();
         // Cache and DB both stay empty.
         assert!(state.items.read().unwrap().is_empty());
-        let conn = state.db.lock().unwrap();
+        let conn = state.store.conn().unwrap();
         let count: i64 = conn
             .query_row("SELECT count(*) FROM item_aliases", [], |r| r.get(0))
             .unwrap();
@@ -516,9 +518,9 @@ mod state_tests {
         // before calling set_alias. The cache check passes (cache is empty),
         // but the DB UNIQUE constraint fires and is_unique_alias_violation
         // re-classifies the rusqlite error as AliasError::Conflict.
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         {
-            let conn = state.db.lock().unwrap();
+            let conn = state.store.conn().unwrap();
             conn.execute(
                 "INSERT INTO item_aliases (object_id, alias, item_name, item_type, created_at)
                  VALUES ('app_smuggled', 'cl', 'Smuggled', 'application', 0)",
@@ -544,7 +546,7 @@ mod state_tests {
 
     #[test]
     fn find_by_alias_returns_match() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state
             .set_alias(
                 "cmd_clip_history",
@@ -561,7 +563,7 @@ mod state_tests {
 
     #[test]
     fn find_by_alias_lowercases_input() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state
             .set_alias(
                 "cmd_clip_history",
@@ -577,14 +579,14 @@ mod state_tests {
 
     #[test]
     fn find_by_alias_returns_none_for_unknown() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         let hit = state.find_by_alias("ghost").unwrap();
         assert!(hit.is_none());
     }
 
     #[test]
     fn find_conflict_excludes_self() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state
             .set_alias("cmd_x", "x", "X", "command", now_ms())
             .unwrap();
@@ -595,7 +597,7 @@ mod state_tests {
 
     #[test]
     fn find_conflict_finds_other_owner() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state
             .set_alias("cmd_x", "x", "X", "command", now_ms())
             .unwrap();
@@ -608,7 +610,7 @@ mod state_tests {
     fn find_conflict_with_no_exclusion_finds_any_owner() {
         // None means "exclude nobody" — any matching alias is reported.
         // Guards against a future refactor that flips the != to == in the predicate.
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state
             .set_alias("cmd_x", "x", "X", "command", now_ms())
             .unwrap();
@@ -618,7 +620,7 @@ mod state_tests {
 
     #[test]
     fn list_all_returns_sorted_by_created_at_descending() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state.set_alias("a", "a", "A", "application", 100).unwrap();
         state.set_alias("b", "b", "B", "application", 200).unwrap();
         state.set_alias("c", "c", "C", "application", 50).unwrap();
@@ -629,7 +631,7 @@ mod state_tests {
 
     #[test]
     fn lookup_alias_for_returns_alias_or_none() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state
             .set_alias("cmd_x", "xx", "X", "command", now_ms())
             .unwrap();
@@ -642,7 +644,7 @@ mod state_tests {
 
     #[test]
     fn prune_orphans_drops_aliases_for_unknown_ids() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state
             .set_alias("app_finder", "f", "Finder", "application", now_ms())
             .unwrap();
@@ -663,7 +665,7 @@ mod state_tests {
         assert_eq!(items[0].object_id, "app_finder");
         // Verify the DELETE path actually fired against the DB, not just the cache.
         drop(items);
-        let conn = state.db.lock().unwrap();
+        let conn = state.store.conn().unwrap();
         let db_count: i64 = conn
             .query_row("SELECT count(*) FROM item_aliases", [], |r| r.get(0))
             .unwrap();
@@ -676,7 +678,7 @@ mod state_tests {
 
     #[test]
     fn prune_orphans_returns_zero_when_all_live() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state
             .set_alias("app_finder", "f", "Finder", "application", now_ms())
             .unwrap();
@@ -687,7 +689,7 @@ mod state_tests {
 
     #[test]
     fn clear_for_extension_removes_only_that_extensions_aliases() {
-        let state = AliasState::new_in_memory();
+        let state = AliasState::new_for_test();
         state
             .set_alias(
                 "cmd_pomodoro_start",
@@ -722,7 +724,7 @@ mod state_tests {
         assert_eq!(items[0].object_id, "cmd_clip_history");
         // DB also reflects the removal.
         drop(items);
-        let conn = state.db.lock().unwrap();
+        let conn = state.store.conn().unwrap();
         let db_count: i64 = conn
             .query_row("SELECT count(*) FROM item_aliases", [], |r| r.get(0))
             .unwrap();

--- a/asyar-launcher/src-tauri/src/commands/extension_state.rs
+++ b/asyar-launcher/src-tauri/src/commands/extension_state.rs
@@ -330,14 +330,10 @@ mod tests {
     use super::*;
     use crate::extensions::extension_runtime::{emitter::RecordingEmitter, RuntimeConfig};
     use crate::extensions::extension_state::RecordingStateEmitter;
-    use crate::storage::extension_state as store;
-    use rusqlite::Connection;
-    use std::sync::Mutex;
-
     fn fresh_svc_with_emitter() -> (Arc<ExtensionStateService>, Arc<RecordingStateEmitter>) {
-        let conn = Connection::open_in_memory().unwrap();
-        store::init_table(&conn).unwrap();
-        let svc = Arc::new(ExtensionStateService::new(Arc::new(Mutex::new(conn))));
+        let svc = Arc::new(ExtensionStateService::new(
+            crate::storage::create_test_store(),
+        ));
         let emitter: Arc<RecordingStateEmitter> = Arc::new(RecordingStateEmitter::default());
         svc.set_emitter(Box::new(Arc::clone(&emitter)));
         (svc, emitter)

--- a/asyar-launcher/src-tauri/src/commands/timers.rs
+++ b/asyar-launcher/src-tauri/src/commands/timers.rs
@@ -114,7 +114,7 @@ mod tests {
 
     #[test]
     fn schedule_without_permission_rejected() {
-        let r = TimerRegistry::in_memory();
+        let r = TimerRegistry::for_test();
         let p = grant("ext-a", &[]);
         let err = timer_schedule_inner(
             &r,
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn schedule_without_extension_id_rejected() {
-        let r = TimerRegistry::in_memory();
+        let r = TimerRegistry::for_test();
         let p = grant("ext-a", &[PERM_SCHEDULE]);
         // Core caller (None) is allowed by perms check but rejected with
         // Validation because there's no iframe to dispatch into.
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn schedule_with_permission_persists_row_and_returns_uuid() {
-        let r = TimerRegistry::in_memory();
+        let r = TimerRegistry::for_test();
         let p = grant("ext-a", &[PERM_SCHEDULE, PERM_LIST]);
         let id = timer_schedule_inner(
             &r,
@@ -162,7 +162,7 @@ mod tests {
 
     #[test]
     fn cancel_without_permission_rejected() {
-        let r = TimerRegistry::in_memory();
+        let r = TimerRegistry::for_test();
         let p = grant("ext-a", &[PERM_SCHEDULE]);
         let id = timer_schedule_inner(
             &r,
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn cancel_of_own_timer_succeeds() {
-        let r = TimerRegistry::in_memory();
+        let r = TimerRegistry::for_test();
         let p = grant("ext-a", &[PERM_SCHEDULE, PERM_CANCEL, PERM_LIST]);
         let id = timer_schedule_inner(
             &r,
@@ -202,7 +202,7 @@ mod tests {
 
     #[test]
     fn list_without_permission_rejected() {
-        let r = TimerRegistry::in_memory();
+        let r = TimerRegistry::for_test();
         let p = grant("ext-a", &[]);
         let err = timer_list_inner(&r, &p, Some("ext-a".into())).unwrap_err();
         assert!(matches!(err, AppError::Permission(_)), "got: {err:?}");
@@ -210,7 +210,7 @@ mod tests {
 
     #[test]
     fn list_returns_only_callers_pending_timers() {
-        let r = TimerRegistry::in_memory();
+        let r = TimerRegistry::for_test();
         let p_a = grant("ext-a", &[PERM_SCHEDULE, PERM_LIST]);
         let p_b = grant("ext-b", &[PERM_SCHEDULE, PERM_LIST]);
         let _ = timer_schedule_inner(

--- a/asyar-launcher/src-tauri/src/extensions/extension_state/mod.rs
+++ b/asyar-launcher/src-tauri/src/extensions/extension_state/mod.rs
@@ -15,7 +15,7 @@
 use crate::error::AppError;
 use crate::extensions::extension_runtime::types::ContextRole;
 use crate::storage::extension_state as store;
-use rusqlite::Connection;
+use crate::storage::DataStore;
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
@@ -99,14 +99,16 @@ pub trait StateEventEmitter: Send + Sync {
 }
 
 pub struct ExtensionStateService {
-    data_store: Arc<Mutex<Connection>>,
+    /// The pool handle. The service is app-lifetime state, so it holds the
+    /// store and checks out a connection per operation rather than owning one.
+    data_store: DataStore,
     subscriptions: Mutex<HashMap<SubscriptionId, Subscription>>,
     next_id: AtomicU64,
     emitter: Mutex<Option<Box<dyn StateEventEmitter>>>,
 }
 
 impl ExtensionStateService {
-    pub fn new(data_store: Arc<Mutex<Connection>>) -> Self {
+    pub fn new(data_store: DataStore) -> Self {
         Self {
             data_store,
             subscriptions: Mutex::new(HashMap::new()),
@@ -123,7 +125,7 @@ impl ExtensionStateService {
     }
 
     pub fn get(&self, extension_id: &str, key: &str) -> Result<Option<Value>, AppError> {
-        let conn = self.data_store.lock().map_err(|_| AppError::Lock)?;
+        let conn = self.data_store.conn()?;
         store::get(&conn, extension_id, key)
     }
 
@@ -140,7 +142,7 @@ impl ExtensionStateService {
         now_ms: u64,
     ) -> Result<(), AppError> {
         {
-            let conn = self.data_store.lock().map_err(|_| AppError::Lock)?;
+            let conn = self.data_store.conn()?;
             store::set(&conn, extension_id, key, &value, now_ms)?;
         }
 
@@ -206,7 +208,7 @@ impl ExtensionStateService {
     /// code paths never enumerate keys, they read one at a time. Returns
     /// rows in arbitrary order; callers sort as needed.
     pub fn list_all(&self, extension_id: &str) -> Result<Vec<StateEntry>, AppError> {
-        let conn = self.data_store.lock().map_err(|_| AppError::Lock)?;
+        let conn = self.data_store.conn()?;
         store::get_all(&conn, extension_id)
     }
 
@@ -262,7 +264,7 @@ impl ExtensionStateService {
     /// down both context machines.
     pub fn clear(&self, extension_id: &str) -> Result<u64, AppError> {
         let row_count = {
-            let conn = self.data_store.lock().map_err(|_| AppError::Lock)?;
+            let conn = self.data_store.conn()?;
             store::clear(&conn, extension_id)?
         };
         let mut subs = self
@@ -347,17 +349,10 @@ impl<T: StateEventEmitter + ?Sized> StateEventEmitter for Arc<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::extension_state as store;
-    use rusqlite::Connection;
-
-    fn fresh_conn() -> Arc<Mutex<Connection>> {
-        let conn = Connection::open_in_memory().unwrap();
-        store::init_table(&conn).unwrap();
-        Arc::new(Mutex::new(conn))
-    }
+    use crate::storage::create_test_store;
 
     fn svc_with_emitter() -> (ExtensionStateService, Arc<RecordingStateEmitter>) {
-        let svc = ExtensionStateService::new(fresh_conn());
+        let svc = ExtensionStateService::new(create_test_store());
         let emitter: Arc<RecordingStateEmitter> = Arc::new(RecordingStateEmitter::default());
         svc.set_emitter(Box::new(Arc::clone(&emitter)));
         (svc, emitter)
@@ -384,16 +379,16 @@ mod tests {
 
     #[test]
     fn set_persists_across_service_restart() {
-        // Mirrors "running the launcher twice" — the underlying SQLite
-        // connection is shared, the service instance is recreated.
-        let conn = fresh_conn();
-        let svc1 = ExtensionStateService::new(Arc::clone(&conn));
+        // Mirrors "running the launcher twice" — the underlying database is
+        // shared, the service instance is recreated.
+        let store = create_test_store();
+        let svc1 = ExtensionStateService::new(store.clone());
         svc1.set("ext.a", "timer", serde_json::json!({ "running": true }), 0)
             .unwrap();
 
         // Drop & recreate the service against the same DB.
         drop(svc1);
-        let svc2 = ExtensionStateService::new(Arc::clone(&conn));
+        let svc2 = ExtensionStateService::new(store.clone());
         assert_eq!(
             svc2.get("ext.a", "timer").unwrap(),
             Some(serde_json::json!({ "running": true })),

--- a/asyar-launcher/src-tauri/src/extensions/lifecycle.rs
+++ b/asyar-launcher/src-tauri/src/extensions/lifecycle.rs
@@ -833,7 +833,7 @@ mod tests {
     }
 
     fn seeded_timer_registry() -> crate::timers::TimerRegistry {
-        let reg = crate::timers::TimerRegistry::in_memory();
+        let reg = crate::timers::TimerRegistry::for_test();
         // alpha has two pending + one fired; beta has one pending — verify
         // nothing of beta's survives-or-disappears accidentally.
         let a1 = reg.schedule("alpha", "bell", "{}", 2_000, 1_000).unwrap();

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -1383,19 +1383,18 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         let _ = storage::extension_cache::prune_all_expired(&conn);
     }
 
-    // One-shot timer registry — shares the DataStore connection via
-    // `conn_arc()`. Must be built before the backlog scan and the live
-    // scheduler so both can see the same rows.
-    let timer_registry = timers::TimerRegistry::new(data_store.conn_arc());
+    // One-shot timer registry — shares the DataStore. Must be built before
+    // the backlog scan and the live scheduler so both can see the same rows.
+    let timer_registry = timers::TimerRegistry::new(data_store.clone());
 
     // Launcher-brokered extension state store + RPC primitive.
-    // Shares the DataStore SQLite connection via `conn_arc()` so writes
-    // land in the same `asyar_data.db` file as every other launcher table.
+    // Shares the DataStore so writes land in the same `asyar_data.db` file
+    // as every other launcher table.
     // The Tauri-backed emitter is installed immediately so the first
     // `state:set` of the boot can fan out cleanly. Logs the database file
     // path so the boot log evidences the SQLite location.
     let extension_state_service = std::sync::Arc::new(
-        crate::extensions::extension_state::ExtensionStateService::new(data_store.conn_arc()),
+        crate::extensions::extension_state::ExtensionStateService::new(data_store.clone()),
     );
     extension_state_service.set_emitter(Box::new(
         crate::extensions::extension_state::TauriStateEmitter {
@@ -1467,15 +1466,19 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         );
         app.manage(fts.clone());
 
-        let conn_arc = app.state::<storage::DataStore>().conn_arc();
+        let store = app.state::<storage::DataStore>().inner().clone();
         let master_key: [u8; 32] = *app
             .state::<crate::crypto::keystore::KeystoreState>()
             .master_key();
         let app_handle = app.handle().clone();
         let fts_for_task = fts.clone();
         tauri::async_runtime::spawn(async move {
+            // The connection is checked out inside `spawn_blocking` and dropped
+            // with it — this scan reads and decrypts every row, and holding a
+            // pooled connection across an await would keep it out of circulation
+            // for the whole rebuild.
             let result = tokio::task::spawn_blocking(move || {
-                let conn = match conn_arc.lock() {
+                let conn = match store.conn() {
                     Ok(c) => c,
                     Err(_) => return false,
                 };
@@ -1503,15 +1506,17 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         );
         app.manage(fts.clone());
 
-        let conn_arc = app.state::<storage::DataStore>().conn_arc();
+        let store = app.state::<storage::DataStore>().inner().clone();
         let master_key: [u8; 32] = *app
             .state::<crate::crypto::keystore::KeystoreState>()
             .master_key();
         let app_handle = app.handle().clone();
         let fts_for_task = fts.clone();
         tauri::async_runtime::spawn(async move {
+            // Same rule as the clipboard rebuild above: the pooled connection
+            // is acquired and released entirely inside `spawn_blocking`.
             let result = tokio::task::spawn_blocking(move || {
-                let conn = match conn_arc.lock() {
+                let conn = match store.conn() {
                     Ok(c) => c,
                     Err(_) => return false,
                 };
@@ -1593,13 +1598,13 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         )));
     }
 
-    // Alias storage shares the DataStore SQLite connection. The schema is
-    // initialized inside DataStore::initialize via aliases::init_table; here
-    // we build the in-memory cache and prune any orphan rows whose owning
-    // search-index item disappeared while the launcher was off.
+    // Alias storage shares the DataStore. The schema is initialized inside
+    // DataStore::initialize via aliases::init_table; here we build the
+    // in-memory cache and prune any orphan rows whose owning search-index
+    // item disappeared while the launcher was off.
     {
         let alias_state =
-            aliases::AliasState::new_with_db(app.state::<storage::DataStore>().conn_arc())
+            aliases::AliasState::new_with_db(app.state::<storage::DataStore>().inner().clone())
                 .expect("init alias state");
         if let Some(search_state) = app.try_state::<std::sync::Arc<search_engine::SearchState>>() {
             if let Ok(live_ids) = search_state.all_ids() {

--- a/asyar-launcher/src-tauri/src/search_engine/commands.rs
+++ b/asyar-launcher/src-tauri/src/search_engine/commands.rs
@@ -560,7 +560,7 @@ mod tests {
         state
             .index_one(make_cmd("cmd_pomodoro_start", "Start", 0))
             .unwrap();
-        let alias_state = crate::aliases::AliasState::new_in_memory();
+        let alias_state = crate::aliases::AliasState::new_for_test();
         alias_state
             .set_alias("cmd_pomodoro_start", "ps", "Start", "command", 1)
             .unwrap();

--- a/asyar-launcher/src-tauri/src/search_engine/mod.rs
+++ b/asyar-launcher/src-tauri/src/search_engine/mod.rs
@@ -1517,7 +1517,7 @@ mod service_tests {
             is_dynamic: false,
         });
         let search_state = fresh_search_state_with(vec![cmd]);
-        let alias_state = AliasState::new_in_memory();
+        let alias_state = AliasState::new_for_test();
         alias_state
             .set_alias("cmd_clip_history", "cl", "Clipboard History", "command", 1)
             .unwrap();
@@ -1544,7 +1544,7 @@ mod service_tests {
             bundle_id: None,
         });
         let search_state = fresh_search_state_with(vec![app]);
-        let alias_state = AliasState::new_in_memory();
+        let alias_state = AliasState::new_for_test();
         alias_state
             .set_alias("app_finder", "f", "Finder", "application", 1)
             .unwrap();
@@ -1560,7 +1560,7 @@ mod service_tests {
     #[test]
     fn merged_search_no_alias_match_when_query_has_no_alias() {
         let search_state = fresh_search_state_with(vec![]);
-        let alias_state = AliasState::new_in_memory();
+        let alias_state = AliasState::new_for_test();
         let resp = search_state
             .merged_search_with_aliases("nothing", vec![], 10, &alias_state, &[])
             .unwrap();
@@ -1579,7 +1579,7 @@ mod service_tests {
             bundle_id: None,
         });
         let search_state = fresh_search_state_with(vec![app]);
-        let alias_state = AliasState::new_in_memory();
+        let alias_state = AliasState::new_for_test();
         alias_state
             .set_alias("app_finder", "f", "Finder", "application", 1)
             .unwrap();
@@ -1907,7 +1907,7 @@ mod service_tests {
             is_dynamic: false,
         });
         let search_state = fresh_search_state_with(vec![other, clip_cmd]);
-        let alias_state = AliasState::new_in_memory();
+        let alias_state = AliasState::new_for_test();
         alias_state
             .set_alias("cmd_clip_history", "cl", "Clipboard History", "command", 1)
             .unwrap();
@@ -1925,7 +1925,7 @@ mod service_tests {
     #[test]
     fn merged_search_with_aliases_pin_is_noop_when_match_object_missing() {
         let search_state = fresh_search_state_with(vec![]);
-        let alias_state = AliasState::new_in_memory();
+        let alias_state = AliasState::new_for_test();
         // Orphaned alias — its object_id isn't indexed. Pin step must not
         // panic when the find-by-id comes up empty.
         alias_state

--- a/asyar-launcher/src-tauri/src/storage/mod.rs
+++ b/asyar-launcher/src-tauri/src/storage/mod.rs
@@ -28,18 +28,68 @@ pub mod sticky_notes;
 pub mod timers;
 
 use crate::error::AppError;
+use r2d2::{CustomizeConnection, Pool};
+use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::Connection;
-use std::sync::{Arc, Mutex};
+use std::path::Path;
 
 const DB_FILE_NAME: &str = "asyar_data.db";
+
+/// How long a writer waits for the write lock before giving up with
+/// `SQLITE_BUSY`. Set explicitly rather than left to rusqlite's own 5s
+/// default: the longest write in the app is the startup rebuild's
+/// `content_hash` backfill, which updates every legacy clipboard row inside
+/// one transaction, and on a large history that can outlast five seconds
+/// while the rest of the app is already live and writing.
+const BUSY_TIMEOUT_MS: i64 = 15_000;
+
+/// Applied to every physical connection the pool opens, before it is ever
+/// handed out. `journal_mode` is a property of the database file, but
+/// `busy_timeout` is per-connection state and has to be set on each one —
+/// which is exactly why it lives here and not in a one-time setup step.
+fn connection_pragmas() -> String {
+    format!("PRAGMA journal_mode=WAL; PRAGMA busy_timeout={BUSY_TIMEOUT_MS};")
+}
+
+/// Cap on simultaneously open connections. SQLite still admits exactly one
+/// writer, so extra connections only buy reader concurrency: eight covers the
+/// two full-table FTS rebuilds at boot plus ordinary UI and extension traffic,
+/// while a launcher that idles most of its life has no use for a web-server-
+/// sized pool.
+const POOL_SIZE: u32 = 8;
 
 /// Shared SQLite-backed data store for user data (clipboard, snippets, shortcuts).
 ///
 /// Each table supports row-level CRUD — individual inserts, updates, and deletes
 /// instead of full-table rewrites.
+///
+/// Backed by a connection pool, so WAL's concurrent readers are actually
+/// concurrent. Two rules come with that:
+///
+/// * **One connection per transaction.** A transaction lives on the connection
+///   that began it; never split one across two [`conn`](Self::conn) calls.
+/// * **Never hold a connection across `.await`.** Checked-out connections are
+///   a bounded resource; blocking database work belongs in `spawn_blocking`.
 #[derive(Clone)]
 pub struct DataStore {
-    db: Arc<Mutex<Connection>>,
+    pool: Pool<SqliteConnectionManager>,
+    /// Test stores live in a temporary directory (see [`create_test_store`]);
+    /// this keeps it alive for as long as any clone of the store.
+    #[cfg(test)]
+    _tempdir: Option<std::sync::Arc<tempfile::TempDir>>,
+}
+
+/// r2d2 hook that stamps [`connection_pragmas`] onto each connection as it is
+/// opened, so no connection can reach a caller unconfigured.
+#[derive(Debug)]
+struct PragmaCustomizer {
+    pragmas: String,
+}
+
+impl CustomizeConnection<Connection, rusqlite::Error> for PragmaCustomizer {
+    fn on_acquire(&self, conn: &mut Connection) -> Result<(), rusqlite::Error> {
+        conn.execute_batch(&self.pragmas)
+    }
 }
 
 impl DataStore {
@@ -52,82 +102,319 @@ impl DataStore {
 
         std::fs::create_dir_all(&app_data_dir)?;
 
-        let db_path = app_data_dir.join(DB_FILE_NAME);
-        let conn = Connection::open(&db_path)?;
+        Ok(Self::open_at(&app_data_dir.join(DB_FILE_NAME))?)
+    }
 
-        // WAL mode for better concurrent read performance
-        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+    /// Open (or create) the database at `db_path` and return a store serving it.
+    fn open_at(db_path: &Path) -> Result<Self, AppError> {
+        Self::open_with_pragmas(db_path, connection_pragmas())
+    }
 
-        migrations::run(&conn)?;
+    fn open_with_pragmas(db_path: &Path, pragmas: String) -> Result<Self, AppError> {
+        let manager = SqliteConnectionManager::file(db_path);
+        let pool = Pool::builder()
+            .max_size(POOL_SIZE)
+            // Open one connection up front and grow on demand — the alternative
+            // (r2d2's default `min_idle = max_size`) makes `build` wait for all
+            // eight before the app can boot.
+            .min_idle(Some(1))
+            // A local file handle never goes stale the way a socket does, so
+            // recycling connections would be pure churn — and switching both off
+            // means r2d2 skips its reaper thread entirely.
+            .max_lifetime(None)
+            .idle_timeout(None)
+            .connection_customizer(Box::new(PragmaCustomizer { pragmas }))
+            .build(manager)
+            .map_err(|e| AppError::Database(format!("failed to build the SQLite pool: {e}")))?;
+
+        // Migrate on a single connection while the pool is still private to this
+        // function: nothing else can hold a handle to it yet, so two connections
+        // cannot race to apply the ledger.
+        {
+            let conn = pool.get().map_err(|e| {
+                AppError::Database(format!("failed to open the migration connection: {e}"))
+            })?;
+            migrations::run(&conn)?;
+        }
 
         Ok(Self {
-            db: Arc::new(Mutex::new(conn)),
+            pool,
+            #[cfg(test)]
+            _tempdir: None,
         })
     }
 
-    #[cfg(test)]
-    pub fn from_conn(conn: Connection) -> Self {
-        Self {
-            db: Arc::new(Mutex::new(conn)),
-        }
-    }
-
-    pub fn conn(&self) -> Result<std::sync::MutexGuard<'_, Connection>, AppError> {
-        self.db.lock().map_err(|_| AppError::Lock)
-    }
-
-    /// Return a clone of the `Arc` guarding the underlying SQLite `Connection`.
-    /// Used by subsystems (like the timer scheduler) that need a cloneable
-    /// handle they can move into a spawned tokio task while still sharing the
-    /// same physical connection as the rest of the DataStore-backed features.
-    pub fn conn_arc(&self) -> Arc<Mutex<Connection>> {
-        Arc::clone(&self.db)
+    /// Check out a connection from the pool. Callers get a handle that derefs
+    /// to [`Connection`]; drop it as soon as the work is done.
+    pub fn conn(&self) -> Result<r2d2::PooledConnection<SqliteConnectionManager>, AppError> {
+        self.pool
+            .get()
+            .map_err(|e| AppError::Database(format!("no SQLite connection available: {e}")))
     }
 }
 
 #[cfg(test)]
 mod agents_test;
 
+/// A throwaway store backed by a real file in a temporary directory.
+///
+/// A file, not `:memory:`, on purpose: each connection to `:memory:` is its own
+/// separate empty database, so a pooled in-memory store would hand out
+/// connections that cannot see each other's schema or rows.
 #[cfg(test)]
 pub fn create_test_store() -> DataStore {
-    let conn = Connection::open_in_memory().expect("Failed to open in-memory DB");
-    conn.execute_batch("PRAGMA journal_mode=WAL;").unwrap();
-    migrations::run(&conn).expect("migration ledger failed on test store");
-    DataStore {
-        db: std::sync::Arc::new(Mutex::new(conn)),
-    }
+    create_test_store_with_pragmas(connection_pragmas())
+}
+
+/// As [`create_test_store`], with foreign-key enforcement switched on.
+///
+/// Production deliberately leaves `foreign_keys` at SQLite's OFF default; a few
+/// agent tests predate the pool and assert cascade behaviour, so they get it
+/// explicitly rather than having it turned on globally.
+#[cfg(test)]
+pub fn create_test_store_with_foreign_keys() -> DataStore {
+    create_test_store_with_pragmas(format!("{} PRAGMA foreign_keys=ON;", connection_pragmas()))
+}
+
+#[cfg(test)]
+fn create_test_store_with_pragmas(pragmas: String) -> DataStore {
+    let dir = tempfile::tempdir().expect("temp dir for the test store");
+    let mut store = DataStore::open_with_pragmas(&dir.path().join(DB_FILE_NAME), pragmas)
+        .expect("test store must open");
+    store._tempdir = Some(std::sync::Arc::new(dir));
+    store
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::mpsc::{self, RecvTimeoutError};
+    use std::time::Duration;
 
-    #[test]
-    fn conn_arc_shares_underlying_data_with_conn() {
-        let store = create_test_store();
-        {
-            let arc = store.conn_arc();
-            let guard = arc.lock().unwrap();
-            guard
-                .execute_batch("CREATE TABLE timer_arc_probe (id INTEGER);")
-                .unwrap();
+    /// Run `f` on a worker thread and fail the test if it has not finished in
+    /// ten seconds. Every concurrency test below needs this: the failure mode
+    /// under a single shared connection is *blocking forever*, not returning a
+    /// wrong answer, and a hung `cargo test` is not a test result.
+    fn run_with_timeout<T: Send + 'static>(
+        label: &str,
+        f: impl FnOnce() -> T + Send + 'static,
+    ) -> T {
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(f());
+        });
+        match rx.recv_timeout(Duration::from_secs(10)) {
+            Ok(value) => value,
+            Err(RecvTimeoutError::Timeout) => panic!(
+                "{label}: still blocked after 10s — a second connection cannot be \
+                 obtained while the first is alive"
+            ),
+            Err(RecvTimeoutError::Disconnected) => {
+                panic!("{label}: worker thread panicked (see the panic printed above)")
+            }
         }
-        let conn = store.conn().unwrap();
-        let count: i32 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM sqlite_master WHERE name='timer_arc_probe'",
-                [],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(count, 1);
     }
 
+    fn insert_snippet(conn: &Connection, id: &str, name: &str) {
+        conn.execute(
+            "INSERT INTO snippets (id, keyword, expansion, name, created_at, pinned)
+             VALUES (?1, ?2, ?3, ?4, ?5, 0)",
+            rusqlite::params![id, ":probe", "ciphertext", name, 1.0_f64],
+        )
+        .expect("insert snippet");
+    }
+
+    /// The whole point of the change: WAL exists so readers run concurrently,
+    /// and a single global mutex made that impossible. Two connections must be
+    /// checked out at the same time and both be usable.
     #[test]
-    fn conn_arc_hands_out_handles_to_same_mutex() {
+    fn two_connections_are_usable_at_the_same_time() {
         let store = create_test_store();
-        let a = store.conn_arc();
-        let b = store.conn_arc();
-        assert!(std::sync::Arc::ptr_eq(&a, &b));
+
+        run_with_timeout("two simultaneous connections", move || {
+            let first = store.conn().expect("first connection");
+            let second = store
+                .conn()
+                .expect("second connection while first is alive");
+
+            first
+                .execute_batch("CREATE TABLE pool_probe (id INTEGER);")
+                .expect("write on the first connection");
+            let seen: i64 = second
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE name = 'pool_probe'",
+                    [],
+                    |r| r.get(0),
+                )
+                .expect("read on the second connection");
+
+            assert_eq!(seen, 1, "both connections must address the same database");
+        });
+    }
+
+    /// Guard against backing the store with `:memory:`: every connection to
+    /// `:memory:` is its own empty database, so a pooled store built that way
+    /// would hand the reader a schema-less connection and this read would fail
+    /// with "no such table: snippets".
+    #[test]
+    fn a_row_written_on_one_connection_is_visible_on_another() {
+        let store = create_test_store();
+
+        run_with_timeout("write on one connection, read on another", move || {
+            let writer = store.conn().expect("writer connection");
+            insert_snippet(&writer, "pool-probe", "Probe");
+
+            // Deliberately still holding `writer` — the reader must not have to
+            // wait for it to be released.
+            let reader = store.conn().expect("reader connection");
+            let name: String = reader
+                .query_row(
+                    "SELECT name FROM snippets WHERE id = 'pool-probe'",
+                    [],
+                    |r| r.get(0),
+                )
+                .expect("committed row must be visible on a second connection");
+
+            assert_eq!(name, "Probe");
+        });
+    }
+
+    /// SQLite allows one writer at a time. Once writers sit on separate
+    /// connections they collide inside SQLite instead of queueing on a Rust
+    /// mutex, and the loser gets `SQLITE_BUSY` immediately unless a busy
+    /// timeout is configured on every connection.
+    ///
+    /// Made deterministic rather than racy: the holder takes the write lock
+    /// with `BEGIN IMMEDIATE`, the contender starts its insert only after that,
+    /// and the holder commits well inside the busy timeout.
+    #[test]
+    fn a_writer_waits_out_a_held_write_lock_instead_of_failing_busy() {
+        let store = create_test_store();
+        let contender_store = store.clone();
+
+        run_with_timeout("two concurrent writers", move || {
+            let holder = store.conn().expect("holder connection");
+            holder
+                .execute_batch("BEGIN IMMEDIATE")
+                .expect("take the write lock");
+            insert_snippet(&holder, "held", "Held");
+
+            let (lock_taken_tx, lock_taken_rx) = mpsc::channel::<()>();
+            let contender = std::thread::spawn(move || {
+                lock_taken_rx.recv().expect("holder signalled");
+                let conn = contender_store.conn().expect("contender connection");
+                conn.execute(
+                    "INSERT INTO snippets (id, keyword, expansion, name, created_at, pinned)
+                     VALUES ('contended', ':probe', 'ciphertext', 'Contended', 2.0, 0)",
+                    [],
+                )
+            });
+
+            lock_taken_tx.send(()).expect("signal the contender");
+            std::thread::sleep(Duration::from_millis(250));
+            holder
+                .execute_batch("COMMIT")
+                .expect("release the write lock");
+
+            let result = contender.join().expect("contender thread");
+            assert!(
+                result.is_ok(),
+                "the second writer must wait for the lock, not fail: {:?}",
+                result.unwrap_err()
+            );
+
+            let ids: Vec<String> = {
+                let mut stmt = holder
+                    .prepare("SELECT id FROM snippets ORDER BY id")
+                    .unwrap();
+                let rows = stmt.query_map([], |r| r.get(0)).unwrap();
+                rows.map(Result::unwrap).collect()
+            };
+            assert_eq!(ids, vec!["contended".to_string(), "held".to_string()]);
+        });
+    }
+
+    /// The ledger runs once per store, on one connection, before the pool
+    /// serves anybody — and a second store opened against the same file finds
+    /// nothing left to do and touches no existing row.
+    #[test]
+    fn opening_the_same_file_twice_migrates_once_and_keeps_rows() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join(DB_FILE_NAME);
+        let latest = migrations::MIGRATIONS.last().unwrap().version;
+
+        let first = DataStore::open_at(&db_path).expect("first open");
+        {
+            let conn = first.conn().unwrap();
+            insert_snippet(&conn, "survivor", "Survivor");
+            assert_eq!(user_version(&conn), latest);
+        }
+        drop(first);
+
+        let second = DataStore::open_at(&db_path).expect("second open");
+        let conn = second.conn().unwrap();
+
+        assert_eq!(
+            user_version(&conn),
+            latest,
+            "a second open must leave user_version at the newest ledger entry"
+        );
+        let name: String = conn
+            .query_row("SELECT name FROM snippets WHERE id = 'survivor'", [], |r| {
+                r.get(0)
+            })
+            .expect("rows written before the second open must still be there");
+        assert_eq!(name, "Survivor");
+    }
+
+    /// Every connection the pool can hand out must carry our busy timeout —
+    /// all of them, checked out at once, not just the first one.
+    ///
+    /// Asserted explicitly because rusqlite happens to apply a 5s default of
+    /// its own: without this test the app would be silently relying on an
+    /// upstream default it never chose and would not notice if it changed.
+    #[test]
+    fn every_pooled_connection_carries_the_configured_busy_timeout() {
+        let store = create_test_store();
+
+        run_with_timeout("busy timeout on every connection", move || {
+            let conns: Vec<_> = (0..POOL_SIZE)
+                .map(|_| store.conn().expect("connection"))
+                .collect();
+
+            for (i, conn) in conns.iter().enumerate() {
+                let timeout: i64 = conn
+                    .query_row("PRAGMA busy_timeout", [], |r| r.get(0))
+                    .unwrap();
+                assert_eq!(
+                    timeout, BUSY_TIMEOUT_MS,
+                    "connection {i} was handed out without the configured busy timeout"
+                );
+            }
+        });
+    }
+
+    fn user_version(conn: &Connection) -> u32 {
+        conn.query_row("PRAGMA user_version", [], |r| r.get::<_, i64>(0))
+            .unwrap() as u32
+    }
+
+    /// Clones share one pool — a `DataStore` handed to a subsystem must reach
+    /// the same database as the one the rest of the app holds.
+    #[test]
+    fn clones_of_a_store_share_one_database() {
+        let store = create_test_store();
+        let clone = store.clone();
+
+        insert_snippet(&store.conn().unwrap(), "shared", "Shared");
+
+        let name: String = clone
+            .conn()
+            .unwrap()
+            .query_row("SELECT name FROM snippets WHERE id = 'shared'", [], |r| {
+                r.get(0)
+            })
+            .expect("a clone must see rows written through the original");
+        assert_eq!(name, "Shared");
     }
 }

--- a/asyar-launcher/src-tauri/src/timers/mod.rs
+++ b/asyar-launcher/src-tauri/src/timers/mod.rs
@@ -13,9 +13,9 @@ pub mod scheduler;
 pub mod startup;
 
 use crate::error::AppError;
-use rusqlite::{params, Connection};
+use crate::storage::DataStore;
+use rusqlite::params;
 use serde::{Deserialize, Serialize};
-use std::sync::{Arc, Mutex};
 
 /// Tauri event name used when a timer fires. The TS-side bridge
 /// (`timerBridge.svelte.ts`) listens for this and dispatches the
@@ -45,22 +45,24 @@ pub struct TimerFirePayload {
     pub fired_at: u64,
 }
 
+/// Holds the pool handle, not a connection: a registry outlives the app's
+/// whole run, and a connection checked out for that long would be a
+/// connection nobody else can use.
 #[derive(Clone)]
 pub struct TimerRegistry {
-    conn: Arc<Mutex<Connection>>,
+    store: DataStore,
 }
 
 impl TimerRegistry {
-    pub fn new(conn: Arc<Mutex<Connection>>) -> Self {
-        Self { conn }
+    pub fn new(store: DataStore) -> Self {
+        Self { store }
     }
 
+    /// A registry over a throwaway file-backed test store.
     #[cfg(test)]
-    pub(crate) fn in_memory() -> Self {
-        let conn = Connection::open_in_memory().expect("in-memory SQLite");
-        crate::storage::timers::init_table(&conn).expect("init extension_timers");
+    pub(crate) fn for_test() -> Self {
         Self {
-            conn: Arc::new(Mutex::new(conn)),
+            store: crate::storage::create_test_store(),
         }
     }
 
@@ -85,7 +87,7 @@ impl TimerRegistry {
             )));
         }
         let timer_id = uuid::Uuid::new_v4().to_string();
-        let conn = self.conn.lock().map_err(|_| AppError::Lock)?;
+        let conn = self.store.conn()?;
         conn.execute(
             "INSERT INTO extension_timers
                 (timer_id, extension_id, command_id, args_json, fire_at, created_at)
@@ -104,7 +106,7 @@ impl TimerRegistry {
     }
 
     pub fn cancel(&self, extension_id: &str, timer_id: &str) -> Result<(), AppError> {
-        let conn = self.conn.lock().map_err(|_| AppError::Lock)?;
+        let conn = self.store.conn()?;
         let owner: Option<String> = conn
             .query_row(
                 "SELECT extension_id FROM extension_timers WHERE timer_id = ?1",
@@ -133,7 +135,7 @@ impl TimerRegistry {
     }
 
     pub fn list_pending(&self, extension_id: &str) -> Result<Vec<TimerDescriptor>, AppError> {
-        let conn = self.conn.lock().map_err(|_| AppError::Lock)?;
+        let conn = self.store.conn()?;
         let mut stmt = conn
             .prepare(
                 "SELECT timer_id, extension_id, command_id, args_json, fire_at, created_at
@@ -153,7 +155,7 @@ impl TimerRegistry {
     }
 
     pub fn due_now(&self, now_ms: u64) -> Result<Vec<TimerDescriptor>, AppError> {
-        let conn = self.conn.lock().map_err(|_| AppError::Lock)?;
+        let conn = self.store.conn()?;
         let mut stmt = conn
             .prepare(
                 "SELECT timer_id, extension_id, command_id, args_json, fire_at, created_at
@@ -178,7 +180,7 @@ impl TimerRegistry {
         timer_id: &str,
         fired_at: u64,
     ) -> Result<(), AppError> {
-        let conn = self.conn.lock().map_err(|_| AppError::Lock)?;
+        let conn = self.store.conn()?;
         // Guard the update with `fired = 0` so a second mark_fired (e.g. a
         // retry after a panic mid-emit) becomes a zero-row update we can
         // detect rather than silently toggling state.
@@ -200,7 +202,7 @@ impl TimerRegistry {
     }
 
     pub fn clear_all_for_extension(&self, extension_id: &str) -> Result<usize, AppError> {
-        let conn = self.conn.lock().map_err(|_| AppError::Lock)?;
+        let conn = self.store.conn()?;
         let n = conn
             .execute(
                 "DELETE FROM extension_timers WHERE extension_id = ?1",
@@ -211,7 +213,7 @@ impl TimerRegistry {
     }
 
     pub fn prune_old_fired(&self, older_than_ms: u64) -> Result<usize, AppError> {
-        let conn = self.conn.lock().map_err(|_| AppError::Lock)?;
+        let conn = self.store.conn()?;
         let n = conn
             .execute(
                 "DELETE FROM extension_timers
@@ -239,7 +241,7 @@ mod tests {
     use super::*;
 
     fn make() -> TimerRegistry {
-        TimerRegistry::in_memory()
+        TimerRegistry::for_test()
     }
 
     #[test]

--- a/docs/explanation/data-persistence.md
+++ b/docs/explanation/data-persistence.md
@@ -15,6 +15,22 @@ Asyar uses two SQLite databases managed by the Rust backend:
 
 Both databases use WAL mode for concurrent read performance and are stored in the platform-specific app data directory.
 
+### The `asyar_data.db` connection pool
+
+`DataStore` owns an [r2d2](https://docs.rs/r2d2) pool of SQLite connections rather than one shared connection. `store.conn()` checks one out; the handle derefs to `rusqlite::Connection`, so every `storage::*` function keeps taking a plain `&Connection`.
+
+This exists because WAL only pays off if readers can actually run at the same time. With a single `Mutex<Connection>`, every reader queued behind every other caller, and the worst case was cold start: the clipboard and notes FTS rebuilds each scan and decrypt the full table, and while they did, no other database work in the app could proceed.
+
+Three rules come with the pool:
+
+- **One connection per transaction.** A transaction lives on the connection that began it. Never start one on a connection from one `conn()` call and finish it on another — hold a single handle for the whole transaction.
+- **A busy timeout is mandatory, and is set on every connection.** SQLite still admits exactly one writer. Writers now collide inside SQLite instead of queueing on a Rust mutex, and the loser fails immediately with `SQLITE_BUSY` unless a timeout tells it to wait. `BUSY_TIMEOUT_MS` (15s) is applied by an r2d2 connection customizer as each connection is opened, so no connection can reach a caller unconfigured. The value is set explicitly rather than left to rusqlite's own 5s default — the longest write in the app is the startup rebuild's `content_hash` backfill, one transaction covering every legacy clipboard row.
+- **Never hold a connection across `.await`.** Checked-out connections are a bounded resource (`POOL_SIZE`, 8), so a handle parked on an await point is one the rest of the app cannot use. Blocking database work belongs in `spawn_blocking`, as the two FTS rebuild tasks do. The old `MutexGuard` was `!Send` and the compiler enforced this for you; a pooled connection is `Send`, so it is now a rule you have to follow rather than one you cannot break.
+
+The pool is 8 connections: SQLite serialises writers regardless, so extra connections only buy reader concurrency, and a launcher that idles most of its life has no use for a web-server-sized pool. Migrations run on a single connection while the pool is still private to `open_at`, so two connections can never race to apply the ledger.
+
+Test stores (`create_test_store()`) are backed by a real file in a temporary directory, not `:memory:` — each connection to `:memory:` is its own separate empty database, so a pooled in-memory store would hand out connections that cannot see each other's schema or rows.
+
 **`asyar_data.db` tables:**
 
 - **`clipboard_items`** — Clipboard history (up to 1000 items). Each copy/paste is a single `INSERT`, not a full-table rewrite. Indexed on `created_at DESC` and `favorite`.


### PR DESCRIPTION
Every reader queued behind one Arc<Mutex<Connection>>, so WAL's
concurrent reads were paid for and discarded — worst at cold start,
where the clipboard and notes FTS rebuilds each held the global lock
through a full scan and decrypt.

DataStore now owns an r2d2 pool. conn() returns a PooledConnection that
derefs to Connection, so the storage call sites are unchanged. conn_arc()
and from_conn() are deleted; the timer registry, extension state service
and alias state hold a DataStore instead of a live connection.

busy_timeout is set explicitly on every connection rather than inherited
from rusqlite's 5s default, and test stores are tempfile-backed because
each :memory: connection is its own empty database.