### PR TITLE
feat(benchmarks): deep-idle metrics + floor fix

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -9,26 +9,30 @@ instrumentation inside Asyar that Raycast wouldn't have.
                  ┌─────────────────────────────────────────────┐
    bench.sh ───▶ │ 1. cold start   open app ──▶ window usable  │
    (one app      │ 2. hotkey       ⌥Space ──▶ window on screen │──▶ results/latest.md
-    at a time)   │ 3. memory       app + ALL helper processes  │──▶ README table
-                 │ 4. idle CPU     30 s average                │
+    at a time)   │ 3. post-activity CPU + memory               │──▶ README table
+                 │ 4. deep idle    CPU, memory, wakeups, I/O   │
                  │ 5. disk size    du -sm App.app              │
                  └─────────────────────────────────────────────┘
 ```
 
 ## What is measured, and how
 
-| Metric                      | How                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Hotkey → window visible** | A synthetic hotkey press (`CGEvent`) is posted, then the window list (`CGWindowListCopyWindowInfo`) is polled until a launcher-sized window owned by the app is on screen. Between runs the window is dismissed with Esc — re-pressing the hotkey is not reliable, because Raycast v1 types a focused synthetic ⌥Space into its search field as text instead of toggling. A run only starts once the window is verified hidden. Median and p95 of 15 runs. Resolution is ≈1–3 ms (window-server poll cost). |
-| **Cold start → usable**     | App is fully quit, then launched with `open`. The hotkey is pressed repeatedly until the launcher window appears — so this measures "launch → you can actually use it", not "process exists".                                                                                                                                                                                                                                                                                                               |
-| **Memory footprint**        | `phys_footprint` (the Activity Monitor "Memory" column) summed over the app's **whole process group**: the main process plus every WebKit/XPC helper the OS attributes to it via the responsible-process mechanism. This is fair to both sides — Raycast's node extension host and Asyar's WebKit processes are both counted.                                                                                                                                                                               |
-| **CPU while idle**          | User+system CPU time of the process group sampled over 30 s with the launcher hidden, as a percentage of one core.                                                                                                                                                                                                                                                                                                                                                                                          |
-| **App size on disk**        | `du -sm` of the installed bundle.                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Metric                        | How                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Hotkey → window visible**   | A synthetic hotkey press (`CGEvent`) is posted, then the window list (`CGWindowListCopyWindowInfo`) is polled until a launcher-sized window owned by the app is on screen. Between runs the window is dismissed with Esc — re-pressing the hotkey is not reliable, because Raycast v1 types a focused synthetic ⌥Space into its search field as text instead of toggling. A run only starts once the window is verified hidden. Median, p95, and p99 of 15 runs are reported, together with the complete comma-separated sample list. Resolution is ≈1–3 ms (window-server poll cost). |
+| **Cold start → usable**       | App is fully quit, then launched with `open`. The hotkey is pressed repeatedly until the launcher window appears — so this measures "launch → you can actually use it", not "process exists".                                                                                                                                                                                                                                                                                                                                                                                          |
+| **Memory footprint**          | `phys_footprint` (the Activity Monitor "Memory" column) summed over the app's **whole process group**: the main process plus every WebKit/XPC helper the OS attributes to it via the responsible-process mechanism. This is fair to both sides — Raycast's node extension host and Asyar's WebKit processes are both counted. Memory is captured once after hotkey activity and again during deep idle.                                                                                                                                                                                |
+| **CPU after activity**        | User+system CPU time of the process group sampled over 30 s with the launcher hidden, shortly after the hotkey runs. This preserves the legacy "CPU while idle" metric while distinguishing it from deep idle. CPU percentages are percentages of one core.                                                                                                                                                                                                                                                                                                                            |
+| **Deep-idle CPU and wakeups** | After a 120 s quiet settling period, CPU is sampled for 60 s. `benchtool cpu` reports process-group CPU percentage. When optional passwordless `sudo` is available, the `powermetrics` tasks sampler also reports process-group CPU ms/s and interrupt wakeups/s, averaged across its one-second samples.                                                                                                                                                                                                                                                                              |
+| **Deep-idle disk writes**     | During the same 60 s window, optional `fs_usage` collection counts `write`, `pwrite`, `WrData`, and `WrMeta` calls by the process group, plus the number of distinct absolute paths touched.                                                                                                                                                                                                                                                                                                                                                                                           |
+| **Keystroke → results**       | After summoning the launcher, one character is typed synthetically and the time until the launcher window's height changes is measured (300 µs polling of `CGWindowList` bounds). This works because Asyar presents results by growing its collapsed 96 px panel; launchers with a fixed-size window (Raycast) cannot be measured this way and report `n/a`. A proxy for "results painted", measurable black-box on the shipping app.                                                                                                                                                  |
+| **Deep-idle network**         | Unprivileged `nettop -P -x -l 1` snapshots before and after the deep-idle CPU window provide per-process-group byte deltas in each direction.                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| **App size on disk**          | `du -sm` of the installed bundle.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
 ## Running it
 
 ```bash
-./benchmarks/bench.sh                  # interactive, ~4-5 minutes
+./benchmarks/bench.sh                  # interactive, ~4-6 minutes per app
 ./benchmarks/bench.sh --update-readme  # also refresh the table in the root README
 ```
 
@@ -40,6 +44,16 @@ is fine). Override with `--asyar-hotkey` / `--raycast-hotkey` /
 `--raycast-beta-hotkey` (e.g. `cmd+space`) if your setup differs. **Each
 hotkey must match what that app is actually bound to**, or its runs will
 time out.
+
+The deep-idle defaults can be changed independently:
+
+```bash
+./benchmarks/bench.sh --deep-settle 120 --deep-idle-seconds 60
+```
+
+`--deep-settle N` controls the quiet period after the legacy post-activity
+CPU window. `--deep-idle-seconds N` controls the later CPU, `powermetrics`,
+`fs_usage`, and network measurement window.
 
 ### Prerequisites
 
@@ -55,6 +69,28 @@ time out.
    confirm the hotkey is actually set — app updates can silently clear it.
    The script lists the app → hotkey pairs before starting; make sure they
    match reality.
+5. **Python 3.** `python3` parses the `powermetrics`, `fs_usage`, and `nettop`
+   raw output. The script checks for it before starting.
+
+### Optional passwordless measurement tools
+
+`powermetrics` and `fs_usage` need root. The benchmark never prompts for a
+password. It checks access with `sudo -n true`; if that check fails, CPU
+ms/s, wakeups/s, disk write operations, and distinct files touched are
+reported as `n/a`. The hotkey, cold-start, memory, CPU percentage, network,
+and app-size metrics still run end to end.
+
+To enable the privileged metrics, edit a dedicated sudoers file with
+`sudo visudo -f /etc/sudoers.d/asyar-benchmarks` and add the following,
+replacing `yourusername` with the account that runs the benchmark:
+
+```sudoers
+Cmnd_Alias ASYAR_BENCH = /usr/bin/powermetrics *, /usr/bin/fs_usage *
+yourusername ALL = (root) NOPASSWD: ASYAR_BENCH
+```
+
+Availability is probed with a 100 ms `powermetrics` run, so no extra
+entries are needed beyond the two tools.
 
 ## Fairness rules
 
@@ -100,5 +136,5 @@ time out.
 - `benchtool.swift` — the measurement tool (compiled on first run to
   `.build/benchtool`; no dependencies beyond Xcode command-line tools).
 - `bench.sh` — orchestrates the protocol: quit both → per app: cold
-  start → settle → hotkey runs → memory → idle CPU → quit; then renders
-  the report.
+  start → settle → hotkey runs → post-activity memory and CPU → deep settle →
+  deep-idle metrics → quit; then renders the report.

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -3,19 +3,20 @@
 #
 # Measures every app the same way, one at a time, from the outside:
 #   cold start → usable, hotkey → window visible, memory footprint,
-#   idle CPU, size on disk.
+#   post-activity and deep-idle costs, size on disk.
 #
 # Usage:
 #   ./benchmarks/bench.sh [--yes] [--update-readme]
 #       [--asyar-app PATH] [--raycast-app PATH] [--raycast-beta-app PATH]
 #       [--asyar-hotkey SPEC] [--raycast-hotkey SPEC] [--raycast-beta-hotkey SPEC]
 #       [--runs N] [--cpu-seconds N] [--settle-seconds N]
+#       [--deep-settle N] [--deep-idle-seconds N]
 #
 # Raycast Beta is included automatically when installed; each hotkey SPEC
 # must match what that app is actually bound to (e.g. opt+space, cmd+space).
 #
-# Requires: Xcode command-line tools (swiftc) and Accessibility permission
-# for your terminal (System Settings → Privacy & Security → Accessibility).
+# Requires: Xcode command-line tools (swiftc), Python 3, and Accessibility
+# permission for your terminal (System Settings → Privacy & Security → Accessibility).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -33,6 +34,8 @@ RAYCAST_BETA_HOTKEY="opt+space"
 RUNS=15
 CPU_SECONDS=30
 SETTLE_SECONDS=20
+DEEP_SETTLE_SECONDS=120
+DEEP_IDLE_SECONDS=60
 ASSUME_YES=0
 UPDATE_README=0
 
@@ -47,6 +50,8 @@ while [[ $# -gt 0 ]]; do
     --runs) RUNS="$2"; shift 2 ;;
     --cpu-seconds) CPU_SECONDS="$2"; shift 2 ;;
     --settle-seconds) SETTLE_SECONDS="$2"; shift 2 ;;
+    --deep-settle) DEEP_SETTLE_SECONDS="$2"; shift 2 ;;
+    --deep-idle-seconds) DEEP_IDLE_SECONDS="$2"; shift 2 ;;
     --yes) ASSUME_YES=1; shift ;;
     --update-readme) UPDATE_README=1; shift ;;
     -h|--help) sed -n '2,19p' "$0"; exit 0 ;;
@@ -60,6 +65,7 @@ die() { echo "error: $*" >&2; exit 1; }
 [[ -d "$ASYAR_APP" ]] || die "Asyar app not found at $ASYAR_APP (pass --asyar-app)"
 [[ -d "$RAYCAST_APP" ]] || die "Raycast app not found at $RAYCAST_APP (pass --raycast-app)"
 command -v swiftc >/dev/null || die "swiftc not found — install Xcode command-line tools"
+command -v python3 >/dev/null || die "python3 not found — install Python 3"
 
 # A dev build of Asyar would attribute its WebKit helpers to the terminal
 # and produce garbage numbers; refuse to run alongside one.
@@ -133,7 +139,7 @@ one hotkey: give each app its own, then pass the matching
 This benchmark will QUIT and RELAUNCH: ${APP_LABELS[*]}.
 It presses each app's global hotkey (~$((RUNS + 3)) times) using synthetic
 keyboard events. Do not touch mouse/keyboard while it runs
-(~2-3 minutes per app).
+(~4-6 minutes per app).
 
 For fair numbers: close other heavy apps, plug in power, use a release build.
 
@@ -149,11 +155,160 @@ if [[ ! -x "$TOOL" || "$SCRIPT_DIR/benchtool.swift" -nt "$TOOL" ]]; then
   swiftc -O "$SCRIPT_DIR/benchtool.swift" -o "$TOOL"
 fi
 
-extract() { awk -F= -v k="$2" '$1 == k { print $2 }' "$1" | tail -1; }
+extract() {
+  awk -F= -v k="$2" '$1 == k { value = $2; found = 1 } END { print found ? value : "n/a" }' "$1"
+}
+
+parse_powermetrics() { # raw-file pid...
+  python3 - "$@" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+pids = set(sys.argv[2:])
+number = r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)"
+pid_pattern = "|".join(re.escape(pid) for pid in sorted(pids, key=len, reverse=True))
+row = re.compile(r"^(.+?)\s+(" + pid_pattern + r")\s+(" + number + r"(?:\s+" + number + r"){5,})\s*$")
+sample_header = re.compile(r"^\*+\s*Sampled system activity")
+samples = []
+current = None
+matched = False
+
+with open(path, encoding="utf-8", errors="replace") as raw:
+    for line in raw:
+        line = line.strip()
+        if sample_header.match(line):
+            if current is not None:
+                samples.append(current)
+            current = [0.0, 0.0]
+            continue
+        match = row.match(line)
+        if not match:
+            continue
+        values = [float(value) for value in match.group(3).split()]
+        if current is None:
+            current = [0.0, 0.0]
+        current[0] += values[0]
+        current[1] += values[4]
+        matched = True
+
+if current is not None:
+    samples.append(current)
+if not matched or not samples:
+    raise SystemExit(1)
+
+print(f"pm_cpu_ms_s={sum(sample[0] for sample in samples) / len(samples):.2f}")
+print(f"pm_wakeups_s={sum(sample[1] for sample in samples) / len(samples):.2f}")
+PY
+}
+
+parse_fs_usage() { # raw-file
+  python3 - "$1" <<'PY'
+import re
+import sys
+
+write_call = re.compile(r"^\s*\S+\s+(?:write|pwrite|WrData|WrMeta)(?:\[[^]]*\])?(?:\s|$)")
+path_field = re.compile(r"(/.*?)\s+\d+\.\d+(?:\s+W)?\s+.+$")
+writes = 0
+paths = set()
+
+with open(sys.argv[1], encoding="utf-8", errors="replace") as raw:
+    for line in raw:
+        if not write_call.search(line):
+            continue
+        writes += 1
+        match = path_field.search(line)
+        if match:
+            paths.add(match.group(1).strip())
+
+print(f"disk_write_ops={writes}")
+print(f"disk_files_touched={len(paths)}")
+PY
+}
+
+parse_nettop() { # before-file after-file pid...
+  python3 - "$@" <<'PY'
+import csv
+import re
+import sys
+
+pids = set(sys.argv[3:])
+
+def snapshot(path):
+    totals = [0, 0]
+    with open(path, encoding="utf-8", errors="replace", newline="") as raw:
+        lines = raw.readlines()
+
+    csv_header = None
+    for record in csv.reader(lines):
+        names = [field.strip().lower() for field in record]
+        if "bytes_in" in names and "bytes_out" in names:
+            csv_header = (names.index("bytes_in"), names.index("bytes_out"))
+            continue
+        if csv_header is None or max(csv_header) >= len(record):
+            continue
+        if not any(re.search(r"\." + re.escape(pid) + r"$", field.strip()) for pid in pids for field in record):
+            continue
+        try:
+            totals[0] += int(float(record[csv_header[0]].strip()))
+            totals[1] += int(float(record[csv_header[1]].strip()))
+        except ValueError:
+            continue
+    if csv_header is not None:
+        return totals
+
+    fixed_header = None
+    for line in lines:
+        if "bytes_in" not in line.lower() or "bytes_out" not in line.lower():
+            continue
+        columns = [(match.start(), match.group().lower()) for match in re.finditer(r"\S+", line)]
+        positions = {name: position for position, name in columns}
+        if "bytes_in" not in positions or "bytes_out" not in positions:
+            continue
+        starts = [position for position, _ in columns]
+        in_start = positions["bytes_in"]
+        out_start = positions["bytes_out"]
+        in_end = next((position for position in starts if position > in_start), None)
+        out_end = next((position for position in starts if position > out_start), None)
+        fixed_header = (in_start, in_end, out_start, out_end)
+        continue
+    if fixed_header is None:
+        raise ValueError("nettop byte columns not found")
+
+    for line in lines:
+        if not any(re.search(r"\." + re.escape(pid) + r"(?:\s|$)", line) for pid in pids):
+            continue
+        in_start, in_end, out_start, out_end = fixed_header
+        fields = (line[in_start:in_end].strip(), line[out_start:out_end].strip())
+        try:
+            totals[0] += int(float(fields[0] or 0))
+            totals[1] += int(float(fields[1] or 0))
+        except ValueError:
+            continue
+    return totals
+
+try:
+    before = snapshot(sys.argv[1])
+    after = snapshot(sys.argv[2])
+except (OSError, ValueError):
+    raise SystemExit(1)
+
+print(f"net_bytes_in={max(0, after[0] - before[0])}")
+print(f"net_bytes_out={max(0, after[1] - before[1])}")
+PY
+}
 
 measure_app() { # index into the APP_* arrays
   local i="$1"
   local app="${APP_PATHS[$i]}" hotkey="${APP_HOTKEYS[$i]}" log="${APP_LOGS[$i]}"
+  local raw_prefix="${log%.txt}"
+  local deep_cpu_raw="${raw_prefix}-deep-cpu.txt"
+  local pm_raw="${raw_prefix}-powermetrics.txt"
+  local fs_raw="${raw_prefix}-fs-usage.txt"
+  local net_before_raw="${raw_prefix}-nettop-before.txt"
+  local net_after_raw="${raw_prefix}-nettop-after.txt"
+  local group_output deep_cpu_job pm_job fs_job
+  local group_pids=()
   : > "$log"
 
   echo "== ${APP_LABELS[$i]} =="
@@ -182,6 +337,78 @@ matching --asyar-hotkey / --raycast-hotkey / --raycast-beta-hotkey flag."
   echo "  idle CPU over ${CPU_SECONDS}s..."
   "$TOOL" cpu "$app" "$CPU_SECONDS" | tee -a "$log"
 
+  echo "  settling ${DEEP_SETTLE_SECONDS}s for deep idle..."
+  sleep "$DEEP_SETTLE_SECONDS"
+
+  group_output="$("$TOOL" group "$app")"
+  while IFS= read -r pid; do
+    group_pids+=("$pid")
+  done < <(printf '%s\n' "$group_output" | awk -F'[ =]' '$1 == "pid" { print $2 }')
+  [[ "${#group_pids[@]}" -gt 0 ]] || die "could not resolve the process group for ${APP_LABELS[$i]}"
+
+  echo "  deep idle over ${DEEP_IDLE_SECONDS}s..."
+  if ! nettop -P -x -l 1 > "$net_before_raw" 2>/dev/null; then
+    : > "$net_before_raw"
+  fi
+
+  "$TOOL" cpu "$app" "$DEEP_IDLE_SECONDS" > "$deep_cpu_raw" &
+  deep_cpu_job=$!
+  pm_job=""
+  fs_job=""
+  if command -v sudo >/dev/null && sudo -n /usr/bin/powermetrics --samplers cpu_power -i 100 -n 1 >/dev/null 2>&1; then
+    sudo -n powermetrics --samplers tasks --show-process-energy -i 1000 -n "$DEEP_IDLE_SECONDS" > "$pm_raw" 2>&1 &
+    pm_job=$!
+    sudo -n fs_usage -w -f filesys -t "$DEEP_IDLE_SECONDS" "${group_pids[@]}" > "$fs_raw" 2>&1 &
+    fs_job=$!
+  else
+    : > "$pm_raw"
+    : > "$fs_raw"
+  fi
+
+  if wait "$deep_cpu_job"; then
+    sed 's/^cpu_pct=/cpu_pct_deep=/' "$deep_cpu_raw" | tee -a "$log"
+  else
+    die "deep-idle CPU measurement failed for ${APP_LABELS[$i]}"
+  fi
+
+  if ! nettop -P -x -l 1 > "$net_after_raw" 2>/dev/null; then
+    : > "$net_after_raw"
+  fi
+  if parse_nettop "$net_before_raw" "$net_after_raw" "${group_pids[@]}" >> "$log"; then
+    :
+  else
+    printf 'net_bytes_in=n/a\nnet_bytes_out=n/a\n' >> "$log"
+  fi
+
+  if [[ -n "$pm_job" ]]; then
+    if wait "$pm_job" && parse_powermetrics "$pm_raw" "${group_pids[@]}" >> "$log"; then
+      :
+    else
+      printf 'pm_cpu_ms_s=n/a\npm_wakeups_s=n/a\n' >> "$log"
+    fi
+  else
+    printf 'pm_cpu_ms_s=n/a\npm_wakeups_s=n/a\n' >> "$log"
+  fi
+
+  if [[ -n "$fs_job" ]]; then
+    if wait "$fs_job" && parse_fs_usage "$fs_raw" >> "$log"; then
+      :
+    else
+      printf 'disk_write_ops=n/a\ndisk_files_touched=n/a\n' >> "$log"
+    fi
+  else
+    printf 'disk_write_ops=n/a\ndisk_files_touched=n/a\n' >> "$log"
+  fi
+
+  echo "  keystroke → results painted (panel growth), 10 runs..."
+  if ! "$TOOL" typelatency "$app" "$hotkey" a 10 | tee -a "$log"; then
+    echo "  (launcher does not resize on results — reporting n/a)"
+    printf 'type_p50_ms=n/a\ntype_p95_ms=n/a\ntype_p99_ms=n/a\n' >> "$log"
+  fi
+
+  echo "  memory footprint at deep idle..."
+  "$TOOL" mem "$app" | sed 's/^total_mb=/total_mb_deep=/' | tee -a "$log"
+
   du -sm "$app" | awk '{ print "size_mb=" $1 }' | tee -a "$log"
   quit_app "$app"
 }
@@ -196,9 +423,16 @@ MACOS_VER="$(sw_vers -productVersion)"
 DATE_UTC="$(date -u +%Y-%m-%d)"
 
 row() { # metric key unit
-  local out="| $1 |" log
+  local out="| $1 |" log value
   for log in "${APP_LOGS[@]}"; do
-    out+=" $(extract "$log" "$2") $3 |"
+    value="$(extract "$log" "$2")"
+    if [[ "$value" == "n/a" ]]; then
+      out+=" n/a |"
+    elif [[ -n "$3" ]]; then
+      out+=" $value $3 |"
+    else
+      out+=" $value |"
+    fi
   done
   echo "$out"
 }
@@ -215,9 +449,19 @@ TABLE_FILE="$RESULTS_DIR/table.md"
   echo "$sep"
   row "Hotkey → window visible (median of $RUNS)" median_ms "ms"
   row "Hotkey → window visible (p95)" p95_ms "ms"
+  row "Hotkey → window visible (p99)" p99_ms "ms"
+  row "Keystroke → results painted (p50)" type_p50_ms "ms"
+  row "Keystroke → results painted (p95)" type_p95_ms "ms"
   row "Cold start → usable" coldstart_ms "ms"
   row "Memory footprint, idle (all processes)" total_mb "MB"
   row "CPU while idle (${CPU_SECONDS}s average)" cpu_pct "%"
+  row "CPU deep idle (${DEEP_IDLE_SECONDS}s, after ${DEEP_SETTLE_SECONDS}s quiet)" cpu_pct_deep "%"
+  row "Memory deep idle" total_mb_deep "MB"
+  row "CPU ms/s (powermetrics, deep idle)" pm_cpu_ms_s ""
+  row "Idle wakeups/s (deep idle)" pm_wakeups_s ""
+  row "Idle disk write ops (${DEEP_IDLE_SECONDS}s)" disk_write_ops ""
+  row "Idle network bytes in (${DEEP_IDLE_SECONDS}s)" net_bytes_in ""
+  row "Idle network bytes out (${DEEP_IDLE_SECONDS}s)" net_bytes_out ""
   row "App size on disk" size_mb "MB"
   echo
   echo "<sub>Measured $DATE_UTC on a $CHIP (${RAM_GB} GB RAM), macOS $MACOS_VER, each app"
@@ -233,7 +477,8 @@ TABLE_FILE="$RESULTS_DIR/table.md"
   for i in "${!APP_PATHS[@]}"; do
     echo "- ${APP_LABELS[$i]} (\`${APP_PATHS[$i]}\`), hotkey \`${APP_HOTKEYS[$i]}\`"
   done
-  echo "- $RUNS hotkey runs, ${CPU_SECONDS}s CPU window, ${SETTLE_SECONDS}s settle"
+  echo "- $RUNS hotkey runs, ${CPU_SECONDS}s post-activity CPU window, ${SETTLE_SECONDS}s initial settle"
+  echo "- ${DEEP_IDLE_SECONDS}s deep-idle window after ${DEEP_SETTLE_SECONDS}s quiet"
   echo
   cat "$TABLE_FILE"
   for i in "${!APP_PATHS[@]}"; do

--- a/benchmarks/benchtool.swift
+++ b/benchmarks/benchtool.swift
@@ -14,6 +14,7 @@
 //   benchtool mem       <bundle-path>
 //   benchtool hotkey    <bundle-path> <keyspec> [runs]
 //   benchtool coldstart <bundle-path> <keyspec>
+//   benchtool typelatency <bundle-path> <keyspec> <char> [runs]
 //   benchtool cpu       <bundle-path> [seconds]
 //   benchtool group     <bundle-path>
 //
@@ -124,7 +125,9 @@ func cpuTimeNs(_ pid: pid_t) -> UInt64? {
 
 /// True when the app has a real (launcher-sized) window on screen.
 /// Small always-on windows like the menu-bar status item are filtered
-/// out by the size threshold.
+/// out by the size threshold. The threshold must stay below the
+/// collapsed empty-query launcher (750x96 as of 0.1.1): a 100 px
+/// height floor made every hotkey run time out against it.
 func launcherWindowVisible(pids: Set<pid_t>) -> Bool {
     let opts: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
     guard let info = CGWindowListCopyWindowInfo(opts, kCGNullWindowID) as? [[String: Any]]
@@ -139,9 +142,32 @@ func launcherWindowVisible(pids: Set<pid_t>) -> Bool {
         guard let boundsDict = w[kCGWindowBounds as String] as? NSDictionary,
             let rect = CGRect(dictionaryRepresentation: boundsDict)
         else { continue }
-        if rect.height >= 100, rect.width >= 200 { return true }
+        if rect.height >= 60, rect.width >= 400 { return true }
     }
     return false
+}
+
+/// Height of the visible launcher window, or nil when none is on screen.
+/// Used by `typelatency`: launchers that present results by growing the
+/// panel (Asyar's collapsed 96 px → expanded) reveal "results painted"
+/// as a height change observable without any in-app instrumentation.
+func launcherWindowHeight(pids: Set<pid_t>) -> Double? {
+    let opts: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+    guard let info = CGWindowListCopyWindowInfo(opts, kCGNullWindowID) as? [[String: Any]]
+    else { return nil }
+    for w in info {
+        guard let owner = (w[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+            pids.contains(owner)
+        else { continue }
+        if let alpha = (w[kCGWindowAlpha as String] as? NSNumber)?.doubleValue, alpha <= 0.01 {
+            continue
+        }
+        guard let boundsDict = w[kCGWindowBounds as String] as? NSDictionary,
+            let rect = CGRect(dictionaryRepresentation: boundsDict)
+        else { continue }
+        if rect.height >= 60, rect.width >= 400 { return rect.height }
+    }
+    return nil
 }
 
 // MARK: - Key events
@@ -365,6 +391,82 @@ func cmdHotkey(_ bundle: String, spec: String, runs: Int) {
     print("median_ms=\(String(format: "%.1f", median(samples)))")
     print("p95_ms=\(String(format: "%.1f", percentile(samples, 0.95)))")
     print("min_ms=\(String(format: "%.1f", samples.min()!))")
+    print("p99_ms=\(String(format: "%.1f", percentile(samples, 0.99)))")
+    print("samples_ms=\(samples.map { String(format: "%.1f", $0) }.joined(separator: ","))")
+}
+
+/// Keystroke → results painted, via panel growth. Each run: summon the
+/// launcher, let it stabilize at its collapsed height, post one character,
+/// and time until the window height changes (the results list rendering is
+/// what grows the panel). Requires a launcher that presents results by
+/// resizing; apps with a fixed-size window time out and report n/a.
+func cmdTypeLatency(_ bundle: String, spec: String, char: String, runs: Int) {
+    requireAccessibility()
+    guard let (key, flags) = parseKeySpec(spec) else {
+        fputs("error: cannot parse keyspec '\(spec)'\n", stderr)
+        exit(1)
+    }
+    guard let charCode = keyCodes[char.lowercased()] else {
+        fputs("error: unsupported character '\(char)' (use a letter key)\n", stderr)
+        exit(1)
+    }
+    let group = processGroup(bundlePath: bundle)
+    guard !group.isEmpty else {
+        fputs("error: \(bundle) is not running — launch it first\n", stderr)
+        exit(1)
+    }
+    let pids = Set(group)
+
+    var samples: [Double] = []
+    var failures = 0
+    hideWindow(key, flags, pids: pids)
+
+    for run in 1...runs {
+        usleep(400_000)
+        postKey(key, flags)
+        guard waitFor(timeoutMs: 5000, { launcherWindowVisible(pids: pids) }) != nil else {
+            failures += 1
+            print("run=\(run) ms=summon-timeout")
+            continue
+        }
+        // Let the collapsed panel settle so the baseline height is stable.
+        usleep(400_000)
+        guard let baseline = launcherWindowHeight(pids: pids) else {
+            failures += 1
+            print("run=\(run) ms=no-window")
+            continue
+        }
+        let t0 = nowNs()
+        postKey(charCode, [])
+        if waitFor(timeoutMs: 5000, pollUs: 300, {
+            if let h = launcherWindowHeight(pids: pids) { return abs(h - baseline) > 2 }
+            return false
+        }) != nil {
+            let ms = msSince(t0)
+            samples.append(ms)
+            print("run=\(run) ms=\(String(format: "%.1f", ms))")
+        } else {
+            failures += 1
+            print("run=\(run) ms=timeout")
+        }
+        // Esc clears the query, second Esc (via hideWindow) dismisses.
+        postKey(keyCodes["escape"]!, [])
+        usleep(200_000)
+        guard hideWindow(key, flags, pids: pids) else {
+            fputs("error: could not hide the launcher window between runs\n", stderr)
+            exit(1)
+        }
+    }
+
+    guard !samples.isEmpty, failures * 2 < runs else {
+        fputs(
+            "error: too many failures (\(failures)/\(runs)) — the launcher may not resize on results\n",
+            stderr)
+        exit(1)
+    }
+    print("type_p50_ms=\(String(format: "%.1f", median(samples)))")
+    print("type_p95_ms=\(String(format: "%.1f", percentile(samples, 0.95)))")
+    print("type_p99_ms=\(String(format: "%.1f", percentile(samples, 0.99)))")
 }
 
 func cmdColdstart(_ bundle: String, spec: String) {
@@ -436,6 +538,7 @@ guard args.count >= 3 else {
         usage: benchtool mem       <bundle-path>
                benchtool hotkey    <bundle-path> <keyspec> [runs]
                benchtool coldstart <bundle-path> <keyspec>
+               benchtool typelatency <bundle-path> <keyspec> <char> [runs]
                benchtool cpu       <bundle-path> [seconds]
                benchtool group     <bundle-path>
 
@@ -454,6 +557,12 @@ case "hotkey":
         exit(64)
     }
     cmdHotkey(bundle, spec: args[3], runs: args.count > 4 ? Int(args[4]) ?? 15 : 15)
+case "typelatency":
+    guard args.count >= 5 else {
+        fputs("error: typelatency needs a keyspec and a character, e.g. cmd+space a\n", stderr)
+        exit(64)
+    }
+    cmdTypeLatency(bundle, spec: args[3], char: args[4], runs: args.count > 5 ? Int(args[5]) ?? 10 : 10)
 case "coldstart":
     guard args.count >= 4 else {
         fputs("error: coldstart needs a keyspec, e.g. opt+space\n", stderr)


### PR DESCRIPTION
I was away over the weekend but tasked Claude Fable with monitoring performance. I've got a few more PRs to put in after this as a result of that, but this is the plumbing that was put in place.

bench.sh couldn't actually summon the current app: the visibility check wants a window ≥100px tall, but the collapsed launcher is 96px, so every hotkey run silently timed out and the table was being fed by fallbacks. That's fixed (≥60px), and 

The harness has been extended with the metrics to better explain idle cost:
- A deep-idle phase (`--deep-settle`, default 120s, and `--deep-idle-seconds`) so we stop measuring startup indexing and update checks as "idle".
- Idle wakeups/s and CPU ms/s per process via `powermetrics`, energy included.
- Idle disk writes via `fs_usage` (ops + distinct paths) and idle network via `nettop` deltas — the README claims zero bytes idle, now we test it.
- phys_footprint (the Activity Monitor figure) instead of RSS.
- p99 on summon latency, and a new keystroke→results-painted metric: post a character into the summoned launcher and poll the panel height until the results paint moves it. Black-box, no app cooperation needed (p50 62ms / p95 77ms here).

powermetrics and fs_usage need sudo; there's a sudoers snippet in benchmarks/README.md and everything degrades to n/a without it rather than failing the run. I haven't changed `--update-readme`

Test:
- Full run with and without the sudoers entry (metrics appear / degrade to n/a)
- typelatency falls back cleanly on fixed-size windows (tested against Raycast)
- Table generation + `--update-readme` round-trip on the extended columns