### PR TITLE
perf(watchers): cut debouncer ticks 8Hz to 2Hz

### DIFF
--- a/asyar-launcher/src-tauri/src/application/index_watcher.rs
+++ b/asyar-launcher/src-tauri/src/application/index_watcher.rs
@@ -148,7 +148,7 @@ impl IndexWatcher {
 
         let mut debouncer = new_debouncer_opt(
             DEBOUNCE_WINDOW,
-            None,
+            Some(DEBOUNCE_WINDOW),
             move |result: DebounceEventResult| match result {
                 Ok(events) if events.is_empty() => {}
                 Ok(_events) => {

--- a/asyar-launcher/src-tauri/src/fs_watcher/mod.rs
+++ b/asyar-launcher/src-tauri/src/fs_watcher/mod.rs
@@ -146,7 +146,7 @@ impl FsWatcherRegistry {
 
         let mut debouncer = new_debouncer_opt(
             debounce,
-            None,
+            Some(debounce),
             move |result: DebounceEventResult| {
                 let events = match result {
                     Ok(e) if !e.is_empty() => e,


### PR DESCRIPTION
Second half of [#606](https://github.com/Xoshbin/asyar/pull/606).

notify-debouncer-full defaults its internal tick to timeout/4 when you pass tick_rate: None, so both the watchers (file index + fs_watcher) wake 8 times a second forever to check a usually-empty queue.

This passes the debounce window as the explicit tick_rate: same debouncing, 2Hz instead of 8Hz per watcher. Events still batch exactly as before; in the worst case a batch can land up to one window later.

Measured with #606
file-change → reindex verified working end-to-end