### PR TITLE
fix: don't abort on Wayland when hiding snap-guides from the cursor

### DIFF
--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -1252,7 +1252,23 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 
     // The snap-guides overlay must never intercept the drag it's decorating
     // — click-through once at startup, not per-drag.
-    if let Some(guides_window) =
+    //
+    // Skipped on Wayland: the overlay is declared `visible: false`, and an
+    // unmapped GTK window has no GDK surface there (X11 realises one much
+    // earlier). tao's CursorIgnoreEvents handler does `window.window().unwrap()`
+    // — see tao/src/platform_impl/linux/event_loop.rs — so the call aborts the
+    // whole process, and it aborts rather than returning Err because the panic
+    // happens on the event-loop thread in a non-unwinding context. The `Err`
+    // arm below can never catch it.
+    let skip_click_through = cfg!(target_os = "linux")
+        && std::env::var_os("WAYLAND_DISPLAY").is_some_and(|v| !v.is_empty());
+    if skip_click_through {
+        log::warn!(
+            "[snap-guides] Wayland session: skipping set_ignore_cursor_events \
+             on the hidden overlay (would abort the process). The overlay may \
+             intercept pointer events during a launcher drag."
+        );
+    } else if let Some(guides_window) =
         handle.get_webview_window(crate::snap_guides::service::SNAP_GUIDES_WINDOW_LABEL)
     {
         if let Err(e) = guides_window.set_ignore_cursor_events(true) {


### PR DESCRIPTION
## The problem

On current `main`, Asyar aborts during startup on any Wayland session. The window never appears.

```
[asyar_lib][ERROR] panic: panicked at tao-0.35.2/src/platform_impl/linux/event_loop.rs:457:18:
called `Option::unwrap()` on a `None` value
[asyar_lib][ERROR] panic: panicked at library/core/src/panicking.rs:225:5:
panic in a function that cannot unwind
thread caused non-unwinding panic. aborting.
```

## Cause

`setup_app` calls `set_ignore_cursor_events(true)` on the snap-guides overlay. That overlay is declared `"visible": false` in `tauri.conf.json`.

On Wayland an unmapped GTK window has no GDK surface yet — X11 realises one much earlier — and tao's `CursorIgnoreEvents` handler unwraps it:

```rust
window.window().unwrap().input_shape_combine_region(&empty_region, 0, 0);
// tao-0.35.2/src/platform_impl/linux/event_loop.rs:457
```

The panic lands on the event-loop thread in a non-unwinding context, so it aborts the process rather than returning `Err`. The existing `if let Err(e)` guard around the call cannot catch it.

Introduced by #604 (`feat/launcher-drag-snap-guides`), which is the current `main`.

## Fix

Skip the call on Wayland and log once. The overlay may then intercept pointer events during a launcher drag, which is clearly the lesser problem — and on a tiling WM the launcher isn't dragged anyway.

Happy to take this a different direction if you'd prefer — deferring the call until the window realises, or disabling the overlay outright on Wayland, both seem reasonable. The `WAYLAND_DISPLAY` guard is the smallest thing that stops the abort.

## Testing

Reproduced and verified fixed on Hyprland 0.56.2 / Arch. The cause is the Wayland surface lifecycle rather than anything compositor-specific, so I'd expect it on GNOME, KDE and sway too — though I've only tested the one compositor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)