### PR TITLE
feat(applications): match macOS apps by their localized display name

### DIFF
--- a/asyar-launcher/src-tauri/src/application/service.rs
+++ b/asyar-launcher/src-tauri/src/application/service.rs
@@ -77,19 +77,16 @@ pub fn sync_application_index<R: tauri::Runtime>(
     // 2. Build current app set
     let mut current_apps: HashMap<String, Application> = HashMap::new();
     for path_str in &scanner.paths {
-        let name = Path::new(path_str)
-            .file_stem()
-            .and_then(|stem| stem.to_str())
-            .unwrap_or("Unknown_App")
-            .to_string();
-
-        let full_app_id = build_app_id(&name, path_str);
+        let path = Path::new(path_str);
+        // Id keyed on the file name, never the display name — see
+        // `bundle_file_name`. Keeps existing ids byte-identical.
+        let full_app_id = build_app_id(&bundle_file_name(path), path_str);
 
         current_apps.insert(
             full_app_id.clone(),
             Application {
                 id: full_app_id,
-                name,
+                name: display_name(path),
                 path: path_str.clone(),
                 usage_count: 0,
                 icon: extract_app_icon(path_str, &icon_cache_dir),
@@ -206,17 +203,12 @@ pub fn list_applications<R: tauri::Runtime>(
     let mut applications = Vec::new();
 
     for path_str in &scanner.paths {
-        let name = Path::new(path_str)
-            .file_stem()
-            .and_then(|stem| stem.to_str())
-            .unwrap_or("Unknown_App")
-            .to_string();
-
-        let full_app_id = build_app_id(&name, path_str);
+        let path = Path::new(path_str);
+        let full_app_id = build_app_id(&bundle_file_name(path), path_str);
 
         applications.push(Application {
             id: full_app_id,
-            name,
+            name: display_name(path),
             path: path_str.clone(),
             usage_count: 0,
             icon: extract_app_icon(path_str, &icon_cache_dir),
@@ -555,6 +547,54 @@ fn score_candidate(filename: &str) -> i32 {
 /// Works the same whether the path comes from a default scan location or from
 /// a user-configured custom scan directory — the logic is purely
 /// path-content-based (Info.plist or .desktop), no registry lookup.
+/// The bundle's file name on disk, without extension.
+///
+/// This is the app's stable identity: `build_app_id` embeds it, and the id
+/// in turn keys usage stats, user-assigned aliases and item shortcuts.
+/// It must never be swapped for a display name, or all three break silently
+/// the first time a user's language changes what the OS reports.
+pub(crate) fn bundle_file_name(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("Unknown_App")
+        .to_string()
+}
+
+/// The name macOS presents for a bundle, which is localized — `Photos.app`
+/// reads as "Fotos" on a German system. Returns `None` when the OS has
+/// nothing to add, so callers fall back to the file name.
+#[cfg(target_os = "macos")]
+pub(crate) fn localized_display_name(path: &Path) -> Option<String> {
+    use objc2_foundation::{NSFileManager, NSString};
+
+    let path_str = path.to_str()?;
+    let ns_path = NSString::from_str(path_str);
+    let display = unsafe { NSFileManager::defaultManager().displayNameAtPath(&ns_path) };
+    // Finder hides the extension by default but honours the user's
+    // "show all filename extensions" setting, so it may come back either way.
+    let display = display.to_string();
+    let trimmed = display.strip_suffix(".app").unwrap_or(&display).trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// What the user sees for this app. Localized on macOS, the plain file name
+/// everywhere else. Deliberately separate from [`bundle_file_name`] — search
+/// matches both, but only the file name may reach `build_app_id`.
+pub(crate) fn display_name(path: &Path) -> String {
+    #[cfg(target_os = "macos")]
+    {
+        localized_display_name(path).unwrap_or_else(|| bundle_file_name(path))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        bundle_file_name(path)
+    }
+}
+
 pub(crate) fn extract_bundle_id(path: &Path) -> Option<String> {
     #[cfg(target_os = "macos")]
     {
@@ -845,6 +885,45 @@ mod tests {
     fn test_is_default_app_location_macos_matches_applications_dir() {
         assert!(is_default_app_location("/Applications/Finder.app"));
         assert!(is_default_app_location("/System/Applications/Calendar.app"));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_localized_display_name_resolves_system_app() {
+        // Locale-independent on purpose: an English system answers "Photos",
+        // a German one "Fotos". Asserting either would fail on the other, so
+        // only assert the properties that must hold in every locale.
+        let name = localized_display_name(Path::new("/System/Applications/Photos.app"))
+            .expect("macOS must resolve a display name for a stock system app");
+        assert!(!name.is_empty());
+        assert!(
+            !name.ends_with(".app"),
+            "extension must be stripped, got {name}"
+        );
+    }
+
+    #[test]
+    fn test_display_name_falls_back_to_file_name_for_unknown_bundle() {
+        // A path the OS knows nothing about must still yield the file name
+        // rather than an empty string, or the app would index as nameless.
+        let tmp = std::env::temp_dir().join("asyar_display_name_fallback_Widget.app");
+        assert_eq!(
+            display_name(&tmp),
+            "asyar_display_name_fallback_Widget",
+            "unknown bundles fall back to the file name"
+        );
+    }
+
+    #[test]
+    fn test_bundle_file_name_is_independent_of_display_name() {
+        // The id is built from this, so it must stay the plain file stem.
+        // If this ever tracked the display name, every localized app would
+        // get a new id and silently lose its usage stats, aliases and
+        // shortcuts on the first scan after a language change.
+        assert_eq!(
+            bundle_file_name(Path::new("/System/Applications/Photos.app")),
+            "Photos"
+        );
     }
 
     #[test]

--- a/asyar-launcher/src-tauri/src/search_engine/mod.rs
+++ b/asyar-launcher/src-tauri/src/search_engine/mod.rs
@@ -422,13 +422,20 @@ impl SearchState {
             let mut scored: Vec<(i64, f32, &SearchableItem)> = guard
                 .iter()
                 .filter_map(|item| {
-                    matcher.fuzzy_match(item.get_name(), trimmed).map(|score| {
-                        (
-                            score,
-                            frecency_score(item.usage_count(), item.last_used_at()),
-                            item,
-                        )
-                    })
+                    // Score every name the item answers to and keep the best
+                    // hit, so a localized macOS app stays reachable under the
+                    // name it carries on disk. See `SearchableItem::search_names`.
+                    item.search_names()
+                        .iter()
+                        .filter_map(|name| matcher.fuzzy_match(name, trimmed))
+                        .max()
+                        .map(|score| {
+                            (
+                                score,
+                                frecency_score(item.usage_count(), item.last_used_at()),
+                                item,
+                            )
+                        })
                 })
                 .collect();
             scored.sort_unstable_by(|a, b| {
@@ -736,8 +743,16 @@ impl SearchState {
                         Some(SearchableItem::Command(cmd)) => {
                             (cmd.subtitle.clone(), vec![cmd.trigger.clone()])
                         }
-                        Some(SearchableItem::Application(app)) => {
-                            (None, app.bundle_id.iter().cloned().collect())
+                        Some(item @ SearchableItem::Application(app)) => {
+                            // Bundle id plus any non-display name the item
+                            // matched on — without the latter, an app found
+                            // via its on-disk name would classify as
+                            // "no name hit" and rank below genuine misses.
+                            let mut keywords: Vec<String> = app.bundle_id.iter().cloned().collect();
+                            keywords.extend(
+                                item.search_names().into_iter().skip(1).map(str::to_string),
+                            );
+                            (None, keywords)
                         }
                         None => (None, vec![]),
                     };
@@ -941,6 +956,20 @@ mod service_tests {
         })
     }
 
+    /// An app whose OS-resolved display name differs from its bundle file
+    /// name, the way localized macOS apps behave.
+    fn app_localized(id: &str, name: &str, file_name: &str, usage: u32) -> SearchableItem {
+        SearchableItem::Application(Application {
+            id: id.to_string(),
+            name: name.to_string(),
+            path: format!("/Applications/{}.app", file_name),
+            usage_count: usage,
+            icon: None,
+            last_used_at: None,
+            bundle_id: None,
+        })
+    }
+
     fn cmd(id: &str, name: &str, usage: u32) -> SearchableItem {
         SearchableItem::Command(Command {
             id: id.to_string(),
@@ -1124,6 +1153,40 @@ mod service_tests {
         let results = state.search("saf").unwrap();
         assert!(!results.is_empty());
         assert_eq!(results[0].name, "Safari");
+    }
+
+    #[test]
+    fn test_search_finds_app_by_alternate_name() {
+        // macOS localizes bundle display names: Photos.app presents as
+        // "Fotos" on a German system while staying Photos.app on disk.
+        // Both spellings must find it — the display name because that is
+        // what the user sees, the on-disk name because that is what people
+        // used to English app names type.
+        let state = make_state();
+        state
+            .index_one(app_localized("app_photos", "Fotos", "Photos", 0))
+            .unwrap();
+
+        assert!(
+            !state.search("Fotos").unwrap().is_empty(),
+            "localized display name must match"
+        );
+        assert!(
+            !state.search("Photos").unwrap().is_empty(),
+            "on-disk bundle name must match"
+        );
+    }
+
+    #[test]
+    fn test_search_by_alternate_name_still_reports_display_name() {
+        // Matching the on-disk name must not leak it into the UI: the row
+        // still has to read "Fotos", the name the rest of the system uses.
+        let state = make_state();
+        state
+            .index_one(app_localized("app_photos", "Fotos", "Photos", 0))
+            .unwrap();
+        let results = state.search("Photos").unwrap();
+        assert_eq!(results[0].name, "Fotos");
     }
 
     #[test]

--- a/asyar-launcher/src-tauri/src/search_engine/models.rs
+++ b/asyar-launcher/src-tauri/src/search_engine/models.rs
@@ -152,6 +152,33 @@ impl SearchableItem {
             SearchableItem::Command(c) => &c.name,
         }
     }
+
+    /// Every name a query may be matched against, display name first.
+    ///
+    /// Callers that score a query must try all of these and keep the best
+    /// hit. Matching only `get_name()` makes localized macOS apps
+    /// unreachable under the name they carry on disk: `Photos.app` presents
+    /// as "Fotos" on a German system, so a user typing "Photos" would find
+    /// nothing. The bundle file name is already available via `path`, so it
+    /// needs no separate storage — it is only surfaced for matching and
+    /// never shown, since `name` remains what the UI renders.
+    pub fn search_names(&self) -> Vec<&str> {
+        match self {
+            SearchableItem::Application(a) => {
+                let mut names = vec![a.name.as_str()];
+                if let Some(stem) = std::path::Path::new(a.path.as_str())
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                {
+                    if !stem.eq_ignore_ascii_case(&a.name) {
+                        names.push(stem);
+                    }
+                }
+                names
+            }
+            SearchableItem::Command(c) => vec![c.name.as_str()],
+        }
+    }
     // Helper to get the type string
     pub fn get_type_str(&self) -> &str {
         match self {

--- a/asyar-launcher/src-tauri/src/search_engine/models.rs
+++ b/asyar-launcher/src-tauri/src/search_engine/models.rs
@@ -166,12 +166,20 @@ impl SearchableItem {
         match self {
             SearchableItem::Application(a) => {
                 let mut names = vec![a.name.as_str()];
-                if let Some(stem) = std::path::Path::new(a.path.as_str())
-                    .file_stem()
-                    .and_then(|s| s.to_str())
-                {
-                    if !stem.eq_ignore_ascii_case(&a.name) {
-                        names.push(stem);
+                // Windows UWP apps are indexed under a synthetic
+                // "shell:AppsFolder\<AUMID>" identifier, not a real bundle
+                // path — file_stem() on that would chop the dotted AUMID
+                // (PackageFamilyName!AppId) and produce a bogus alternate
+                // name, e.g. "Microsoft" from every Microsoft-published app.
+                let is_real_bundle_path = !a.path.starts_with(r"shell:AppsFolder\");
+                if is_real_bundle_path {
+                    if let Some(stem) = std::path::Path::new(a.path.as_str())
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                    {
+                        if !stem.eq_ignore_ascii_case(&a.name) {
+                            names.push(stem);
+                        }
                     }
                 }
                 names
@@ -358,6 +366,31 @@ mod tests {
     fn test_command_get_type_str() {
         let item = make_cmd("cmd_find", "Find");
         assert_eq!(item.get_type_str(), "command");
+    }
+
+    #[test]
+    fn test_search_names_ignores_uwp_synthetic_path() {
+        // UWP apps are indexed under a synthetic "shell:AppsFolder\<AUMID>"
+        // identifier, not a real bundle path. AUMIDs are dotted
+        // (PackageFamilyName!AppId, e.g.
+        // "Microsoft.WindowsCalculator_8wekyb3d8bbwe!App"), so file_stem()
+        // on the raw string would chop it at that dot and produce
+        // "Microsoft" — a bogus alternate name that would make every
+        // Microsoft-published app match a search for "Microsoft".
+        let item = SearchableItem::Application(Application {
+            id: "app_calculator".to_string(),
+            name: "Calculator".to_string(),
+            path: r"shell:AppsFolder\Microsoft.WindowsCalculator_8wekyb3d8bbwe!App".to_string(),
+            usage_count: 0,
+            icon: None,
+            last_used_at: None,
+            bundle_id: None,
+        });
+        assert_eq!(
+            item.search_names(),
+            vec!["Calculator"],
+            "a UWP path must not contribute a bogus file-stem alternate name"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

macOS localizes bundle display names. On a German system `Photos.app` presents as "Fotos", `Notes.app` as "Notizen", `System Settings.app` as "Systemeinstellungen". Asyar indexes the bundle *file* name, so those apps are unreachable under the name the user actually sees.

On one German install this affects twelve stock system apps — Fotos, Notizen, Erinnerungen, Kalender, Nachrichten, Karten, Musik, Wetter, Rechner, Vorschau, Kontakte, Systemeinstellungen — plus any localized third-party app. For non-English users this makes application search substantially less useful.

The name has to come from the OS. `CFBundleDisplayName` in `Info.plist` reads "Photos" even on a localized system, and the `lproj` resources aren't reliably parseable (`Photos.app/Contents/Resources/de.lproj` carries no readable `InfoPlist.strings` at all). `NSFileManager.displayName(atPath:)` is the supported route; `objc2-foundation` is already a dependency, so this adds none.

## Both names stay searchable

Replacing `name` outright would trade one bug for another — users who know apps by their English names would stop finding them, and macOS itself keeps both (`kMDItemDisplayName` = `Fotos.app`, `kMDItemAlternateNames` = `Photos.app`).

`SearchableItem::search_names()` returns the display name plus the bundle file name when the two differ, and the skim pre-filter scores all of them and keeps the best hit. This has to happen in the pre-filter: `merged_search` uses `search()` as its gate, so a name only reachable via `keywords` would be filtered out before ranking ever sees it. The classifier's `keywords` are extended too, otherwise a file-name match would classify as "no name hit" and rank below genuine misses.

The file name is derived from `path`, which is already stored — no new field, no schema change, no regenerated TS bindings, no migration. Only `name` is rendered, so results still read "Fotos".

## App ids are deliberately unaffected

`build_app_id()` embeds the name, and the resulting id keys usage stats, user-assigned aliases (`item_aliases.object_id`) and item shortcuts. Letting a localized display name reach it would have changed the id of every localized app on the first scan after upgrade and silently dropped all three.

So the id keeps receiving the file name, via a new `bundle_file_name()` helper that is deliberately separate from `display_name()`. Existing ids stay byte-identical. A test pins this down so the two don't get merged back together later.

This also de-duplicates the `file_stem()` logic that was copy-pasted across `sync_application_index` and `list_applications`.

## Cost

`NSFileManager` resolution measured over a real install: **246 apps in 64 ms (261 µs/app)**, on the index sync that already walks the filesystem and extracts icons — both far more expensive. No cache added: it would raise an invalidation question (language change, app update, rename) for a cost that doesn't currently warrant one. Happy to add one if you'd rather.

## Testing

`cargo test --lib` → 3176 passed, 9 ignored. `cargo clippy` clean, `cargo fmt --check` clean.

One pre-existing failure, unrelated to this change: `file_index::deep::mdfind::tests::probe_succeeds_on_a_real_mac` fails when the test process can't reach Spotlight. Verified by stashing this branch's changes and re-running it — it fails identically on a clean tree.

Note on locale coverage: no test can assert "Fotos" without failing on an English CI runner. The search-side tests therefore run against synthetic items and are locale-independent, while the `NSFileManager` test only asserts what must hold in every locale (non-empty, extension stripped). Confirming the German behaviour end-to-end needs a localized machine.