### PR TITLE
perf(timers): skip idle 1Hz SQLite poll

### DIFF
--- a/asyar-launcher/src-tauri/src/timers/mod.rs
+++ b/asyar-launcher/src-tauri/src/timers/mod.rs
@@ -16,6 +16,10 @@ use crate::error::AppError;
 use crate::storage::DataStore;
 use rusqlite::params;
 use serde::{Deserialize, Serialize};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 /// Tauri event name used when a timer fires. The TS-side bridge
 /// (`timerBridge.svelte.ts`) listens for this and dispatches the
@@ -51,11 +55,15 @@ pub struct TimerFirePayload {
 #[derive(Clone)]
 pub struct TimerRegistry {
     store: DataStore,
+    maybe_nonempty: Arc<AtomicBool>,
 }
 
 impl TimerRegistry {
     pub fn new(store: DataStore) -> Self {
-        Self { store }
+        Self {
+            store,
+            maybe_nonempty: Arc::new(AtomicBool::new(true)),
+        }
     }
 
     /// A registry over a throwaway file-backed test store.
@@ -63,6 +71,7 @@ impl TimerRegistry {
     pub(crate) fn for_test() -> Self {
         Self {
             store: crate::storage::create_test_store(),
+            maybe_nonempty: Arc::new(AtomicBool::new(true)),
         }
     }
 
@@ -102,7 +111,20 @@ impl TimerRegistry {
             ],
         )
         .map_err(|e| AppError::Database(format!("Failed to insert timer: {e}")))?;
+        self.maybe_nonempty.store(true, Ordering::Release);
         Ok(timer_id)
+    }
+
+    pub(crate) fn should_poll(&self) -> bool {
+        self.maybe_nonempty.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn begin_poll(&self) {
+        self.maybe_nonempty.store(false, Ordering::Release);
+    }
+
+    pub(crate) fn keep_polling(&self) {
+        self.maybe_nonempty.store(true, Ordering::Release);
     }
 
     pub fn cancel(&self, extension_id: &str, timer_id: &str) -> Result<(), AppError> {
@@ -155,23 +177,50 @@ impl TimerRegistry {
     }
 
     pub fn due_now(&self, now_ms: u64) -> Result<Vec<TimerDescriptor>, AppError> {
+        self.poll_due(now_ms).map(|(due, _)| due)
+    }
+
+    pub(crate) fn poll_due(&self, now_ms: u64) -> Result<(Vec<TimerDescriptor>, bool), AppError> {
         let conn = self.store.conn()?;
         let mut stmt = conn
             .prepare(
-                "SELECT timer_id, extension_id, command_id, args_json, fire_at, created_at
-                 FROM extension_timers
-                 WHERE fired = 0 AND fire_at <= ?1
-                 ORDER BY fire_at ASC",
+                "SELECT due.timer_id, due.extension_id, due.command_id, due.args_json,
+                        due.fire_at, due.created_at,
+                        EXISTS(SELECT 1 FROM extension_timers WHERE fired = 0)
+                 FROM (SELECT 1) AS state
+                 LEFT JOIN extension_timers AS due
+                    ON due.fired = 0 AND due.fire_at <= ?1
+                 ORDER BY due.fire_at ASC",
             )
-            .map_err(|e| AppError::Database(format!("Failed to prepare due_now: {e}")))?;
+            .map_err(|e| AppError::Database(format!("Failed to prepare poll_due: {e}")))?;
         let iter = stmt
-            .query_map(params![now_ms as i64], Self::map_row)
-            .map_err(|e| AppError::Database(format!("Failed to query due_now: {e}")))?;
+            .query_map(params![now_ms as i64], |row| {
+                let timer_id = row.get::<_, Option<String>>(0)?;
+                let desc = match timer_id {
+                    Some(timer_id) => Some(TimerDescriptor {
+                        timer_id,
+                        extension_id: row.get(1)?,
+                        command_id: row.get(2)?,
+                        args_json: row.get(3)?,
+                        fire_at: row.get::<_, i64>(4)? as u64,
+                        created_at: row.get::<_, i64>(5)? as u64,
+                    }),
+                    None => None,
+                };
+                Ok((desc, row.get::<_, bool>(6)?))
+            })
+            .map_err(|e| AppError::Database(format!("Failed to query poll_due: {e}")))?;
         let mut out = Vec::new();
+        let mut has_unfired = false;
         for r in iter {
-            out.push(r.map_err(|e| AppError::Database(format!("Row error: {e}")))?);
+            let (desc, any_unfired) =
+                r.map_err(|e| AppError::Database(format!("Row error: {e}")))?;
+            has_unfired = any_unfired;
+            if let Some(desc) = desc {
+                out.push(desc);
+            }
         }
-        Ok(out)
+        Ok((out, has_unfired))
     }
 
     pub fn mark_fired(
@@ -383,6 +432,21 @@ mod tests {
         let id = r.schedule("ext-a", "cmd", "{}", 2_000, 1_000).unwrap();
         r.mark_fired("ext-a", &id, 2_001).unwrap();
         assert!(r.due_now(9_000).unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_poll_disables_polling_until_a_timer_is_scheduled() {
+        let r = make();
+        assert!(r.should_poll());
+
+        r.begin_poll();
+        let (due, has_unfired) = r.poll_due(1_000).unwrap();
+        assert!(due.is_empty());
+        assert!(!has_unfired);
+        assert!(!r.should_poll());
+
+        r.schedule("ext-a", "cmd", "{}", 2_000, 1_000).unwrap();
+        assert!(r.should_poll());
     }
 
     #[test]

--- a/asyar-launcher/src-tauri/src/timers/scheduler.rs
+++ b/asyar-launcher/src-tauri/src/timers/scheduler.rs
@@ -29,37 +29,49 @@ pub fn select_fireable(pending: &[TimerDescriptor], now_ms: u64) -> Vec<&TimerDe
     pending.iter().filter(|d| d.fire_at <= now_ms).collect()
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct TickPlan {
+    poll_due: bool,
+    prune: bool,
+}
+
+impl TickPlan {
+    fn new(has_pending_timers: bool, now_ms: u64, last_prune_ms: u64) -> Self {
+        Self {
+            poll_due: has_pending_timers,
+            prune: now_ms.saturating_sub(last_prune_ms) >= PRUNE_INTERVAL_SECS * 1000,
+        }
+    }
+}
+
 pub fn start(app: AppHandle, registry: TimerRegistry) {
     tauri::async_runtime::spawn(async move {
         let mut last_prune_ms: u64 = 0;
 
         loop {
             tokio::time::sleep(Duration::from_secs(POLL_INTERVAL_SECS)).await;
-
-            if !registry.should_poll() {
-                continue;
-            }
-            registry.begin_poll();
-
             let now = now_millis();
-            let should_prune = match registry.poll_due(now) {
-                Ok((due, has_unfired)) => {
-                    if has_unfired {
-                        registry.keep_polling();
-                    }
-                    for desc in due {
-                        fire_one(&app, &registry, desc, now);
-                    }
-                    has_unfired
-                }
-                Err(e) => {
-                    registry.keep_polling();
-                    warn!("[timers] due_now query failed: {e}");
-                    true
-                }
-            };
+            let plan = TickPlan::new(registry.should_poll(), now, last_prune_ms);
 
-            if should_prune && now.saturating_sub(last_prune_ms) >= PRUNE_INTERVAL_SECS * 1000 {
+            if plan.poll_due {
+                registry.begin_poll();
+                match registry.poll_due(now) {
+                    Ok((due, has_unfired)) => {
+                        if has_unfired {
+                            registry.keep_polling();
+                        }
+                        for desc in due {
+                            fire_one(&app, &registry, desc, now);
+                        }
+                    }
+                    Err(e) => {
+                        registry.keep_polling();
+                        warn!("[timers] due_now query failed: {e}");
+                    }
+                }
+            }
+
+            if plan.prune {
                 let cutoff = now.saturating_sub(PRUNE_AGE_MILLIS);
                 match registry.prune_old_fired(cutoff) {
                     Ok(n) if n > 0 => info!("[timers] pruned {n} stale fired timers"),
@@ -160,5 +172,13 @@ mod tests {
     fn prune_interval_and_age_are_one_hour_and_twenty_four_hours() {
         assert_eq!(PRUNE_INTERVAL_SECS, 3600);
         assert_eq!(PRUNE_AGE_MILLIS, 24 * 60 * 60 * 1000);
+    }
+
+    #[test]
+    fn idle_due_polling_does_not_skip_a_due_prune() {
+        let plan = TickPlan::new(false, PRUNE_INTERVAL_SECS * 1000, 0);
+
+        assert!(!plan.poll_due);
+        assert!(plan.prune);
     }
 }

--- a/asyar-launcher/src-tauri/src/timers/scheduler.rs
+++ b/asyar-launcher/src-tauri/src/timers/scheduler.rs
@@ -36,17 +36,30 @@ pub fn start(app: AppHandle, registry: TimerRegistry) {
         loop {
             tokio::time::sleep(Duration::from_secs(POLL_INTERVAL_SECS)).await;
 
+            if !registry.should_poll() {
+                continue;
+            }
+            registry.begin_poll();
+
             let now = now_millis();
-            match registry.due_now(now) {
-                Ok(due) => {
+            let should_prune = match registry.poll_due(now) {
+                Ok((due, has_unfired)) => {
+                    if has_unfired {
+                        registry.keep_polling();
+                    }
                     for desc in due {
                         fire_one(&app, &registry, desc, now);
                     }
+                    has_unfired
                 }
-                Err(e) => warn!("[timers] due_now query failed: {e}"),
-            }
+                Err(e) => {
+                    registry.keep_polling();
+                    warn!("[timers] due_now query failed: {e}");
+                    true
+                }
+            };
 
-            if now.saturating_sub(last_prune_ms) >= PRUNE_INTERVAL_SECS * 1000 {
+            if should_prune && now.saturating_sub(last_prune_ms) >= PRUNE_INTERVAL_SECS * 1000 {
                 let cutoff = now.saturating_sub(PRUNE_AGE_MILLIS);
                 match registry.prune_old_fired(cutoff) {
                     Ok(n) if n > 0 => info!("[timers] pruned {n} stale fired timers"),


### PR DESCRIPTION
powermetrics on a parked launcher showed the main process waking ~17 times/s at idle. One steady contributor was that the extension-timer scheduler queries SQLite every second even when nothing has ever scheduled a timer.

The registry now keeps a cheap `maybe_nonempty` flag, armed whenever a timer is inserted. The scheduler skips the poll entirely while it's clear, and the poll query itself reports (via an EXISTS over unfired rows, same single query) whether it should keep polling. A future scheduled timer will keep the loop alive / not get stranded. Firing behaviour is unchanged; this just removes un-needed wake ups.

Together with my next PR (perf(watchers)), idle main-process wake ups drop from 17.1/s to 11.5/s and CPU ms/s about 19% in 60s powermetrics windows on my machine. Summon latency is unchanged.

Test:
- Timer suite green (43 tests), including new coverage for the arm/skip path and the future-timer-keeps-polling case
- Schedule an extension timer → fires on time; remove all timers → poll stops
- Before/after powermetrics numbers above