### PR TITLE
fix: approve esbuild & keytar build scripts in both pnpm workspace configs

### DIFF
--- a/asyar-launcher/pnpm-workspace.yaml
+++ b/asyar-launcher/pnpm-workspace.yaml
@@ -2,3 +2,11 @@ packages:
   - '.'
   - 'src/built-in-features/*'
   - '../asyar-sdk'
+
+allowBuilds:
+  esbuild: true
+  keytar: true
+
+onlyBuiltDependencies:
+  - 'esbuild'
+  - 'keytar'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,10 @@ allowBuilds:
   esbuild: true
   keytar: true
 
+onlyBuiltDependencies:
+  - 'esbuild'
+  - 'keytar'
+
 supportedArchitectures:
   cpu:
     - 'arm64'


### PR DESCRIPTION
Fresh checkouts fail `tauri dev` with `ERR_PNPM_IGNORED_BUILDS: esbuild, keytar` when pnpm 11 is on PATH.

My [#501](https://github.com/Xoshbin/asyar/pull/501) allowlist only used v11-only syntax, and `tauri dev` actually resolves the nested `asyar-launcher/pnpm-workspace.yaml` too, which had no allowlist at all.

This includes syntax for both pnpm 10+11, and is applied across workspaces.

Verified: a pnpm 11.20 install from `asyar-launcher` now runs both build scripts and completes, and `pnpm dev` through the 11.x shim gets all the way to vite. The pinned 10.26 flow is unchanged.