### PR TITLE
feat(launcher): allow moving the launcher window (drag or setting)

### DIFF
--- a/asyar-launcher/src-tauri/src/commands/app.rs
+++ b/asyar-launcher/src-tauri/src/commands/app.rs
@@ -86,8 +86,7 @@ pub fn commit_show(
         let window = app_handle
             .get_webview_window(SPOTLIGHT_LABEL)
             .ok_or_else(|| AppError::NotFound("launcher window".to_string()))?;
-        crate::platform::macos::center_at_cursor_monitor(&window)
-            .map_err(|e| AppError::Platform(format!("center_at_cursor_monitor: {e}")))?;
+        crate::platform::macos::position_launcher(&window)?;
         crate::platform::macos::set_window_alpha(&window, 1.0);
         // prepare_show's panel.show() ran on an already-visible (parked)
         // panel, which doesn't rebuild the responder chain; without this,
@@ -99,7 +98,7 @@ pub fn commit_show(
         let window = app_handle
             .get_webview_window(SPOTLIGHT_LABEL)
             .ok_or_else(|| AppError::NotFound("launcher window".to_string()))?;
-        center_on_primary_monitor(&window)?;
+        crate::launcher_placement::service::apply(&app_handle)?;
         let _ = window.set_focus();
     }
     // Flip the visibility flag only after the panel is actually composited at
@@ -133,7 +132,7 @@ pub fn show(app_handle: AppHandle, state: tauri::State<'_, AppState>) -> Result<
         let window = app_handle
             .get_webview_window(SPOTLIGHT_LABEL)
             .ok_or_else(|| AppError::NotFound("launcher window".to_string()))?;
-        center_on_primary_monitor(&window)?;
+        crate::launcher_placement::service::apply(&app_handle)?;
         let _ = window.show();
         let _ = window.set_focus();
     }
@@ -203,52 +202,6 @@ fn capture_previous_foreground(state: &tauri::State<'_, AppState>) -> Result<(),
         *prev = wid;
     }
     let _ = state;
-    Ok(())
-}
-
-/// Pure arithmetic for the centered-with-top-weight launcher position.
-/// Horizontally centered in the monitor; vertically placed at 16% from the
-/// top edge (matches the macOS cursor-monitor path's top-weight).
-#[cfg(any(not(target_os = "macos"), test))]
-fn compute_centered_position(
-    monitor_pos: (f64, f64),
-    monitor_size: (f64, f64),
-    window_size: (f64, f64),
-) -> (f64, f64) {
-    let x = monitor_pos.0 + (monitor_size.0 - window_size.0) / 2.0;
-    let y = monitor_pos.1 + monitor_size.1 * 0.16;
-    (x, y)
-}
-
-/// Cross-platform "center on primary monitor" for the reveal path.
-/// macOS uses its own cursor-monitor centering; Windows/Linux fall back to
-/// primary monitor since cursor-monitor lookup is platform-dependent and
-/// not currently wired up outside macOS.
-#[cfg(not(target_os = "macos"))]
-fn center_on_primary_monitor<R: tauri::Runtime>(
-    window: &tauri::WebviewWindow<R>,
-) -> Result<(), AppError> {
-    let monitor = window
-        .primary_monitor()
-        .map_err(|e| AppError::Platform(format!("primary_monitor: {e}")))?
-        .ok_or_else(|| AppError::NotFound("primary monitor".to_string()))?;
-    let scale = monitor.scale_factor();
-    let monitor_size = monitor.size().to_logical::<f64>(scale);
-    let monitor_position = monitor.position().to_logical::<f64>(scale);
-    let window_size = window
-        .outer_size()
-        .map_err(|e| AppError::Platform(format!("outer_size: {e}")))?
-        .to_logical::<f64>(scale);
-
-    let (x, y) = compute_centered_position(
-        (monitor_position.x, monitor_position.y),
-        (monitor_size.width, monitor_size.height),
-        (window_size.width, window_size.height),
-    );
-
-    window
-        .set_position(Position::Logical(LogicalPosition { x, y }))
-        .map_err(|e| AppError::Platform(format!("set_position: {e}")))?;
     Ok(())
 }
 
@@ -413,7 +366,7 @@ pub fn show_launcher(app: &AppHandle) -> Result<(), AppError> {
         let window = app
             .get_webview_window(SPOTLIGHT_LABEL)
             .ok_or_else(|| AppError::NotFound("launcher window".to_string()))?;
-        center_on_primary_monitor(&window)?;
+        crate::launcher_placement::service::apply(app)?;
         let _ = window.show();
         let _ = window.set_focus();
     }
@@ -429,29 +382,6 @@ pub fn quit_app(app_handle: AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn centers_on_origin_monitor() {
-        let (x, y) = compute_centered_position((0.0, 0.0), (1920.0, 1080.0), (480.0, 96.0));
-        assert_eq!(x, (1920.0 - 480.0) / 2.0);
-        assert_eq!(y, 1080.0 * 0.16);
-    }
-
-    #[test]
-    fn centers_on_offset_monitor() {
-        // Secondary display whose top-left is at (1920, -200) — common
-        // multi-monitor layout. Position must include the monitor origin.
-        let (x, y) = compute_centered_position((1920.0, -200.0), (2560.0, 1440.0), (480.0, 96.0));
-        assert_eq!(x, 1920.0 + (2560.0 - 480.0) / 2.0);
-        assert_eq!(y, -200.0 + 1440.0 * 0.16);
-    }
-
-    #[test]
-    fn handles_window_wider_than_monitor() {
-        // Pathological but should not panic; x just goes negative.
-        let (x, _) = compute_centered_position((0.0, 0.0), (800.0, 600.0), (1000.0, 96.0));
-        assert_eq!(x, (800.0 - 1000.0) / 2.0);
-    }
 
     #[test]
     fn rejects_nan() {

--- a/asyar-launcher/src-tauri/src/launcher_placement/commands.rs
+++ b/asyar-launcher/src-tauri/src/launcher_placement/commands.rs
@@ -1,0 +1,25 @@
+//! Thin wrappers over [`super::store`]. All the logic lives in the service
+//! and resolver modules; these convert wire types and delegate.
+
+use super::store;
+use super::types::LauncherPlacement;
+use crate::error::AppError;
+use tauri::AppHandle;
+
+/// The user's current placement preference, or the default if none has been
+/// saved. Backs the Settings → Appearance → Launcher Position section.
+#[tauri::command]
+pub fn get_launcher_placement(app: AppHandle) -> LauncherPlacement {
+    store::load(&app)
+}
+
+/// Persists a placement chosen in Settings. It takes effect on the next
+/// summon — the reveal path re-reads the store every time, so there is
+/// nothing to push at a hidden window.
+#[tauri::command]
+pub fn set_launcher_placement(
+    app: AppHandle,
+    placement: LauncherPlacement,
+) -> Result<(), AppError> {
+    store::save(&app, placement)
+}

--- a/asyar-launcher/src-tauri/src/launcher_placement/mod.rs
+++ b/asyar-launcher/src-tauri/src/launcher_placement/mod.rs
@@ -1,0 +1,47 @@
+//! Where the launcher window appears, and how the user changes it.
+//!
+//! Before #596 the position was recomputed on every reveal from a formula
+//! hardcoded in two platform-specific places, so there was nothing to drag and
+//! nothing to configure. This module owns that decision instead:
+//!
+//! ```text
+//! reveal ─▶ service::apply()
+//!            ├─ store::load()        the persisted LauncherPlacement
+//!            ├─ pick_monitor()       cursor or primary
+//!            ├─ resolve::resolve_origin()   PURE — the only copy of the maths
+//!            └─ platform conversion  AppKit bottom-left ⇆ Tauri top-left
+//! ```
+//!
+//! Dragging goes the other way: [`crate::window_drag`] moves the window, and
+//! on drop [`service::persist_dragged`] turns the landing spot back into
+//! monitor fractions.
+
+pub mod commands;
+pub mod resolve;
+pub mod service;
+pub mod store;
+pub mod types;
+
+pub use types::{LauncherAnchor, LauncherMonitorChoice, LauncherPlacement, DEFAULT_TOP_BIAS};
+
+/// The tallest the launcher ever gets. Positions reserve this much room below
+/// the top edge so an expanded launcher is never clipped — see
+/// [`resolve::resolve_origin`].
+///
+/// macOS keeps its own copy in `platform::macos::window` because the NSPanel
+/// geometry code is written against it; `matches_macos_constant` below holds
+/// the two together.
+pub const LAUNCHER_MAX_HEIGHT: f64 = 480.0;
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn matches_macos_constant() {
+        assert_eq!(
+            super::LAUNCHER_MAX_HEIGHT,
+            crate::platform::macos::LAUNCHER_MAX_HEIGHT,
+            "the placement resolver reserves the same height the NSPanel resize code uses"
+        );
+    }
+}

--- a/asyar-launcher/src-tauri/src/launcher_placement/resolve.rs
+++ b/asyar-launcher/src-tauri/src/launcher_placement/resolve.rs
@@ -1,0 +1,280 @@
+//! The launcher's position arithmetic. Pure, platform-free, and the **only**
+//! place the formula lives — before #596 it was copy-pasted into
+//! `platform::macos::window::center_at_cursor_monitor` and
+//! `commands::app::center_on_primary_monitor`, which is how Windows and Linux
+//! ended up permanently pinned to the primary display.
+
+use super::types::LauncherAnchor;
+
+/// A rectangle in a neutral **top-left origin, y-down** space. Callers put
+/// the monitor and its work area into the same space and convert the result
+/// back; see [`super::service`] for the two conversions.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Rect {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+impl Rect {
+    pub fn new(x: f64, y: f64, width: f64, height: f64) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+}
+
+/// Resolves the launcher's top-left corner.
+///
+/// Two rectangles, on purpose:
+///
+/// - `monitor` is what the **anchor** is measured against. Keeping the anchor
+///   on the full monitor is what makes `TopWeighted { bias: 0.16 }` reproduce
+///   the pre-#596 position exactly, and it keeps a dragged fraction stable
+///   when the dock auto-hides.
+/// - `work` is what the result is **clamped** into, so the launcher never
+///   opens under the menu bar, the taskbar, or the dock.
+///
+/// `reserve_height` is the height the window is allowed to grow to, not its
+/// current height. The launcher pins its *top* edge and expands downward
+/// (`platform::macos::window::set_launcher_window_height`), so a position that
+/// fits while compact (96px) would hang off the bottom once expanded. Both the
+/// vertical centring and the bottom clamp therefore use the expanded height —
+/// which also means the top edge does not move between a compact and an
+/// expanded reveal.
+pub fn resolve_origin(
+    anchor: &LauncherAnchor,
+    monitor: Rect,
+    work: Rect,
+    window_width: f64,
+    reserve_height: f64,
+) -> (f64, f64) {
+    let (x, y) = match *anchor {
+        LauncherAnchor::TopWeighted { bias } => (
+            monitor.x + (monitor.width - window_width) / 2.0,
+            monitor.y + monitor.height * bias,
+        ),
+        LauncherAnchor::Centered => (
+            monitor.x + (monitor.width - window_width) / 2.0,
+            monitor.y + (monitor.height - reserve_height) / 2.0,
+        ),
+        LauncherAnchor::Free { x, y } => (
+            monitor.x + monitor.width * x,
+            monitor.y + monitor.height * y,
+        ),
+    };
+
+    (
+        clamp_into(x, work.x, work.x + work.width - window_width),
+        clamp_into(y, work.y, work.y + work.height - reserve_height),
+    )
+}
+
+/// Expresses `origin` as fractions of `monitor` — the inverse of the `Free`
+/// branch above, used to turn a drop position into a persistable anchor.
+pub fn origin_to_fractions(origin: (f64, f64), monitor: Rect) -> (f64, f64) {
+    let fx = fraction(origin.0 - monitor.x, monitor.width);
+    let fy = fraction(origin.1 - monitor.y, monitor.height);
+    (fx, fy)
+}
+
+fn fraction(offset: f64, extent: f64) -> f64 {
+    if extent <= 0.0 || !offset.is_finite() {
+        return 0.0;
+    }
+    (offset / extent).clamp(0.0, 1.0)
+}
+
+/// `f64::clamp` panics on an inverted range or a NaN bound, both of which are
+/// reachable here: a monitor narrower than the launcher inverts the horizontal
+/// range, and one shorter than `reserve_height` inverts the vertical one.
+/// Collapsing to `lo` in that case pins the window to the top-left of the work
+/// area, which is the only fully-visible choice available.
+fn clamp_into(v: f64, lo: f64, hi: f64) -> f64 {
+    if !v.is_finite() || !lo.is_finite() {
+        return if lo.is_finite() { lo } else { 0.0 };
+    }
+    let hi = if hi.is_finite() { hi.max(lo) } else { lo };
+    v.clamp(lo, hi)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A 1920x1080 monitor at the origin whose work area excludes a 25px
+    /// menu bar — the ordinary single-display Mac.
+    fn primary() -> (Rect, Rect) {
+        (
+            Rect::new(0.0, 0.0, 1920.0, 1080.0),
+            Rect::new(0.0, 25.0, 1920.0, 1055.0),
+        )
+    }
+
+    const WIN_W: f64 = 800.0;
+    const MAX_H: f64 = 480.0;
+
+    fn top_weighted() -> LauncherAnchor {
+        LauncherAnchor::default()
+    }
+
+    // --- TopWeighted: must reproduce the pre-#596 position exactly ---------
+
+    #[test]
+    fn top_weighted_centers_horizontally_and_sits_at_16_percent() {
+        let (m, w) = primary();
+        let (x, y) = resolve_origin(&top_weighted(), m, w, WIN_W, MAX_H);
+        assert_eq!(x, (1920.0 - 800.0) / 2.0);
+        assert_eq!(y, 1080.0 * 0.16);
+    }
+
+    #[test]
+    fn top_weighted_includes_the_monitor_origin() {
+        // Secondary display whose top-left is at (1920, -200) — a common
+        // multi-monitor layout. This is the case the old
+        // `compute_centered_position` covered.
+        let m = Rect::new(1920.0, -200.0, 2560.0, 1440.0);
+        let w = m;
+        let (x, y) = resolve_origin(&top_weighted(), m, w, WIN_W, MAX_H);
+        assert_eq!(x, 1920.0 + (2560.0 - 800.0) / 2.0);
+        assert_eq!(y, -200.0 + 1440.0 * 0.16);
+    }
+
+    #[test]
+    fn top_weighted_honours_a_custom_bias() {
+        let (m, w) = primary();
+        let (_, y) = resolve_origin(
+            &LauncherAnchor::TopWeighted { bias: 0.4 },
+            m,
+            w,
+            WIN_W,
+            MAX_H,
+        );
+        assert_eq!(y, 1080.0 * 0.4);
+    }
+
+    // --- Centered ----------------------------------------------------------
+
+    #[test]
+    fn centered_uses_the_expanded_height_so_the_top_edge_never_moves() {
+        let (m, w) = primary();
+        let (x, y) = resolve_origin(&LauncherAnchor::Centered, m, w, WIN_W, MAX_H);
+        assert_eq!(x, (1920.0 - 800.0) / 2.0);
+        assert_eq!(y, (1080.0 - 480.0) / 2.0);
+    }
+
+    // --- Free --------------------------------------------------------------
+
+    #[test]
+    fn free_maps_fractions_onto_the_monitor() {
+        let (m, w) = primary();
+        let (x, y) = resolve_origin(
+            &LauncherAnchor::Free { x: 0.25, y: 0.1 },
+            m,
+            w,
+            WIN_W,
+            MAX_H,
+        );
+        assert_eq!(x, 1920.0 * 0.25);
+        assert_eq!(y, 1080.0 * 0.1);
+    }
+
+    #[test]
+    fn free_lands_in_the_same_relative_spot_on_a_smaller_display() {
+        let anchor = LauncherAnchor::Free { x: 0.25, y: 0.1 };
+        let big = Rect::new(0.0, 0.0, 2560.0, 1440.0);
+        let small = Rect::new(0.0, 0.0, 1280.0, 720.0);
+        let (bx, by) = resolve_origin(&anchor, big, big, WIN_W, MAX_H);
+        let (sx, sy) = resolve_origin(&anchor, small, small, WIN_W, MAX_H);
+        assert_eq!(bx / 2560.0, sx / 1280.0);
+        assert_eq!(by / 1440.0, sy / 720.0);
+    }
+
+    // --- Clamping ----------------------------------------------------------
+
+    #[test]
+    fn clamps_a_low_drop_so_the_expanded_window_still_fits() {
+        let (m, w) = primary();
+        // Dropped at 95% down — the expanded 480px window would hang far off
+        // the bottom.
+        let (_, y) = resolve_origin(
+            &LauncherAnchor::Free { x: 0.5, y: 0.95 },
+            m,
+            w,
+            WIN_W,
+            MAX_H,
+        );
+        assert_eq!(y, 25.0 + 1055.0 - 480.0);
+        assert!(y + MAX_H <= w.y + w.height);
+    }
+
+    #[test]
+    fn clamps_off_the_right_edge() {
+        let (m, w) = primary();
+        let (x, _) = resolve_origin(&LauncherAnchor::Free { x: 1.0, y: 0.2 }, m, w, WIN_W, MAX_H);
+        assert_eq!(x, 1920.0 - 800.0);
+    }
+
+    #[test]
+    fn clamps_above_the_menu_bar() {
+        let (m, w) = primary();
+        let (_, y) = resolve_origin(&LauncherAnchor::Free { x: 0.5, y: 0.0 }, m, w, WIN_W, MAX_H);
+        assert_eq!(y, 25.0, "must not slide under the menu bar");
+    }
+
+    #[test]
+    fn respects_a_work_area_inset_on_an_offset_monitor() {
+        // Left-hand display with a 60px dock on its left edge.
+        let m = Rect::new(-1440.0, 0.0, 1440.0, 900.0);
+        let w = Rect::new(-1380.0, 0.0, 1380.0, 900.0);
+        let (x, _) = resolve_origin(&LauncherAnchor::Free { x: 0.0, y: 0.2 }, m, w, WIN_W, MAX_H);
+        assert_eq!(x, -1380.0);
+    }
+
+    #[test]
+    fn does_not_invert_when_the_window_is_wider_than_the_monitor() {
+        let m = Rect::new(0.0, 0.0, 600.0, 400.0);
+        let (x, y) = resolve_origin(&top_weighted(), m, m, WIN_W, MAX_H);
+        assert_eq!(x, 0.0, "pins to the left edge rather than panicking");
+        assert_eq!(y, 0.0, "pins to the top edge rather than panicking");
+    }
+
+    #[test]
+    fn survives_a_nan_bias() {
+        let (m, w) = primary();
+        let (x, y) = resolve_origin(
+            &LauncherAnchor::TopWeighted { bias: f64::NAN },
+            m,
+            w,
+            WIN_W,
+            MAX_H,
+        );
+        assert!(x.is_finite() && y.is_finite());
+    }
+
+    // --- origin_to_fractions ----------------------------------------------
+
+    #[test]
+    fn fractions_round_trip_through_resolve() {
+        let m = Rect::new(1920.0, -200.0, 2560.0, 1440.0);
+        let anchor = LauncherAnchor::Free { x: 0.3, y: 0.25 };
+        let origin = resolve_origin(&anchor, m, m, WIN_W, MAX_H);
+        assert_eq!(origin_to_fractions(origin, m), (0.3, 0.25));
+    }
+
+    #[test]
+    fn fractions_clamp_a_drop_outside_the_monitor() {
+        let m = Rect::new(0.0, 0.0, 1920.0, 1080.0);
+        assert_eq!(origin_to_fractions((-500.0, 5000.0), m), (0.0, 1.0));
+    }
+
+    #[test]
+    fn fractions_of_a_degenerate_monitor_are_zero() {
+        let m = Rect::new(0.0, 0.0, 0.0, 0.0);
+        assert_eq!(origin_to_fractions((10.0, 10.0), m), (0.0, 0.0));
+    }
+}

--- a/asyar-launcher/src-tauri/src/launcher_placement/service.rs
+++ b/asyar-launcher/src-tauri/src/launcher_placement/service.rs
@@ -1,0 +1,444 @@
+//! Applies a [`LauncherPlacement`] to the real window, and turns a drop back
+//! into one.
+//!
+//! ## Two coordinate spaces, on purpose
+//!
+//! [`super::resolve`] works in a **monitor-relative, top-left origin, y-down**
+//! space: `(0, 0)` is the monitor's top-left corner. Each platform converts in
+//! and out of that space once, here:
+//!
+//! - **macOS** stays in AppKit's bottom-left, y-up space the whole way. The
+//!   `monitor` crate (`get_monitor_with_cursor`) returns raw `NSScreen` frames
+//!   — *not* Tauri's normalised coordinates — and the reveal path positions
+//!   the panel with `set_window_frame` rather than `set_position`, because the
+//!   flash-free reveal machinery in `platform::macos::window` is written
+//!   against `NSRect`. Both directions go through [`macos_conv`].
+//! - **Windows/Linux** use Tauri's monitor APIs, which are already top-left
+//!   y-down, so the conversion is an origin offset.
+
+use super::resolve::{origin_to_fractions, resolve_origin, Rect};
+use super::store;
+use super::types::{LauncherAnchor, LauncherMonitorChoice, LauncherPlacement};
+use super::LAUNCHER_MAX_HEIGHT;
+use crate::error::AppError;
+use crate::SPOTLIGHT_LABEL;
+use tauri::{AppHandle, Manager, Runtime};
+
+/// A monitor and its usable area, both monitor-relative and y-down, as
+/// [`resolve_origin`] wants them.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Frames {
+    pub monitor: Rect,
+    pub work: Rect,
+}
+
+/// The AppKit ⇆ neutral-space conversion, kept pure so the sign errors that
+/// this kind of code invites are caught by tests rather than by dragging the
+/// launcher onto a second display.
+#[cfg(target_os = "macos")]
+pub mod macos_conv {
+    use super::{Frames, Rect};
+
+    /// An `NSRect`-shaped value: AppKit's bottom-left origin, y-up.
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    pub struct AppKitRect {
+        pub x: f64,
+        pub y: f64,
+        pub width: f64,
+        pub height: f64,
+    }
+
+    impl AppKitRect {
+        /// The screen y of this rect's *top* edge.
+        pub fn top(&self) -> f64 {
+            self.y + self.height
+        }
+    }
+
+    /// Expresses a screen's frame and visible frame in the neutral space.
+    pub fn frames(screen: AppKitRect, visible: AppKitRect) -> Frames {
+        Frames {
+            monitor: Rect::new(0.0, 0.0, screen.width, screen.height),
+            work: Rect::new(
+                visible.x - screen.x,
+                screen.top() - visible.top(),
+                visible.width,
+                visible.height,
+            ),
+        }
+    }
+
+    /// Neutral offsets → the AppKit origin (bottom-left) of a window of
+    /// `window_height`.
+    pub fn to_appkit_origin(
+        screen: AppKitRect,
+        offsets: (f64, f64),
+        window_height: f64,
+    ) -> (f64, f64) {
+        (
+            screen.x + offsets.0,
+            screen.top() - offsets.1 - window_height,
+        )
+    }
+
+    /// An existing window's AppKit frame → neutral offsets from the screen's
+    /// top-left. The inverse of [`to_appkit_origin`].
+    pub fn to_offsets(screen: AppKitRect, window: AppKitRect) -> (f64, f64) {
+        (window.x - screen.x, screen.top() - window.top())
+    }
+}
+
+/// Positions the launcher for a reveal. Fail-soft by contract: the caller is
+/// mid-reveal and a placement problem must never stop the window appearing, so
+/// every failure path leaves the window where it was.
+pub fn apply<R: Runtime>(app: &AppHandle<R>) -> Result<(), AppError> {
+    let placement = store::load(app);
+    apply_placement(app, &placement)
+}
+
+#[cfg(target_os = "macos")]
+fn apply_placement<R: Runtime>(
+    app: &AppHandle<R>,
+    placement: &LauncherPlacement,
+) -> Result<(), AppError> {
+    use crate::platform::macos::{get_window_frame, set_window_frame};
+    use objc2_foundation::{NSPoint, NSRect};
+
+    let window = app
+        .get_webview_window(SPOTLIGHT_LABEL)
+        .ok_or_else(|| AppError::NotFound("launcher window".to_string()))?;
+
+    let screen = pick_screen(placement.monitor)
+        .ok_or_else(|| AppError::NotFound("target monitor".to_string()))?;
+    let frames = macos_conv::frames(screen.frame, screen.visible);
+
+    let window_frame = get_window_frame(&window);
+    let offsets = resolve_origin(
+        &placement.anchor,
+        frames.monitor,
+        frames.work,
+        window_frame.size.width,
+        LAUNCHER_MAX_HEIGHT,
+    );
+    let (x, y) = macos_conv::to_appkit_origin(screen.frame, offsets, window_frame.size.height);
+
+    set_window_frame(
+        &window,
+        NSRect {
+            origin: NSPoint { x, y },
+            size: window_frame.size,
+        },
+    );
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn apply_placement<R: Runtime>(
+    app: &AppHandle<R>,
+    placement: &LauncherPlacement,
+) -> Result<(), AppError> {
+    use tauri::{LogicalPosition, Position};
+
+    let window = app
+        .get_webview_window(SPOTLIGHT_LABEL)
+        .ok_or_else(|| AppError::NotFound("launcher window".to_string()))?;
+
+    let monitor = pick_monitor(app, &window, placement.monitor)
+        .ok_or_else(|| AppError::NotFound("target monitor".to_string()))?;
+    let (origin, frames) = monitor_frames(&monitor);
+
+    let scale = monitor.scale_factor();
+    let window_size = window
+        .outer_size()
+        .map_err(|e| AppError::Platform(format!("outer_size: {e}")))?
+        .to_logical::<f64>(scale);
+
+    let (dx, dy) = resolve_origin(
+        &placement.anchor,
+        frames.monitor,
+        frames.work,
+        window_size.width,
+        LAUNCHER_MAX_HEIGHT,
+    );
+
+    window
+        .set_position(Position::Logical(LogicalPosition {
+            x: origin.0 + dx,
+            y: origin.1 + dy,
+        }))
+        .map_err(|e| AppError::Platform(format!("set_position: {e}")))?;
+    Ok(())
+}
+
+/// Records where a drag left the launcher, as fractions of the display it was
+/// dropped on. Registered as the launcher's [`crate::window_drag`] drop
+/// handler, so it runs once per drag rather than once per frame.
+pub fn persist_dragged<R: Runtime>(app: &AppHandle<R>) {
+    match dragged_anchor(app) {
+        Some(anchor) => {
+            let placement = LauncherPlacement {
+                anchor,
+                ..store::load(app)
+            };
+            if let Err(e) = store::save(app, placement) {
+                log::warn!("[launcher-placement] could not persist dragged position: {e}");
+            }
+        }
+        None => {
+            log::warn!("[launcher-placement] drag ended but the window position was unreadable")
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn dragged_anchor<R: Runtime>(app: &AppHandle<R>) -> Option<LauncherAnchor> {
+    use crate::platform::macos::get_window_frame;
+    use macos_conv::AppKitRect;
+
+    let window = app.get_webview_window(SPOTLIGHT_LABEL)?;
+    let f = get_window_frame(&window);
+    let window_rect = AppKitRect {
+        x: f.origin.x,
+        y: f.origin.y,
+        width: f.size.width,
+        height: f.size.height,
+    };
+    // The display the window ended up on, not the one it started on — a drag
+    // can cross displays.
+    let screen = screen_containing(center_of(window_rect))?;
+    let frames = macos_conv::frames(screen.frame, screen.visible);
+    let offsets = macos_conv::to_offsets(screen.frame, window_rect);
+    let (x, y) = origin_to_fractions(offsets, frames.monitor);
+    Some(LauncherAnchor::Free { x, y })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn dragged_anchor<R: Runtime>(app: &AppHandle<R>) -> Option<LauncherAnchor> {
+    let window = app.get_webview_window(SPOTLIGHT_LABEL)?;
+    let scale = window.scale_factor().ok()?;
+    let pos = window.outer_position().ok()?.to_logical::<f64>(scale);
+    let size = window.outer_size().ok()?.to_logical::<f64>(scale);
+
+    let center = (pos.x + size.width / 2.0, pos.y + size.height / 2.0);
+    let monitor = window
+        .monitor_from_point(center.0, center.1)
+        .ok()
+        .flatten()
+        .or_else(|| window.primary_monitor().ok().flatten())?;
+
+    let (origin, frames) = monitor_frames(&monitor);
+    let offsets = (pos.x - origin.0, pos.y - origin.1);
+    let (x, y) = origin_to_fractions(offsets, frames.monitor);
+    Some(LauncherAnchor::Free { x, y })
+}
+
+// --- monitor selection -----------------------------------------------------
+
+#[cfg(target_os = "macos")]
+struct Screen {
+    frame: macos_conv::AppKitRect,
+    visible: macos_conv::AppKitRect,
+}
+
+#[cfg(target_os = "macos")]
+fn to_screen(m: &monitor::Monitor) -> Screen {
+    let scale = m.scale_factor();
+    let f = m.size().to_logical::<f64>(scale);
+    let p = m.position().to_logical::<f64>(scale);
+    let visible = m.visible_area();
+    let vs = visible.size().to_logical::<f64>(scale);
+    let vp = visible.position().to_logical::<f64>(scale);
+    Screen {
+        frame: macos_conv::AppKitRect {
+            x: p.x,
+            y: p.y,
+            width: f.width,
+            height: f.height,
+        },
+        visible: macos_conv::AppKitRect {
+            x: vp.x,
+            y: vp.y,
+            width: vs.width,
+            height: vs.height,
+        },
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn pick_screen(choice: LauncherMonitorChoice) -> Option<Screen> {
+    match choice {
+        LauncherMonitorChoice::Cursor => monitor::get_monitor_with_cursor()
+            .as_ref()
+            .map(to_screen)
+            .or_else(|| pick_screen(LauncherMonitorChoice::Primary)),
+        LauncherMonitorChoice::Primary => monitor::get_monitors()
+            .iter()
+            .find(|m| m.is_primary())
+            .map(to_screen),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn center_of(r: macos_conv::AppKitRect) -> (f64, f64) {
+    (r.x + r.width / 2.0, r.y + r.height / 2.0)
+}
+
+#[cfg(target_os = "macos")]
+fn screen_containing(point: (f64, f64)) -> Option<Screen> {
+    let monitors = monitor::get_monitors();
+    monitors
+        .iter()
+        .find(|m| {
+            let s = to_screen(m);
+            point.0 >= s.frame.x
+                && point.0 < s.frame.x + s.frame.width
+                && point.1 >= s.frame.y
+                && point.1 < s.frame.y + s.frame.height
+        })
+        .or_else(|| monitors.iter().find(|m| m.is_primary()))
+        .map(to_screen)
+}
+
+/// Cursor-monitor lookup on Windows/Linux. This is new with #596 — both
+/// platforms previously hardcoded the primary display, which is the "it always
+/// opens on the wrong screen" half of the issue.
+#[cfg(not(target_os = "macos"))]
+fn pick_monitor<R: Runtime>(
+    app: &AppHandle<R>,
+    window: &tauri::WebviewWindow<R>,
+    choice: LauncherMonitorChoice,
+) -> Option<tauri::Monitor> {
+    let primary = || window.primary_monitor().ok().flatten();
+    match choice {
+        LauncherMonitorChoice::Primary => primary(),
+        LauncherMonitorChoice::Cursor => app
+            .cursor_position()
+            .ok()
+            .and_then(|p| window.monitor_from_point(p.x, p.y).ok().flatten())
+            .or_else(primary),
+    }
+}
+
+/// A Tauri monitor's absolute logical origin, plus its frames in the neutral
+/// (monitor-relative) space.
+#[cfg(not(target_os = "macos"))]
+fn monitor_frames(m: &tauri::Monitor) -> ((f64, f64), Frames) {
+    let scale = m.scale_factor();
+    let size = m.size().to_logical::<f64>(scale);
+    let pos = m.position().to_logical::<f64>(scale);
+    let work = m.work_area();
+    let work_pos = work.position.to_logical::<f64>(scale);
+    let work_size = work.size.to_logical::<f64>(scale);
+
+    (
+        (pos.x, pos.y),
+        Frames {
+            monitor: Rect::new(0.0, 0.0, size.width, size.height),
+            work: Rect::new(
+                work_pos.x - pos.x,
+                work_pos.y - pos.y,
+                work_size.width,
+                work_size.height,
+            ),
+        },
+    )
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod macos_tests {
+    use super::macos_conv::*;
+    use super::*;
+
+    /// The built-in display: AppKit origin (0,0), 25px menu bar at the top.
+    fn builtin() -> (AppKitRect, AppKitRect) {
+        (
+            AppKitRect {
+                x: 0.0,
+                y: 0.0,
+                width: 1920.0,
+                height: 1080.0,
+            },
+            AppKitRect {
+                x: 0.0,
+                y: 0.0,
+                width: 1920.0,
+                height: 1055.0,
+            },
+        )
+    }
+
+    /// A display stacked *above* the built-in one: in AppKit its origin.y is
+    /// positive. This is the layout the neutral space exists to get right.
+    fn above() -> (AppKitRect, AppKitRect) {
+        (
+            AppKitRect {
+                x: 0.0,
+                y: 1080.0,
+                width: 2560.0,
+                height: 1440.0,
+            },
+            AppKitRect {
+                x: 0.0,
+                y: 1080.0,
+                width: 2560.0,
+                height: 1440.0,
+            },
+        )
+    }
+
+    #[test]
+    fn work_area_inset_is_measured_downward_from_the_screen_top() {
+        let (screen, visible) = builtin();
+        let f = frames(screen, visible);
+        assert_eq!(f.monitor, Rect::new(0.0, 0.0, 1920.0, 1080.0));
+        assert_eq!(
+            f.work,
+            Rect::new(0.0, 25.0, 1920.0, 1055.0),
+            "the 25px menu bar sits at the top in the neutral space, even though AppKit measures the visible frame from the bottom"
+        );
+    }
+
+    #[test]
+    fn to_appkit_origin_reproduces_the_pre_596_position() {
+        // The old center_at_cursor_monitor: top edge at 16% from the top.
+        let (screen, _) = builtin();
+        let (_, y) = to_appkit_origin(screen, (560.0, 1080.0 * 0.16), 480.0);
+        let old = (screen.y + screen.height - screen.height * 0.16) - 480.0;
+        assert_eq!(y, old);
+    }
+
+    #[test]
+    fn to_appkit_origin_handles_a_screen_above_the_primary() {
+        let (screen, _) = above();
+        let (x, y) = to_appkit_origin(screen, (100.0, 200.0), 480.0);
+        assert_eq!(x, 100.0);
+        assert_eq!(y, 1080.0 + 1440.0 - 200.0 - 480.0);
+    }
+
+    #[test]
+    fn offsets_round_trip_through_the_appkit_origin() {
+        for (screen, _) in [builtin(), above()] {
+            let offsets = (321.0, 654.0);
+            let (x, y) = to_appkit_origin(screen, offsets, 480.0);
+            let window = AppKitRect {
+                x,
+                y,
+                width: 800.0,
+                height: 480.0,
+            };
+            assert_eq!(to_offsets(screen, window), offsets);
+        }
+    }
+
+    #[test]
+    fn a_window_at_the_screen_top_left_has_zero_offsets() {
+        let (screen, _) = above();
+        let window = AppKitRect {
+            x: screen.x,
+            y: screen.top() - 480.0,
+            width: 800.0,
+            height: 480.0,
+        };
+        assert_eq!(to_offsets(screen, window), (0.0, 0.0));
+    }
+}

--- a/asyar-launcher/src-tauri/src/launcher_placement/service.rs
+++ b/asyar-launcher/src-tauri/src/launcher_placement/service.rs
@@ -12,7 +12,10 @@
 //!   — *not* Tauri's normalised coordinates — and the reveal path positions
 //!   the panel with `set_window_frame` rather than `set_position`, because the
 //!   flash-free reveal machinery in `platform::macos::window` is written
-//!   against `NSRect`. Both directions go through [`macos_conv`].
+//!   against `NSRect`. Both directions go through the `macos_conv` submodule.
+//!   (Not an intra-doc link: that module is `cfg(target_os = "macos")`, so the
+//!   link would be unresolvable when these docs are built for any other
+//!   target — and `cargo doc` runs with `-D warnings` in CI.)
 //! - **Windows/Linux** use Tauri's monitor APIs, which are already top-left
 //!   y-down, so the conversion is an origin offset.
 

--- a/asyar-launcher/src-tauri/src/launcher_placement/store.rs
+++ b/asyar-launcher/src-tauri/src/launcher_placement/store.rs
@@ -10,6 +10,15 @@
 //! Reads are fail-soft in the style of `lib::parse_launch_view`: a missing
 //! file, an unreadable store, or a value written by a future version all
 //! resolve to the default rather than failing a reveal.
+//!
+//! ## Deliberately not backed up or synced
+//!
+//! `SettingsSyncProvider` exports `settingsService.getSettings()` — the
+//! frontend's `settings` blob — so this sibling key is *not* carried by
+//! profile backup, restore, or sync. That is intended, not an oversight:
+//! where the launcher sits is a per-machine choice, tied to the displays in
+//! front of you, and restoring a 27"-derived position onto a laptop is not a
+//! favour. Do not add a sync provider for it without asking first.
 
 use super::types::LauncherPlacement;
 use crate::error::AppError;

--- a/asyar-launcher/src-tauri/src/launcher_placement/store.rs
+++ b/asyar-launcher/src-tauri/src/launcher_placement/store.rs
@@ -1,0 +1,130 @@
+//! Persistence for [`LauncherPlacement`].
+//!
+//! Lives in `settings.dat` under its **own top-level key**, deliberately not
+//! inside the `settings` blob that the frontend owns: `settingsService`
+//! rewrites that blob wholesale (`store.set('settings', snapshot)`), so a
+//! Rust read-modify-write of the same key during a drag could drop a
+//! concurrent edit made in the settings window. `auth::token_store` owns its
+//! keys in the same store for the same reason.
+//!
+//! Reads are fail-soft in the style of `lib::parse_launch_view`: a missing
+//! file, an unreadable store, or a value written by a future version all
+//! resolve to the default rather than failing a reveal.
+
+use super::types::LauncherPlacement;
+use crate::error::AppError;
+use tauri::{AppHandle, Runtime};
+use tauri_plugin_store::StoreExt;
+
+/// Top-level key inside `settings.dat`.
+pub const PLACEMENT_KEY: &str = "launcherPlacement";
+
+const STORE_FILE: &str = "settings.dat";
+
+/// Reads the persisted placement, falling back to the default on any problem.
+pub fn load<R: Runtime>(app: &AppHandle<R>) -> LauncherPlacement {
+    let Ok(store) = app.store(STORE_FILE) else {
+        return LauncherPlacement::default();
+    };
+    parse_placement(store.get(PLACEMENT_KEY).as_ref())
+}
+
+/// Writes the placement, sanitising first so nothing out-of-range reaches
+/// disk. `save` is explicit: the plugin's autosave would otherwise leave a
+/// drag unpersisted across a crash.
+pub fn save<R: Runtime>(app: &AppHandle<R>, placement: LauncherPlacement) -> Result<(), AppError> {
+    let store = app
+        .store(STORE_FILE)
+        .map_err(|e| AppError::Other(format!("Failed to open {STORE_FILE}: {e}")))?;
+    let value = serde_json::to_value(placement.sanitized())
+        .map_err(|e| AppError::Other(format!("Failed to serialize launcher placement: {e}")))?;
+    store.set(PLACEMENT_KEY, value);
+    store
+        .save()
+        .map_err(|e| AppError::Other(format!("Failed to save {STORE_FILE}: {e}")))?;
+    Ok(())
+}
+
+/// Pure JSON-navigation half of [`load`], extracted so the fallback behaviour
+/// is testable without a Tauri app.
+pub fn parse_placement(raw: Option<&serde_json::Value>) -> LauncherPlacement {
+    raw.and_then(|v| serde_json::from_value::<LauncherPlacement>(v.clone()).ok())
+        .unwrap_or_default()
+        .sanitized()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::types::{LauncherAnchor, LauncherMonitorChoice, DEFAULT_TOP_BIAS};
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn absent_key_yields_the_default() {
+        assert_eq!(parse_placement(None), LauncherPlacement::default());
+    }
+
+    #[test]
+    fn malformed_value_yields_the_default() {
+        let v = json!("top-left, please");
+        assert_eq!(parse_placement(Some(&v)), LauncherPlacement::default());
+    }
+
+    #[test]
+    fn unknown_anchor_kind_yields_the_default() {
+        // What a downgrade from a future version would see.
+        let v = json!({ "monitor": "cursor", "anchor": { "kind": "magnetic" } });
+        assert_eq!(parse_placement(Some(&v)), LauncherPlacement::default());
+    }
+
+    #[test]
+    fn reads_a_free_anchor() {
+        let v = json!({
+            "monitor": "primary",
+            "anchor": { "kind": "free", "x": 0.2, "y": 0.7 },
+        });
+        assert_eq!(
+            parse_placement(Some(&v)),
+            LauncherPlacement {
+                monitor: LauncherMonitorChoice::Primary,
+                anchor: LauncherAnchor::Free { x: 0.2, y: 0.7 },
+            }
+        );
+    }
+
+    #[test]
+    fn out_of_range_values_are_normalised_on_read() {
+        let v = json!({
+            "monitor": "cursor",
+            "anchor": { "kind": "topWeighted", "bias": 9.0 },
+        });
+        assert_eq!(
+            parse_placement(Some(&v)).anchor,
+            LauncherAnchor::TopWeighted { bias: 1.0 }
+        );
+    }
+
+    #[test]
+    fn a_null_bias_yields_the_default() {
+        let v = json!({
+            "monitor": "cursor",
+            "anchor": { "kind": "topWeighted", "bias": null },
+        });
+        assert_eq!(
+            parse_placement(Some(&v)).anchor,
+            LauncherAnchor::TopWeighted {
+                bias: DEFAULT_TOP_BIAS
+            }
+        );
+    }
+
+    #[test]
+    fn round_trips_what_save_would_write() {
+        let p = LauncherPlacement {
+            monitor: LauncherMonitorChoice::Primary,
+            anchor: LauncherAnchor::Centered,
+        };
+        let v = serde_json::to_value(p).unwrap();
+        assert_eq!(parse_placement(Some(&v)), p);
+    }
+}

--- a/asyar-launcher/src-tauri/src/launcher_placement/types.rs
+++ b/asyar-launcher/src-tauri/src/launcher_placement/types.rs
@@ -1,0 +1,160 @@
+//! The persisted description of *where the launcher appears*.
+//!
+//! Deliberately a description, not coordinates: the same value has to make
+//! sense on a 13" laptop and a 27" display, before and after a resolution
+//! change. [`resolve_origin`](super::resolve::resolve_origin) turns it into
+//! pixels against whichever monitor the reveal picked.
+
+use serde::{Deserialize, Serialize};
+
+/// Today's vertical placement: top edge at 16% of the monitor's height.
+pub const DEFAULT_TOP_BIAS: f64 = 0.16;
+
+/// Which display the launcher opens on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum LauncherMonitorChoice {
+    /// The display the mouse pointer is currently on. The default, and what
+    /// macOS has always done — Windows and Linux only gained it with this
+    /// feature.
+    #[default]
+    Cursor,
+    /// Always the primary display, wherever the pointer is.
+    Primary,
+}
+
+/// Where within the chosen display the launcher sits.
+///
+/// `Free` is the drag result and stores **fractions of the monitor**, not
+/// pixels. Pixels would put the launcher off-screen the first time a display
+/// is unplugged or a resolution changes, with no way back except a reset;
+/// fractions land in the same relative spot on any display and are clamped
+/// into the work area on every reveal.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, specta::Type)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum LauncherAnchor {
+    /// Horizontally centred; top edge at `bias` of the monitor's height.
+    TopWeighted { bias: f64 },
+    /// Centred on both axes.
+    Centered,
+    /// Free position from a drag, as fractions of the monitor for the
+    /// window's top-left corner.
+    Free { x: f64, y: f64 },
+}
+
+impl Default for LauncherAnchor {
+    fn default() -> Self {
+        Self::TopWeighted {
+            bias: DEFAULT_TOP_BIAS,
+        }
+    }
+}
+
+impl LauncherAnchor {
+    /// Coerces values that arrived from disk (or a buggy caller) into the
+    /// ranges the resolver assumes. Anything non-finite falls back to the
+    /// default rather than propagating a NaN into window geometry.
+    pub fn sanitized(self) -> Self {
+        match self {
+            Self::TopWeighted { bias } => Self::TopWeighted {
+                bias: sanitize_fraction(bias).unwrap_or(DEFAULT_TOP_BIAS),
+            },
+            Self::Centered => Self::Centered,
+            Self::Free { x, y } => match (sanitize_fraction(x), sanitize_fraction(y)) {
+                (Some(x), Some(y)) => Self::Free { x, y },
+                _ => Self::default(),
+            },
+        }
+    }
+}
+
+/// `Some(v)` clamped to 0..=1, or `None` if the value is not a real number.
+fn sanitize_fraction(v: f64) -> Option<f64> {
+    if v.is_finite() {
+        Some(v.clamp(0.0, 1.0))
+    } else {
+        None
+    }
+}
+
+/// The whole user-facing placement preference. Default reproduces the
+/// pre-#596 behaviour exactly, so an install that never opens the setting
+/// sees no change.
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct LauncherPlacement {
+    pub monitor: LauncherMonitorChoice,
+    pub anchor: LauncherAnchor,
+}
+
+impl LauncherPlacement {
+    pub fn sanitized(self) -> Self {
+        Self {
+            monitor: self.monitor,
+            anchor: self.anchor.sanitized(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_reproduces_pre_596_behaviour() {
+        let p = LauncherPlacement::default();
+        assert_eq!(p.monitor, LauncherMonitorChoice::Cursor);
+        assert_eq!(p.anchor, LauncherAnchor::TopWeighted { bias: 0.16 });
+    }
+
+    #[test]
+    fn sanitize_clamps_out_of_range_bias() {
+        let a = LauncherAnchor::TopWeighted { bias: 4.2 }.sanitized();
+        assert_eq!(a, LauncherAnchor::TopWeighted { bias: 1.0 });
+    }
+
+    #[test]
+    fn sanitize_replaces_nan_bias_with_default() {
+        let a = LauncherAnchor::TopWeighted { bias: f64::NAN }.sanitized();
+        assert_eq!(
+            a,
+            LauncherAnchor::TopWeighted {
+                bias: DEFAULT_TOP_BIAS
+            }
+        );
+    }
+
+    #[test]
+    fn sanitize_clamps_free_fractions() {
+        let a = LauncherAnchor::Free { x: -0.5, y: 1.5 }.sanitized();
+        assert_eq!(a, LauncherAnchor::Free { x: 0.0, y: 1.0 });
+    }
+
+    #[test]
+    fn sanitize_replaces_non_finite_free_with_default() {
+        let a = LauncherAnchor::Free {
+            x: f64::INFINITY,
+            y: 0.5,
+        }
+        .sanitized();
+        assert_eq!(a, LauncherAnchor::default());
+    }
+
+    #[test]
+    fn serializes_with_a_tagged_anchor() {
+        let json = serde_json::to_value(LauncherPlacement::default()).unwrap();
+        assert_eq!(json["monitor"], "cursor");
+        assert_eq!(json["anchor"]["kind"], "topWeighted");
+        assert_eq!(json["anchor"]["bias"], 0.16);
+    }
+
+    #[test]
+    fn round_trips_a_free_anchor() {
+        let p = LauncherPlacement {
+            monitor: LauncherMonitorChoice::Primary,
+            anchor: LauncherAnchor::Free { x: 0.25, y: 0.4 },
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        assert_eq!(serde_json::from_str::<LauncherPlacement>(&json).unwrap(), p);
+    }
+}

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -110,6 +110,7 @@ pub mod files_scope;
 pub mod fs_watcher;
 pub mod hud_window;
 pub mod index_events;
+pub mod launcher_placement;
 pub mod mcp;
 pub mod network;
 mod notes_export;
@@ -144,6 +145,7 @@ pub mod tray;
 pub mod uri_schemes;
 pub mod usage;
 pub mod walkthrough;
+pub mod window_drag;
 pub mod window_management;
 
 pub const SPOTLIGHT_LABEL: &str = "main";
@@ -538,12 +540,14 @@ pub fn run() {
             storage::commands::note_backlinks,
             storage::commands::note_export_markdown,
             // Sticky notes (one always-on-top window per pinned note)
+            window_drag::window_drag_start,
+            window_drag::window_drag_move,
+            window_drag::window_drag_end,
+            launcher_placement::commands::get_launcher_placement,
+            launcher_placement::commands::set_launcher_placement,
             sticky_window::sticky_open,
             sticky_window::sticky_close,
             sticky_window::sticky_new,
-            sticky_window::sticky_drag_start,
-            sticky_window::sticky_drag_move,
-            sticky_window::sticky_drag_end,
             sticky_window::sticky_is_stuck,
             sticky_window::sticky_list,
             sticky_window::sticky_save_geometry,
@@ -1226,6 +1230,16 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_os = "macos")]
     crate::platform::macos::install_appearance_observer(handle);
 
+    // Dragging the launcher by its search header rewrites the saved
+    // placement, but only once the pointer is released — `window_drag` fires
+    // this on drop, not on every frame, so a drag is one store write.
+    {
+        let handle_for_drop = handle.clone();
+        window_drag::register_drop_handler(SPOTLIGHT_LABEL, move || {
+            launcher_placement::service::persist_dragged(&handle_for_drop);
+        });
+    }
+
     // Seed the launcher geometry from the persisted launchView BEFORE the
     // first panel.show(), so compact users never see the 480→96 reflow that
     // a JS-side crop would produce (settings load sits behind appInitializer).
@@ -1774,7 +1788,11 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 #[cfg(not(target_os = "macos"))]
                 {
                     use tauri::{LogicalSize, Size};
-                    let height = if compact { 96.0 } else { 480.0 };
+                    let height = if compact {
+                        96.0
+                    } else {
+                        crate::launcher_placement::LAUNCHER_MAX_HEIGHT
+                    };
                     if let Ok(size) = window.inner_size() {
                         let scale = window.scale_factor().unwrap_or(1.0);
                         let logical_width = size.width as f64 / scale;

--- a/asyar-launcher/src-tauri/src/platform/macos/window.rs
+++ b/asyar-launcher/src-tauri/src/platform/macos/window.rs
@@ -340,8 +340,10 @@ pub fn park_launcher_panel<R: Runtime>(window: &WebviewWindow<R>, panel: &Panel)
 /// rebuild the responder chain and under this lifecycle every show is one.
 pub fn reveal_launcher_panel<R: Runtime>(window: &WebviewWindow<R>, panel: &Panel) {
     set_ignores_mouse_events(window, false);
-    if let Err(e) = center_at_cursor_monitor(window) {
-        log::warn!("[launcher-reveal] center_at_cursor_monitor failed: {e}; revealing at previous position");
+    if let Err(e) = position_launcher(window) {
+        log::warn!(
+            "[launcher-reveal] position_launcher failed: {e}; revealing at previous position"
+        );
     }
     panel.show();
     set_window_alpha(window, 1.0);
@@ -1155,23 +1157,16 @@ fn schedule_on_next_pre_commit<F: FnOnce() + 'static>(f: F) {
     }
 }
 
-pub fn center_at_cursor_monitor<R: Runtime>(window: &WebviewWindow<R>) -> tauri::Result<()> {
-    let monitor =
-        monitor::get_monitor_with_cursor().ok_or_else(|| tauri::Error::FailedToReceiveMessage)?;
-    let monitor_scale_factor = monitor.scale_factor();
-    let monitor_size = monitor.size().to_logical::<f64>(monitor_scale_factor);
-    let monitor_position = monitor.position().to_logical::<f64>(monitor_scale_factor);
-    let window_frame = get_window_frame(window);
-    let top_y = monitor_position.y + monitor_size.height - (monitor_size.height * 0.16);
-    let rect = NSRect {
-        origin: NSPoint {
-            x: (monitor_position.x + (monitor_size.width / 2.0)) - (window_frame.size.width / 2.0),
-            y: top_y - window_frame.size.height,
-        },
-        size: window_frame.size,
-    };
-    set_window_frame(window, rect);
-    Ok(())
+/// Places the launcher for a reveal, honouring the user's saved placement.
+///
+/// This used to be `center_at_cursor_monitor`, which hardcoded "centred on the
+/// cursor's monitor, 16% down". That formula now lives — as the default —
+/// in [`crate::launcher_placement::resolve`], alongside the drag position and
+/// the Settings choices.
+pub fn position_launcher<R: Runtime>(
+    window: &WebviewWindow<R>,
+) -> Result<(), crate::error::AppError> {
+    crate::launcher_placement::service::apply(window.app_handle())
 }
 #[cfg(test)]
 mod tests {

--- a/asyar-launcher/src-tauri/src/search_engine/models.rs
+++ b/asyar-launcher/src-tauri/src/search_engine/models.rs
@@ -507,7 +507,10 @@ mod bindings_export {
             .register::<crate::agents::editor::AgentProviderDescriptor>()
             .register::<crate::agents::runner::AgentRunConfig>()
             .register::<crate::agents::runner::AgentStreamEvent>()
-            .register::<crate::system_actions::SystemAction>();
+            .register::<crate::system_actions::SystemAction>()
+            .register::<crate::launcher_placement::LauncherPlacement>()
+            .register::<crate::launcher_placement::LauncherMonitorChoice>()
+            .register::<crate::launcher_placement::LauncherAnchor>();
 
         Typescript::default()
             .bigint(BigIntExportBehavior::Number)

--- a/asyar-launcher/src-tauri/src/sticky_window.rs
+++ b/asyar-launcher/src-tauri/src/sticky_window.rs
@@ -22,7 +22,11 @@ const CASCADE_STEP: f64 = 28.0;
 const REVEAL_FALLBACK_MS: u64 = 400;
 
 /// Deterministic window label so an already-open sticky can be found, focused,
-/// and closed by note id alone.
+/// and closed by note id alone. It is also what the frontend passes to
+/// [`crate::window_drag`] to drag a note by its title bar — the per-note
+/// `sticky_drag_*` commands that used to live here were generalised into that
+/// module when the launcher needed the same behaviour. Position is still
+/// persisted by the `WindowEvent::Moved` listener below, not by the drag.
 pub fn window_label(note_id: &str) -> String {
     format!("{LABEL_PREFIX}{note_id}")
 }
@@ -100,16 +104,6 @@ fn persist_geometry(app: &AppHandle, note_id: &str) {
         return;
     };
     let _ = sticky_notes::save_geometry(&conn, note_id, pos.x, pos.y, size.width, size.height);
-}
-
-/// Window position captured at mousedown, per note, so each drag frame can be
-/// applied as an absolute offset from where the drag started (rather than
-/// accumulating per-frame deltas, which drifts).
-fn drag_anchors() -> &'static std::sync::Mutex<std::collections::HashMap<String, (f64, f64)>> {
-    static STATE: std::sync::OnceLock<
-        std::sync::Mutex<std::collections::HashMap<String, (f64, f64)>>,
-    > = std::sync::OnceLock::new();
-    STATE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
 }
 
 /// Debounced geometry save — the last move/resize in a burst wins.
@@ -341,55 +335,6 @@ pub fn sticky_new(
     open(&app, &note.id)?;
     crate::storage::commands::emit_note_changed(&app, &note.id);
     Ok(note.id)
-}
-
-/// Begin a drag: remember where the window currently is.
-///
-/// Dragging is done manually rather than with `data-tauri-drag-region` because
-/// these windows are converted to `NSPanel`s on macOS, and the native
-/// `startDragging` path (`performWindowDragWithEvent:`) is not something we can
-/// rely on there. Anchor + absolute offset is deterministic on every platform.
-#[tauri::command]
-pub fn sticky_drag_start(note_id: String, app: AppHandle) -> Result<(), AppError> {
-    let Some(window) = app.get_webview_window(&window_label(&note_id)) else {
-        return Ok(());
-    };
-    let (Ok(scale), Ok(pos)) = (window.scale_factor(), window.outer_position()) else {
-        return Ok(());
-    };
-    let pos = pos.to_logical::<f64>(scale);
-    if let Ok(mut anchors) = drag_anchors().lock() {
-        anchors.insert(note_id, (pos.x, pos.y));
-    }
-    Ok(())
-}
-
-/// Move the window to `anchor + (dx, dy)`, where the deltas are screen-space
-/// pixels accumulated since [`sticky_drag_start`].
-#[tauri::command]
-pub fn sticky_drag_move(note_id: String, dx: f64, dy: f64, app: AppHandle) -> Result<(), AppError> {
-    let anchor = drag_anchors()
-        .lock()
-        .ok()
-        .and_then(|anchors| anchors.get(&note_id).copied());
-    let Some((anchor_x, anchor_y)) = anchor else {
-        return Ok(());
-    };
-    let Some(window) = app.get_webview_window(&window_label(&note_id)) else {
-        return Ok(());
-    };
-    let _ = window.set_position(tauri::LogicalPosition::new(anchor_x + dx, anchor_y + dy));
-    Ok(())
-}
-
-/// Drop the drag anchor. The `Moved` events emitted during the drag already
-/// scheduled the debounced geometry save, so there's nothing to persist here.
-#[tauri::command]
-pub fn sticky_drag_end(note_id: String) -> Result<(), AppError> {
-    if let Ok(mut anchors) = drag_anchors().lock() {
-        anchors.remove(&note_id);
-    }
-    Ok(())
 }
 
 #[tauri::command]

--- a/asyar-launcher/src-tauri/src/window_drag.rs
+++ b/asyar-launcher/src-tauri/src/window_drag.rs
@@ -1,0 +1,222 @@
+//! Dragging a borderless window by a region of its own content.
+//!
+//! `data-tauri-drag-region` is not an option here. Both windows that need this
+//! — the launcher and sticky notes — are converted to `NSPanel`s on macOS, and
+//! the native `startDragging` path (`performWindowDragWithEvent:`) is not
+//! something we can rely on there. So the frontend sends screen-space deltas
+//! and this module applies them as an **absolute offset from an anchor**
+//! captured at pointerdown. Absolute-from-anchor rather than per-frame deltas:
+//! deltas accumulate rounding error and the window drifts away from the
+//! cursor over a long drag.
+//!
+//! Windows opt into "do something once the drag ends" by registering a drop
+//! handler at startup, rather than this module knowing which windows care —
+//! the launcher persists its new position that way
+//! ([`crate::launcher_placement::service::persist_dragged`]), while sticky
+//! notes need nothing here because their `WindowEvent::Moved` listener already
+//! schedules a debounced geometry save.
+
+use crate::error::AppError;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+use tauri::{AppHandle, Manager};
+
+/// Runs once when a drag on the given window label finishes. It captures its
+/// own `AppHandle` at registration time, which keeps this module free of
+/// runtime generics and keeps the registry unit-testable. `Arc` rather than
+/// `Box` so [`run_drop_handler`] can clone the handler out and invoke it with
+/// the registry lock released.
+type DropHandler = Arc<dyn Fn() + Send + Sync>;
+
+/// Window origin (logical, top-left) captured at pointerdown, keyed by label.
+fn drag_anchors() -> &'static Mutex<HashMap<String, (f64, f64)>> {
+    static STATE: OnceLock<Mutex<HashMap<String, (f64, f64)>>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn drop_handlers() -> &'static Mutex<HashMap<String, DropHandler>> {
+    static STATE: OnceLock<Mutex<HashMap<String, DropHandler>>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Registers `handler` to run after a drag of `label` ends. Call from setup.
+/// Registering twice for the same label replaces the first handler.
+pub fn register_drop_handler(label: impl Into<String>, handler: impl Fn() + Send + Sync + 'static) {
+    if let Ok(mut map) = drop_handlers().lock() {
+        map.insert(label.into(), Arc::new(handler));
+    }
+}
+
+/// Where the window should sit for a drag that has moved `(dx, dy)` since it
+/// started at `anchor`.
+fn target_origin(anchor: (f64, f64), dx: f64, dy: f64) -> Option<(f64, f64)> {
+    let (x, y) = (anchor.0 + dx, anchor.1 + dy);
+    (x.is_finite() && y.is_finite()).then_some((x, y))
+}
+
+fn set_anchor(label: &str, origin: (f64, f64)) {
+    if let Ok(mut map) = drag_anchors().lock() {
+        map.insert(label.to_string(), origin);
+    }
+}
+
+fn peek_anchor(label: &str) -> Option<(f64, f64)> {
+    drag_anchors().lock().ok()?.get(label).copied()
+}
+
+fn take_anchor(label: &str) -> Option<(f64, f64)> {
+    drag_anchors().lock().ok()?.remove(label)
+}
+
+fn run_drop_handler(label: &str) {
+    // Cloned out and invoked with the lock released: the handler calls back
+    // into window code (the launcher's reads geometry and writes the store)
+    // and must not be holding the registry while it does.
+    let handler = drop_handlers()
+        .lock()
+        .ok()
+        .and_then(|map| map.get(label).cloned());
+    if let Some(handler) = handler {
+        handler();
+    }
+}
+
+/// Begin a drag: remember where the window currently is.
+#[tauri::command]
+pub fn window_drag_start(label: String, app: AppHandle) -> Result<(), AppError> {
+    let Some(window) = app.get_webview_window(&label) else {
+        return Ok(());
+    };
+    let (Ok(scale), Ok(pos)) = (window.scale_factor(), window.outer_position()) else {
+        return Ok(());
+    };
+    let pos = pos.to_logical::<f64>(scale);
+    set_anchor(&label, (pos.x, pos.y));
+    Ok(())
+}
+
+/// Move the window to `anchor + (dx, dy)`, where the deltas are screen-space
+/// pixels accumulated since [`window_drag_start`]. A move with no live anchor
+/// (the drag was never started, or already ended) is a no-op.
+#[tauri::command]
+pub fn window_drag_move(label: String, dx: f64, dy: f64, app: AppHandle) -> Result<(), AppError> {
+    let Some(anchor) = peek_anchor(&label) else {
+        return Ok(());
+    };
+    let Some((x, y)) = target_origin(anchor, dx, dy) else {
+        return Ok(());
+    };
+    let Some(window) = app.get_webview_window(&label) else {
+        return Ok(());
+    };
+    let _ = window.set_position(tauri::LogicalPosition::new(x, y));
+    Ok(())
+}
+
+/// Drop the anchor and let the window's registered drop handler react.
+#[tauri::command]
+pub fn window_drag_end(label: String) -> Result<(), AppError> {
+    if take_anchor(&label).is_some() {
+        run_drop_handler(&label);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    // The registries are process-wide statics and tests run in parallel, so
+    // every test uses a label of its own.
+
+    #[test]
+    fn target_is_the_anchor_plus_the_delta() {
+        assert_eq!(
+            target_origin((100.0, 50.0), 20.0, -10.0),
+            Some((120.0, 40.0))
+        );
+    }
+
+    #[test]
+    fn target_does_not_drift_across_a_long_drag() {
+        // The same total delta must give the same result however it was
+        // accumulated — the reason anchors exist instead of per-frame deltas.
+        let anchor = (100.0, 50.0);
+        let one_shot = target_origin(anchor, 300.0, 200.0);
+        let stepwise = (1..=300).fold(anchor, |_, i| {
+            target_origin(anchor, i as f64, (i as f64) * 2.0 / 3.0).unwrap()
+        });
+        assert_eq!(one_shot, Some(stepwise));
+    }
+
+    #[test]
+    fn target_rejects_a_non_finite_delta() {
+        assert_eq!(target_origin((0.0, 0.0), f64::NAN, 0.0), None);
+        assert_eq!(target_origin((0.0, 0.0), 0.0, f64::INFINITY), None);
+    }
+
+    #[test]
+    fn anchor_round_trips_and_is_consumed_once() {
+        let label = "test-anchor-round-trip";
+        assert_eq!(peek_anchor(label), None);
+        set_anchor(label, (12.0, 34.0));
+        assert_eq!(peek_anchor(label), Some((12.0, 34.0)));
+        assert_eq!(take_anchor(label), Some((12.0, 34.0)));
+        assert_eq!(take_anchor(label), None, "a second end must be a no-op");
+    }
+
+    #[test]
+    fn drop_handler_runs_for_its_own_label_only() {
+        let mine = Arc::new(AtomicUsize::new(0));
+        let theirs = Arc::new(AtomicUsize::new(0));
+
+        let m = mine.clone();
+        register_drop_handler("test-drop-mine", move || {
+            m.fetch_add(1, Ordering::SeqCst);
+        });
+        let t = theirs.clone();
+        register_drop_handler("test-drop-theirs", move || {
+            t.fetch_add(1, Ordering::SeqCst);
+        });
+
+        run_drop_handler("test-drop-mine");
+
+        assert_eq!(mine.load(Ordering::SeqCst), 1);
+        assert_eq!(theirs.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn drop_handler_for_an_unregistered_label_is_a_no_op() {
+        run_drop_handler("test-drop-nobody-registered");
+    }
+
+    #[test]
+    fn ending_a_drag_that_never_started_does_not_fire_the_handler() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let c = count.clone();
+        register_drop_handler("test-drop-never-started", move || {
+            c.fetch_add(1, Ordering::SeqCst);
+        });
+
+        window_drag_end("test-drop-never-started".to_string()).unwrap();
+
+        assert_eq!(count.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn ending_a_started_drag_fires_the_handler_exactly_once() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let c = count.clone();
+        register_drop_handler("test-drop-once", move || {
+            c.fetch_add(1, Ordering::SeqCst);
+        });
+
+        set_anchor("test-drop-once", (0.0, 0.0));
+        window_drag_end("test-drop-once".to_string()).unwrap();
+        window_drag_end("test-drop-once".to_string()).unwrap();
+
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+}

--- a/asyar-launcher/src/bindings.ts
+++ b/asyar-launcher/src/bindings.ts
@@ -214,6 +214,47 @@ export type ItemAlias = {
 	createdAt: number,
 };
 
+/**
+ *  Where within the chosen display the launcher sits.
+ * 
+ *  `Free` is the drag result and stores **fractions of the monitor**, not
+ *  pixels. Pixels would put the launcher off-screen the first time a display
+ *  is unplugged or a resolution changes, with no way back except a reset;
+ *  fractions land in the same relative spot on any display and are clamped
+ *  into the work area on every reveal.
+ */
+export type LauncherAnchor = 
+// Horizontally centred; top edge at `bias` of the monitor's height.
+{ kind: "topWeighted"; bias: number } | 
+// Centred on both axes.
+{ kind: "centered" } | 
+/**
+ *  Free position from a drag, as fractions of the monitor for the
+ *  window's top-left corner.
+ */
+{ kind: "free"; x: number; y: number };
+
+// Which display the launcher opens on.
+export type LauncherMonitorChoice = 
+/**
+ *  The display the mouse pointer is currently on. The default, and what
+ *  macOS has always done — Windows and Linux only gained it with this
+ *  feature.
+ */
+"cursor" | 
+// Always the primary display, wherever the pointer is.
+"primary";
+
+/**
+ *  The whole user-facing placement preference. Default reproduces the
+ *  pre-#596 behaviour exactly, so an install that never opens the setting
+ *  sees no change.
+ */
+export type LauncherPlacement = {
+	monitor: LauncherMonitorChoice,
+	anchor: LauncherAnchor,
+};
+
 export type MergedSearchResponse = {
 	results: SearchResult[],
 	aliasMatch?: AliasMatch | null,

--- a/asyar-launcher/src/components/base/SegmentedControl.svelte
+++ b/asyar-launcher/src/components/base/SegmentedControl.svelte
@@ -2,14 +2,24 @@
   let {
     options,
     value = $bindable(''),
+    onchange,
     onfocus,
     onblur,
   }: {
     options: { value: string; label: string }[];
     value: string;
+    /** For callers that persist the choice rather than binding to local
+     *  state. Fires only on a real change, so a re-click is not a save. */
+    onchange?: (value: string) => void;
     onfocus?: () => void;
     onblur?: () => void;
   } = $props();
+
+  function select(next: string) {
+    if (next === value) return;
+    value = next;
+    onchange?.(next);
+  }
 </script>
 
 <div class="segmented-control" role="radiogroup">
@@ -20,9 +30,7 @@
       aria-checked={value === option.value}
       class="segment"
       class:active={value === option.value}
-      onclick={() => {
-        value = option.value;
-      }}
+      onclick={() => select(option.value)}
       {onfocus}
       {onblur}
     >

--- a/asyar-launcher/src/components/layout/SearchHeader.svelte
+++ b/asyar-launcher/src/components/layout/SearchHeader.svelte
@@ -12,6 +12,7 @@
   import { searchBarAccessoryService } from '../../services/search/searchBarAccessoryService.svelte';
   import { logService } from '../../services/log/logService';
   import { looksLikeAIIntent } from './aiHintIntensity';
+  import { createWindowDragController } from '../../services/launcher/windowDragController';
 
   // Public handle exposed via `bind:accessoryRef={...}` so the global
   // keyboard chain (⌘P) can call togglePopover() from outside this component.
@@ -233,6 +234,27 @@
 
   let accessory = $derived(searchBarAccessoryService.active);
 
+  // The header doubles as the launcher's drag handle — the window is
+  // undecorated, so there is no title bar to grab. The controller ignores
+  // presses that land on the input or a button and only starts once the
+  // pointer clears a few pixels, so click-to-focus still works.
+  const drag = createWindowDragController('main');
+
+  function onHeaderPointerDown(e: PointerEvent) {
+    drag.onPointerDown(e);
+    window.addEventListener('pointermove', onHeaderPointerMove);
+    window.addEventListener('pointerup', onHeaderPointerUp, { once: true });
+  }
+
+  function onHeaderPointerMove(e: PointerEvent) {
+    drag.onPointerMove(e);
+  }
+
+  function onHeaderPointerUp() {
+    window.removeEventListener('pointermove', onHeaderPointerMove);
+    drag.onPointerUp();
+  }
+
   function onAccessoryChange(value: string): void {
     if (!accessory) return;
     searchBarAccessoryService
@@ -242,8 +264,10 @@
 </script>
 
 <div class="search-header">
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     class="relative w-full border-b border-[var(--separator)] flex items-center min-h-[var(--shell-header-h)] px-4 gap-3"
+    onpointerdown={onHeaderPointerDown}
   >
     {#if showBack}
       <button

--- a/asyar-launcher/src/lib/ipc/notesCommands.ts
+++ b/asyar-launcher/src/lib/ipc/notesCommands.ts
@@ -96,19 +96,10 @@ export async function stickyNew(): Promise<string | null> {
   return invokeSafe<string>('sticky_new');
 }
 
-// Manual window dragging. `data-tauri-drag-region` relies on the native
-// startDragging path, which isn't dependable for the NSPanel-converted sticky
-// windows on macOS — anchor-plus-offset works the same on every platform.
-export async function stickyDragStart(noteId: string): Promise<void> {
-  await invokeSafe('sticky_drag_start', { noteId });
-}
-
-export async function stickyDragMove(noteId: string, dx: number, dy: number): Promise<void> {
-  await invokeSafe('sticky_drag_move', { noteId, dx, dy });
-}
-
-export async function stickyDragEnd(noteId: string): Promise<void> {
-  await invokeSafe('sticky_drag_end', { noteId });
+/** The Rust-side window label for a note, and the handle the shared drag
+ *  commands are addressed by. Mirrors `sticky_window::window_label`. */
+export function stickyWindowLabel(noteId: string): string {
+  return `sticky-${noteId}`;
 }
 
 export async function stickyIsStuck(noteId: string): Promise<boolean | null> {

--- a/asyar-launcher/src/lib/ipc/windowCommands.ts
+++ b/asyar-launcher/src/lib/ipc/windowCommands.ts
@@ -1,6 +1,7 @@
 // asyar-launcher/src/lib/ipc/windowCommands.ts
 // Tauri command wrappers, re-exported through ./commands (the barrel).
 import { invokeSafe } from './invokeSafe';
+import type { LauncherPlacement } from '../../bindings';
 
 // ── Window ────────────────────────────────────────────────────────────────────
 
@@ -197,4 +198,35 @@ export async function showHud(args: {
 
 export async function hideHud(): Promise<void> {
   await invokeSafe('hide_hud');
+}
+
+// ── Window dragging ───────────────────────────────────────────────────────────
+// `data-tauri-drag-region` relies on the native startDragging path, which is
+// not dependable for the NSPanel-converted launcher and sticky windows on
+// macOS. Rust instead anchors on the window's position at pointerdown and
+// applies each screen-space delta as an absolute offset — see
+// `src-tauri/src/window_drag.rs`. Callers address a window by its Tauri label.
+
+export async function windowDragStart(label: string): Promise<void> {
+  await invokeSafe('window_drag_start', { label });
+}
+
+export async function windowDragMove(label: string, dx: number, dy: number): Promise<void> {
+  await invokeSafe('window_drag_move', { label, dx, dy });
+}
+
+export async function windowDragEnd(label: string): Promise<void> {
+  await invokeSafe('window_drag_end', { label });
+}
+
+// ── Launcher placement ────────────────────────────────────────────────────────
+
+/** Where the launcher opens. Resolved against the target monitor on every
+ * reveal, so a change takes effect on the next summon. */
+export async function getLauncherPlacement(): Promise<LauncherPlacement | null> {
+  return invokeSafe<LauncherPlacement>('get_launcher_placement');
+}
+
+export async function setLauncherPlacement(placement: LauncherPlacement): Promise<void> {
+  await invokeSafe('set_launcher_placement', { placement });
 }

--- a/asyar-launcher/src/routes/settings/tabs/GeneralTab.svelte
+++ b/asyar-launcher/src/routes/settings/tabs/GeneralTab.svelte
@@ -8,7 +8,10 @@
     AppearanceThemeSelector,
     WindowModeSelector,
     Button,
+    SegmentedControl,
+    SettingsRangeSlider,
   } from '../../../components';
+  import { launcherPlacementService } from '../../../services/launcher/launcherPlacementService.svelte';
   import { onboardingCommands } from '../../../lib/ipc/commands';
   import type { SettingsHandler } from '../settingsHandlers.svelte';
   import { shortcutService } from '../../../built-in-features/shortcuts/shortcutService';
@@ -32,6 +35,15 @@
   let activeThemeId = $state<string | null>(null);
 
   onMount(async () => {
+    // Separate from the theme-extension load below: Rust owns the placement,
+    // so a failure there must not blank the placement controls (and vice
+    // versa).
+    try {
+      await launcherPlacementService.load();
+    } catch (e) {
+      logService.error(`Failed to load launcher placement: ${e}`);
+    }
+
     try {
       const records = await discoverExtensions();
       themeExtensions = (records ?? [])
@@ -77,6 +89,26 @@
     } catch (e) {
       handler.isSaving = false;
       return 'Cannot save, shortcut may be reserved by the OS or another app';
+    }
+  }
+
+  const placement = launcherPlacementService;
+
+  /** Each placement edit is one store write. Persist-then-adopt lives in the
+   *  service, so a failure leaves the previous choice selected rather than a
+   *  setting that isn't on disk. */
+  async function updatePlacement(change: () => Promise<void>, what: string) {
+    try {
+      await change();
+    } catch (error) {
+      logService.error(`Failed to update launcher ${what}: ${error}`);
+      feedbackService.report({
+        source: 'frontend',
+        kind: 'manual',
+        severity: 'error',
+        retryable: false,
+        context: { message: `Could not save the launcher ${what}` },
+      });
     }
   }
 
@@ -157,6 +189,60 @@
   <SettingsFormRow label="Window Mode">
     <WindowModeSelector value={handler.selectedLaunchView} onchange={selectLaunchView} />
   </SettingsFormRow>
+
+  <SettingsFormRow label="Launcher Display" separator>
+    <SegmentedControl
+      options={[
+        { value: 'cursor', label: 'Display with cursor' },
+        { value: 'primary', label: 'Primary display' },
+      ]}
+      value={placement.placement.monitor}
+      onchange={(v) =>
+        updatePlacement(() => placement.setMonitor(v as 'cursor' | 'primary'), 'display')}
+    />
+  </SettingsFormRow>
+
+  <SettingsFormRow label="Launcher Position">
+    <SegmentedControl
+      options={[
+        { value: 'top', label: 'Top' },
+        { value: 'center', label: 'Centre' },
+        { value: 'custom', label: 'Custom' },
+      ]}
+      value={placement.vertical ?? ''}
+      onchange={(v) =>
+        updatePlacement(() => placement.setVertical(v as 'top' | 'center' | 'custom'), 'position')}
+    />
+  </SettingsFormRow>
+
+  {#if placement.vertical === 'custom'}
+    <SettingsFormRow label="Distance from top">
+      <SettingsRangeSlider
+        min={0}
+        max={100}
+        value={placement.biasPercent}
+        suffix="%"
+        onchange={(v) => updatePlacement(() => placement.setBias(v), 'position')}
+      />
+    </SettingsFormRow>
+  {/if}
+
+  {#if placement.isDragged}
+    <SettingsFormRow label="Custom position">
+      <div class="onboarding-row">
+        <span class="onboarding-row__hint">
+          Set by dragging the launcher. Stored relative to the display, so it holds up across
+          screens and resolutions.
+        </span>
+        <Button
+          class="btn-secondary"
+          onclick={() => updatePlacement(() => placement.reset(), 'position')}
+        >
+          Reset
+        </Button>
+      </div>
+    </SettingsFormRow>
+  {/if}
 
   <SettingsFormRow label="Onboarding" separator>
     <div class="onboarding-row">

--- a/asyar-launcher/src/routes/sticky/+page.svelte
+++ b/asyar-launcher/src/routes/sticky/+page.svelte
@@ -6,10 +6,9 @@
     noteUpdate,
     stickyClose,
     stickyNew,
-    stickyDragStart,
-    stickyDragMove,
-    stickyDragEnd,
+    stickyWindowLabel,
   } from '../../lib/ipc/commands';
+  import { createWindowDragController } from '../../services/launcher/windowDragController';
   import '../../resources/styles/style.css';
 
   let noteId = $state<string | null>(null);
@@ -88,40 +87,24 @@
     await stickyNew();
   }
 
-  // Drag the window by its title bar. Screen coordinates are used so the delta
-  // is unaffected by the window moving out from under the cursor mid-drag, and
-  // moves are coalesced to one per animation frame to keep IPC light.
-  let dragOrigin: { x: number; y: number } | null = null;
-  let pendingDelta: { dx: number; dy: number } | null = null;
-  let dragFrame = 0;
+  // Drag the window by its title bar. The mechanics live in the shared
+  // controller — the launcher's search header uses the same one.
+  let drag = $derived(noteId ? createWindowDragController(stickyWindowLabel(noteId)) : null);
 
   function onDragPointerDown(e: PointerEvent) {
-    if (e.button !== 0 || !noteId) return;
-    dragOrigin = { x: e.screenX, y: e.screenY };
-    void stickyDragStart(noteId);
+    if (!drag) return;
+    drag.onPointerDown(e);
     window.addEventListener('pointermove', onDragPointerMove);
     window.addEventListener('pointerup', onDragPointerUp, { once: true });
   }
 
   function onDragPointerMove(e: PointerEvent) {
-    if (!dragOrigin) return;
-    pendingDelta = { dx: e.screenX - dragOrigin.x, dy: e.screenY - dragOrigin.y };
-    if (dragFrame) return;
-    dragFrame = requestAnimationFrame(() => {
-      dragFrame = 0;
-      if (noteId && pendingDelta) void stickyDragMove(noteId, pendingDelta.dx, pendingDelta.dy);
-    });
+    drag?.onPointerMove(e);
   }
 
   function onDragPointerUp() {
     window.removeEventListener('pointermove', onDragPointerMove);
-    if (dragFrame) {
-      cancelAnimationFrame(dragFrame);
-      dragFrame = 0;
-    }
-    dragOrigin = null;
-    pendingDelta = null;
-    if (noteId) void stickyDragEnd(noteId);
+    drag?.onPointerUp();
   }
 </script>
 

--- a/asyar-launcher/src/services/launcher/launcherPlacementService.svelte.ts
+++ b/asyar-launcher/src/services/launcher/launcherPlacementService.svelte.ts
@@ -1,0 +1,105 @@
+import { getLauncherPlacement, setLauncherPlacement } from '../../lib/ipc/commands';
+import type { LauncherAnchor, LauncherMonitorChoice, LauncherPlacement } from '../../bindings';
+
+/**
+ * Mirrors `LauncherPlacement::default()` in
+ * `src-tauri/src/launcher_placement/types.rs` — the pre-#596 behaviour, and
+ * what Rust returns when nothing has been saved. Only used to render before
+ * the real value arrives (and by Reset); Rust remains the source of truth.
+ */
+export const DEFAULT_PLACEMENT: LauncherPlacement = {
+  monitor: 'cursor',
+  anchor: { kind: 'topWeighted', bias: 0.16 },
+};
+
+const DEFAULT_BIAS = 0.16;
+
+/** The three presets the Settings segmented control offers. A dragged
+ *  position is none of them — see {@link LauncherPlacementService.vertical}. */
+export type VerticalPreset = 'top' | 'center' | 'custom';
+
+/**
+ * Presenter for Settings → Appearance → Launcher Position.
+ *
+ * Deliberately thin: it holds the current value for rendering and forwards
+ * edits to Rust, which owns every placement decision. No geometry is computed
+ * here — see `src-tauri/src/launcher_placement/resolve.rs`.
+ */
+export class LauncherPlacementService {
+  placement = $state<LauncherPlacement>(DEFAULT_PLACEMENT);
+  /** False until the persisted value has arrived; gate the UI on it so the
+   *  default doesn't flash through as a selected segment. */
+  loaded = $state(false);
+
+  async load(): Promise<void> {
+    this.placement = (await getLauncherPlacement()) ?? DEFAULT_PLACEMENT;
+    this.loaded = true;
+  }
+
+  /** Which segment is selected, or `null` when the position came from a drag
+   *  and matches no preset. */
+  get vertical(): VerticalPreset | null {
+    const a = this.placement.anchor;
+    if (a.kind === 'centered') return 'center';
+    if (a.kind === 'topWeighted') return a.bias === DEFAULT_BIAS ? 'top' : 'custom';
+    return null;
+  }
+
+  get isDragged(): boolean {
+    return this.placement.anchor.kind === 'free';
+  }
+
+  /** The custom slider's value, as a whole percentage. */
+  get biasPercent(): number {
+    const a = this.placement.anchor;
+    return Math.round((a.kind === 'topWeighted' ? a.bias : DEFAULT_BIAS) * 100);
+  }
+
+  setMonitor(monitor: LauncherMonitorChoice): Promise<void> {
+    return this.commit({ ...this.placement, monitor });
+  }
+
+  setVertical(preset: VerticalPreset): Promise<void> {
+    return this.commit({ ...this.placement, anchor: anchorFor(preset, this.placement.anchor) });
+  }
+
+  setBias(percent: number): Promise<void> {
+    return this.commit({
+      ...this.placement,
+      anchor: { kind: 'topWeighted', bias: clampFraction(percent / 100) },
+    });
+  }
+
+  reset(): Promise<void> {
+    return this.commit(DEFAULT_PLACEMENT);
+  }
+
+  /** Persist first, adopt second: a failed write must not leave the UI
+   *  showing a setting that isn't on disk. */
+  private async commit(next: LauncherPlacement): Promise<void> {
+    await setLauncherPlacement(next);
+    this.placement = next;
+  }
+}
+
+function anchorFor(preset: VerticalPreset, current: LauncherAnchor): LauncherAnchor {
+  switch (preset) {
+    case 'top':
+      return { kind: 'topWeighted', bias: DEFAULT_BIAS };
+    case 'center':
+      return { kind: 'centered' };
+    case 'custom':
+      // Carry the current bias across so the slider appears where the
+      // launcher already is instead of jumping to a default.
+      return {
+        kind: 'topWeighted',
+        bias: current.kind === 'topWeighted' ? current.bias : DEFAULT_BIAS,
+      };
+  }
+}
+
+function clampFraction(v: number): number {
+  return Number.isFinite(v) ? Math.min(1, Math.max(0, v)) : DEFAULT_BIAS;
+}
+
+export const launcherPlacementService = new LauncherPlacementService();

--- a/asyar-launcher/src/services/launcher/launcherPlacementService.test.ts
+++ b/asyar-launcher/src/services/launcher/launcherPlacementService.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/ipc/commands', () => ({
+  getLauncherPlacement: vi.fn(),
+  setLauncherPlacement: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { LauncherPlacementService, DEFAULT_PLACEMENT } from './launcherPlacementService.svelte';
+import { getLauncherPlacement, setLauncherPlacement } from '../../lib/ipc/commands';
+
+describe('LauncherPlacementService', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('starts on the default placement before anything is loaded', () => {
+    const svc = new LauncherPlacementService();
+    expect(svc.placement).toEqual(DEFAULT_PLACEMENT);
+    expect(svc.loaded).toBe(false);
+  });
+
+  it('loads the persisted placement', async () => {
+    vi.mocked(getLauncherPlacement).mockResolvedValueOnce({
+      monitor: 'primary',
+      anchor: { kind: 'centered' },
+    });
+    const svc = new LauncherPlacementService();
+    await svc.load();
+
+    expect(svc.placement).toEqual({ monitor: 'primary', anchor: { kind: 'centered' } });
+    expect(svc.loaded).toBe(true);
+  });
+
+  it('falls back to the default when the command returns nothing', async () => {
+    vi.mocked(getLauncherPlacement).mockResolvedValueOnce(null);
+    const svc = new LauncherPlacementService();
+    await svc.load();
+
+    expect(svc.placement).toEqual(DEFAULT_PLACEMENT);
+    expect(svc.loaded).toBe(true);
+  });
+
+  it('persists a monitor change without touching the anchor', async () => {
+    const svc = new LauncherPlacementService();
+    await svc.setMonitor('primary');
+
+    expect(setLauncherPlacement).toHaveBeenCalledWith({
+      monitor: 'primary',
+      anchor: DEFAULT_PLACEMENT.anchor,
+    });
+    expect(svc.placement.monitor).toBe('primary');
+  });
+
+  it('persists a vertical preset without touching the monitor', async () => {
+    vi.mocked(getLauncherPlacement).mockResolvedValueOnce({
+      monitor: 'primary',
+      anchor: { kind: 'free', x: 0.1, y: 0.9 },
+    });
+    const svc = new LauncherPlacementService();
+    await svc.load();
+    await svc.setVertical('center');
+
+    expect(setLauncherPlacement).toHaveBeenCalledWith({
+      monitor: 'primary',
+      anchor: { kind: 'centered' },
+    });
+  });
+
+  it('carries the current bias into custom mode so the slider does not jump', async () => {
+    const svc = new LauncherPlacementService();
+    await svc.setVertical('custom');
+
+    expect(setLauncherPlacement).toHaveBeenCalledWith({
+      monitor: 'cursor',
+      anchor: { kind: 'topWeighted', bias: 0.16 },
+    });
+  });
+
+  it('converts the slider percentage to a fraction', async () => {
+    const svc = new LauncherPlacementService();
+    await svc.setBias(42);
+
+    expect(setLauncherPlacement).toHaveBeenCalledWith({
+      monitor: 'cursor',
+      anchor: { kind: 'topWeighted', bias: 0.42 },
+    });
+  });
+
+  describe('vertical (the segmented control selection)', () => {
+    it('reports top for the default bias', () => {
+      expect(new LauncherPlacementService().vertical).toBe('top');
+    });
+
+    it('reports custom for any other bias', async () => {
+      vi.mocked(getLauncherPlacement).mockResolvedValueOnce({
+        monitor: 'cursor',
+        anchor: { kind: 'topWeighted', bias: 0.5 },
+      });
+      const svc = new LauncherPlacementService();
+      await svc.load();
+      expect(svc.vertical).toBe('custom');
+    });
+
+    it('reports null for a dragged position, so no segment looks selected', async () => {
+      vi.mocked(getLauncherPlacement).mockResolvedValueOnce({
+        monitor: 'cursor',
+        anchor: { kind: 'free', x: 0.3, y: 0.4 },
+      });
+      const svc = new LauncherPlacementService();
+      await svc.load();
+
+      expect(svc.vertical).toBeNull();
+      expect(svc.isDragged).toBe(true);
+    });
+  });
+
+  it('reset returns the whole placement to the default', async () => {
+    vi.mocked(getLauncherPlacement).mockResolvedValueOnce({
+      monitor: 'primary',
+      anchor: { kind: 'free', x: 0.3, y: 0.4 },
+    });
+    const svc = new LauncherPlacementService();
+    await svc.load();
+    await svc.reset();
+
+    expect(setLauncherPlacement).toHaveBeenCalledWith(DEFAULT_PLACEMENT);
+    expect(svc.isDragged).toBe(false);
+  });
+
+  it('keeps the previous value when a save fails', async () => {
+    vi.mocked(setLauncherPlacement).mockRejectedValueOnce(new Error('disk full'));
+    const svc = new LauncherPlacementService();
+
+    await expect(svc.setMonitor('primary')).rejects.toThrow('disk full');
+    expect(svc.placement).toEqual(DEFAULT_PLACEMENT);
+  });
+});

--- a/asyar-launcher/src/services/launcher/windowDragController.test.ts
+++ b/asyar-launcher/src/services/launcher/windowDragController.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../lib/ipc/commands', () => ({
+  windowDragStart: vi.fn().mockResolvedValue(undefined),
+  windowDragMove: vi.fn().mockResolvedValue(undefined),
+  windowDragEnd: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { createWindowDragController, DRAG_THRESHOLD_PX } from './windowDragController';
+import { windowDragStart, windowDragMove, windowDragEnd } from '../../lib/ipc/commands';
+
+/** Minimal PointerEvent stand-in — jsdom's lacks screenX/screenY plumbing. */
+function pointer(
+  screenX: number,
+  screenY: number,
+  opts: { button?: number; target?: EventTarget | null } = {},
+) {
+  return {
+    button: opts.button ?? 0,
+    screenX,
+    screenY,
+    target: opts.target ?? null,
+  } as unknown as PointerEvent;
+}
+
+/** A pointerdown target that reports itself as `selector`, like a real
+ *  Element would through `closest()`. */
+function elementMatching(selector: string | null): EventTarget {
+  return { closest: (s: string) => (s === selector ? {} : null) } as unknown as EventTarget;
+}
+
+describe('windowDragController', () => {
+  let frames: Array<() => void>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    frames = [];
+    vi.stubGlobal('requestAnimationFrame', (cb: () => void) => {
+      frames.push(cb);
+      return frames.length;
+    });
+    vi.stubGlobal('cancelAnimationFrame', () => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function flushFrame() {
+    const pending = frames;
+    frames = [];
+    pending.forEach((cb) => cb());
+  }
+
+  it('does not start a drag before the pointer clears the threshold', () => {
+    const c = createWindowDragController('main');
+    c.onPointerDown(pointer(100, 100));
+    c.onPointerMove(pointer(100 + DRAG_THRESHOLD_PX - 1, 100));
+    flushFrame();
+
+    expect(windowDragStart).not.toHaveBeenCalled();
+    expect(windowDragMove).not.toHaveBeenCalled();
+  });
+
+  it('keeps a plain click free of any drag IPC', () => {
+    const c = createWindowDragController('main');
+    c.onPointerDown(pointer(100, 100));
+    c.onPointerMove(pointer(101, 100));
+    c.onPointerUp();
+    flushFrame();
+
+    expect(windowDragStart).not.toHaveBeenCalled();
+    expect(windowDragEnd).not.toHaveBeenCalled();
+    expect(c.isDragging()).toBe(false);
+  });
+
+  it('starts the drag once the threshold is crossed', () => {
+    const c = createWindowDragController('main');
+    c.onPointerDown(pointer(100, 100));
+    c.onPointerMove(pointer(100 + DRAG_THRESHOLD_PX + 1, 100));
+    flushFrame();
+
+    expect(windowDragStart).toHaveBeenCalledWith('main');
+    expect(c.isDragging()).toBe(true);
+  });
+
+  it('sends deltas measured from the original pointerdown, not from the threshold', () => {
+    const c = createWindowDragController('main');
+    c.onPointerDown(pointer(100, 100));
+    c.onPointerMove(pointer(150, 130));
+    flushFrame();
+
+    expect(windowDragMove).toHaveBeenCalledWith('main', 50, 30);
+  });
+
+  it('coalesces a burst of moves into one call per frame', () => {
+    const c = createWindowDragController('main');
+    c.onPointerDown(pointer(0, 0));
+    for (let x = 10; x <= 40; x += 10) c.onPointerMove(pointer(x, 0));
+    flushFrame();
+
+    expect(windowDragMove).toHaveBeenCalledTimes(1);
+    expect(windowDragMove).toHaveBeenCalledWith('main', 40, 0);
+  });
+
+  it('ends the drag and reports it finished', () => {
+    const c = createWindowDragController('main');
+    c.onPointerDown(pointer(0, 0));
+    c.onPointerMove(pointer(100, 0));
+    flushFrame();
+    c.onPointerUp();
+
+    expect(windowDragEnd).toHaveBeenCalledWith('main');
+    expect(c.isDragging()).toBe(false);
+  });
+
+  it('drops a queued frame that lands after pointerup', () => {
+    const c = createWindowDragController('main');
+    c.onPointerDown(pointer(0, 0));
+    c.onPointerMove(pointer(100, 0));
+    c.onPointerUp();
+    flushFrame();
+
+    expect(windowDragMove).not.toHaveBeenCalled();
+  });
+
+  it.each(['input', 'button', 'a', '[role="button"]', '[data-no-window-drag]'])(
+    'ignores a pointerdown that started on %s',
+    (selector) => {
+      const c = createWindowDragController('main');
+      c.onPointerDown(pointer(0, 0, { target: elementMatching(selector) }));
+      c.onPointerMove(pointer(200, 200));
+      flushFrame();
+
+      expect(windowDragStart).not.toHaveBeenCalled();
+    },
+  );
+
+  it('ignores a non-primary button', () => {
+    const c = createWindowDragController('main');
+    c.onPointerDown(pointer(0, 0, { button: 2 }));
+    c.onPointerMove(pointer(200, 200));
+    flushFrame();
+
+    expect(windowDragStart).not.toHaveBeenCalled();
+  });
+
+  it('addresses whichever window label it was created for', () => {
+    const c = createWindowDragController('sticky-abc');
+    c.onPointerDown(pointer(0, 0));
+    c.onPointerMove(pointer(100, 0));
+    flushFrame();
+    c.onPointerUp();
+
+    expect(windowDragStart).toHaveBeenCalledWith('sticky-abc');
+    expect(windowDragMove).toHaveBeenCalledWith('sticky-abc', 100, 0);
+    expect(windowDragEnd).toHaveBeenCalledWith('sticky-abc');
+  });
+
+  it('starts a second drag cleanly after the first one ended', () => {
+    const c = createWindowDragController('main');
+    c.onPointerDown(pointer(0, 0));
+    c.onPointerMove(pointer(100, 0));
+    flushFrame();
+    c.onPointerUp();
+
+    c.onPointerDown(pointer(500, 500));
+    c.onPointerMove(pointer(560, 500));
+    flushFrame();
+
+    expect(windowDragStart).toHaveBeenCalledTimes(2);
+    expect(windowDragMove).toHaveBeenLastCalledWith('main', 60, 0);
+  });
+});

--- a/asyar-launcher/src/services/launcher/windowDragController.ts
+++ b/asyar-launcher/src/services/launcher/windowDragController.ts
@@ -1,0 +1,103 @@
+import { windowDragStart, windowDragMove, windowDragEnd } from '../../lib/ipc/commands';
+
+/**
+ * How far the pointer must travel before a press becomes a drag.
+ *
+ * The launcher's drag handle is its search header, which is also the
+ * click-to-focus target for the search input; sticky notes' handle sits beside
+ * their buttons. Without a threshold, the sub-pixel movement in an ordinary
+ * click would nudge the window and swallow the click.
+ */
+export const DRAG_THRESHOLD_PX = 4;
+
+/** A pointerdown inside any of these is the control's, not the window's. */
+const NON_DRAG_SELECTORS = [
+  'input',
+  'textarea',
+  'button',
+  'a',
+  'select',
+  '[role="button"]',
+  '[contenteditable="true"]',
+  '[data-no-window-drag]',
+];
+
+export interface WindowDragController {
+  onPointerDown(e: PointerEvent): void;
+  onPointerMove(e: PointerEvent): void;
+  onPointerUp(): void;
+  /** True between the threshold being crossed and pointerup. */
+  isDragging(): boolean;
+}
+
+/**
+ * Turns pointer events on a drag handle into `window_drag_*` calls for the
+ * window with the given Tauri label.
+ *
+ * Screen coordinates, not client ones: the window moves out from under the
+ * cursor mid-drag, so client deltas would feed back on themselves. Moves are
+ * coalesced to one IPC call per animation frame — a drag emits hundreds of
+ * pointermove events and each call crosses the process boundary.
+ *
+ * Extracted from the component so it can be tested directly; the Svelte side
+ * only forwards events.
+ */
+export function createWindowDragController(label: string): WindowDragController {
+  let origin: { x: number; y: number } | null = null;
+  let dragging = false;
+  let pending: { dx: number; dy: number } | null = null;
+  let frame = 0;
+
+  function startsOnAControl(target: EventTarget | null): boolean {
+    const el = target as { closest?: (s: string) => unknown } | null;
+    if (!el?.closest) return false;
+    return NON_DRAG_SELECTORS.some((selector) => el.closest!(selector) != null);
+  }
+
+  function flush() {
+    frame = 0;
+    if (!dragging || !pending) return;
+    void windowDragMove(label, pending.dx, pending.dy);
+    pending = null;
+  }
+
+  return {
+    onPointerDown(e) {
+      if (e.button !== 0 || startsOnAControl(e.target)) return;
+      origin = { x: e.screenX, y: e.screenY };
+    },
+
+    onPointerMove(e) {
+      if (!origin) return;
+      const dx = e.screenX - origin.x;
+      const dy = e.screenY - origin.y;
+
+      if (!dragging) {
+        if (Math.hypot(dx, dy) <= DRAG_THRESHOLD_PX) return;
+        dragging = true;
+        // The anchor is captured Rust-side now, but the deltas stay measured
+        // from the original pointerdown so the window does not jump by the
+        // threshold distance on the first frame.
+        void windowDragStart(label);
+      }
+
+      pending = { dx, dy };
+      if (frame) return;
+      frame = requestAnimationFrame(flush);
+    },
+
+    onPointerUp() {
+      if (frame) {
+        cancelAnimationFrame(frame);
+        frame = 0;
+      }
+      pending = null;
+      origin = null;
+      if (!dragging) return;
+      dragging = false;
+      void windowDragEnd(label);
+    },
+
+    isDragging: () => dragging,
+  };
+}

--- a/docs/reference/host-settings.md
+++ b/docs/reference/host-settings.md
@@ -58,3 +58,60 @@ The index stops growing at 1,000,000 files and shows a "cap reached" warning in 
 Changing either triggers a background rebuild — the app stays responsive while it runs, and the Settings status card shows progress.
 
 ---
+
+### Launcher Position
+
+By default the launcher opens horizontally centred on the display your cursor
+is on, with its top edge 16% of the way down. **Settings → General** changes
+both halves of that (**Launcher Display** and **Launcher Position**), and you
+can also just drag the window.
+
+#### Launcher Display
+
+| Option                | Behaviour                                                      |
+| --------------------- | -------------------------------------------------------------- |
+| `Display with cursor` | Opens on whichever display the pointer is on. The default.     |
+| `Primary display`     | Always the primary display, wherever the pointer happens to be |
+
+> [!NOTE]
+> Before v0.1.1, `Display with cursor` was macOS-only behaviour and Windows and
+> Linux always used the primary display. Both now honour the setting.
+
+#### Launcher Position
+
+- **Top** — the default, 16% down.
+- **Centre** — centred vertically, measured against the launcher's expanded
+  height so the top edge does not shift when results appear.
+- **Custom** — a slider, 0–100% of the display height.
+
+#### Dragging
+
+Press and drag the launcher's **search header** to move it. A plain click still
+focuses the search field; the drag only begins once the pointer has travelled a
+few pixels, and presses that land on the input or a button are left alone.
+
+Dropping the window saves its position as **fractions of the display**, not
+pixels, so it lands in the same relative spot on a laptop and on an external
+monitor and survives a resolution change. The saved position is clamped into
+the display's work area on every summon — the launcher can never open under the
+menu bar or off the bottom edge, and it always leaves room for its expanded
+height. **Reset** in Settings returns it to the default.
+
+#### Where it is stored
+
+`settings.dat`, under a top-level `launcherPlacement` key that Rust owns
+(separate from the frontend's `settings` blob):
+
+```json
+{
+  "monitor": "cursor",
+  "anchor": { "kind": "topWeighted", "bias": 0.16 }
+}
+```
+
+`anchor.kind` is one of `topWeighted` (with `bias`), `centered`, or `free`
+(with `x` and `y` fractions, written by a drag). Anything missing or
+unrecognised falls back to the default, so a hand-edited or downgraded file
+cannot leave the launcher unreachable.
+
+---


### PR DESCRIPTION
Position was recomputed on every reveal from a formula hardcoded in two
platform-specific places. Rust now owns it: one pure resolver, one
persisted LauncherPlacement, honoured by both reveal paths.

- drag by the search header, via a shared window_drag module that
  sticky notes also moves onto (NSPanel rules out data-tauri-drag-region)
- Settings > General: display choice + top/centre/custom placement
- cursor-monitor selection now works on Windows and Linux too
- dragged positions store as monitor fractions and clamp to the work
  area, reserving the expanded height

Closes #596