### PR TITLE
feat(wayland): let the compositor summon the launcher

### DIFF
--- a/asyar-launcher/src-tauri/src/commands/app.rs
+++ b/asyar-launcher/src-tauri/src/commands/app.rs
@@ -67,6 +67,8 @@ pub fn prepare_show(
             y: OFFSCREEN_COORD,
         }));
         let _ = window.show();
+        #[cfg(target_os = "linux")]
+        crate::mark_launcher_shown(&state);
     }
     let _ = state;
     Ok(())
@@ -100,6 +102,8 @@ pub fn commit_show(
             .ok_or_else(|| AppError::NotFound("launcher window".to_string()))?;
         crate::launcher_placement::service::apply(&app_handle)?;
         let _ = window.set_focus();
+        #[cfg(target_os = "linux")]
+        crate::mark_launcher_shown(&state);
     }
     // Flip the visibility flag only after the panel is actually composited at
     // its final position and alpha — otherwise a concurrent showWindow() that
@@ -135,6 +139,8 @@ pub fn show(app_handle: AppHandle, state: tauri::State<'_, AppState>) -> Result<
         crate::launcher_placement::service::apply(&app_handle)?;
         let _ = window.show();
         let _ = window.set_focus();
+        #[cfg(target_os = "linux")]
+        crate::mark_launcher_shown(&state);
     }
     Ok(())
 }

--- a/asyar-launcher/src-tauri/src/commands/shortcuts.rs
+++ b/asyar-launcher/src-tauri/src/commands/shortcuts.rs
@@ -448,7 +448,19 @@ pub fn handle_shortcut(app: &tauri::AppHandle, shortcut: &Shortcut, event: Short
         }
     }
 
+    toggle_launcher(app);
+}
+
+/// Toggle launcher visibility. The body of the launcher-summon hotkey, split
+/// out so non-hotkey summon paths can reuse it — notably the single-instance
+/// callback, which is how a Wayland compositor summons the launcher (the X11
+/// key grab behind `tauri-plugin-global-shortcut` cannot see keystrokes there,
+/// so the compositor owns the binding and re-execs the binary instead).
+pub fn toggle_launcher(app: &tauri::AppHandle) {
+    let state = app.state::<AppState>();
+
     let Some(window) = app.get_webview_window(SPOTLIGHT_LABEL) else {
+        log::warn!("[toggle_launcher] no window labelled {SPOTLIGHT_LABEL}");
         return;
     };
 
@@ -496,6 +508,8 @@ pub fn handle_shortcut(app: &tauri::AppHandle, shortcut: &Shortcut, event: Short
 
             let _ = window.show();
             let _ = window.set_focus();
+            #[cfg(target_os = "linux")]
+            crate::mark_launcher_shown(&state);
         }
     }
 }

--- a/asyar-launcher/src-tauri/src/commands/snippet_commands.rs
+++ b/asyar-launcher/src-tauri/src/commands/snippet_commands.rs
@@ -146,6 +146,8 @@ mod contribute_tests {
             #[cfg(target_os = "linux")]
             linux_prev_window_id: Mutex::new(0),
             is_expanding: AtomicBool::new(false),
+            #[cfg(target_os = "linux")]
+            launcher_shown_at: Mutex::new(None),
         }
     }
 

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -47,6 +47,44 @@ pub struct AppState {
     pub linux_prev_window_id: Mutex<u64>,
     /// Set during snippet expansion to suppress the monitor from re-triggering.
     pub is_expanding: AtomicBool,
+    /// When the launcher was last revealed. Read by the blur handler on Wayland
+    /// to ignore the spurious `Focused(false)` that arrives before the
+    /// compositor has granted keyboard focus. See `blur_hide_is_spurious`.
+    #[cfg(target_os = "linux")]
+    pub launcher_shown_at: Mutex<Option<std::time::Instant>>,
+}
+
+/// How long after a reveal a `Focused(false)` is treated as compositor noise
+/// rather than a real click-away.
+#[cfg(target_os = "linux")]
+pub const BLUR_HIDE_GRACE: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// True when a `Focused(false)` arrived so soon after the reveal that it cannot
+/// be a deliberate click-away.
+///
+/// Wayland has no way for a client to focus itself: `set_focus()` sends an
+/// xdg-activation request and returns `Ok(())` whether or not the compositor
+/// honours it. Between `show()` and the compositor granting focus, the window
+/// is mapped but unfocused, so the blur handler fires and hides the launcher
+/// the instant it appears. Under `input:follow_mouse` the compositor may
+/// never grant focus at all, because the pointer is still over whatever the
+/// user was looking at.
+///
+/// X11 is unaffected (the grab focuses synchronously) but shares this code
+/// path; the grace window is short enough that a real click-away inside it is
+/// not humanly reachable.
+#[cfg(target_os = "linux")]
+pub fn blur_hide_is_spurious(shown_at: Option<std::time::Instant>) -> bool {
+    shown_at.is_some_and(|t| t.elapsed() < BLUR_HIDE_GRACE)
+}
+
+/// Start the blur grace window. Called from every path that reveals the
+/// launcher; a later call simply extends the window.
+#[cfg(target_os = "linux")]
+pub fn mark_launcher_shown(state: &AppState) {
+    if let Ok(mut guard) = state.launcher_shown_at.lock() {
+        *guard = Some(std::time::Instant::now());
+    }
 }
 
 /// Adapts the managed `runtimes::RuntimeManager` to
@@ -192,7 +230,26 @@ pub fn run() {
         // feature) forwards that instance's asyar:// URL argv into on_open_url
         // — the only way a deep link reaches an already-running app on
         // Windows/Linux.
-        .plugin(tauri_plugin_single_instance::init(|_app, _args, _cwd| {}))
+        .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+            // A bare re-exec (`asyar` with no URL argv) is a summon request:
+            // it is the only way a Wayland compositor can drive the launcher,
+            // since the X11 key grab behind tauri-plugin-global-shortcut never
+            // sees keystrokes there. Bind a compositor key to the binary and
+            // this callback toggles the already-running instance.
+            //
+            // Skip when argv carries an asyar:// URL — those instances exist to
+            // deliver a deep link, and the deep-link handler decides on its own
+            // whether to reveal the window (view commands do, background ones
+            // do not). Toggling here would fight that, and would *hide* the
+            // launcher whenever a deep link arrived while it was open.
+            let scheme = deeplink::deep_link_scheme(app);
+            let carries_deeplink = args
+                .iter()
+                .any(|arg| arg.starts_with(&format!("{scheme}://")));
+            if !carries_deeplink {
+                commands::toggle_launcher(app);
+            }
+        }))
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_clipboard_x::init())
@@ -306,6 +363,8 @@ pub fn run() {
             #[cfg(target_os = "linux")]
             linux_prev_window_id: Mutex::new(0),
             is_expanding: AtomicBool::new(false),
+            #[cfg(target_os = "linux")]
+            launcher_shown_at: Mutex::new(None),
         })
         .manage(crate::onboarding::commands::OnboardingCursor::new(cfg!(
             target_os = "macos"
@@ -1756,10 +1815,21 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         window.on_window_event(move |event| {
             if let tauri::WindowEvent::Focused(false) = event {
                 let state = handle_clone.state::<AppState>();
-                if !state.focus_locked.load(Ordering::Relaxed) {
-                    state.asyar_visible.store(false, Ordering::Relaxed);
-                    let _ = window_clone.hide();
+                if state.focus_locked.load(Ordering::Relaxed) {
+                    return;
                 }
+                // Drop the blur that races the reveal on Wayland — otherwise
+                // the launcher hides itself the moment it is summoned.
+                #[cfg(target_os = "linux")]
+                {
+                    let shown_at = state.launcher_shown_at.lock().ok().and_then(|g| *g);
+                    if blur_hide_is_spurious(shown_at) {
+                        log::debug!("[launcher] ignoring blur within reveal grace window");
+                        return;
+                    }
+                }
+                state.asyar_visible.store(false, Ordering::Relaxed);
+                let _ = window_clone.hide();
             }
         });
     }
@@ -2412,6 +2482,34 @@ mod appearance_theme_tests {
     fn returns_system_when_json_is_empty_object() {
         let v = json!({});
         assert_eq!(parse_appearance_theme(Some(&v)), ThemePreference::System);
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod blur_hide_grace_tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn never_suppresses_when_the_launcher_was_never_shown() {
+        assert!(!blur_hide_is_spurious(None));
+    }
+
+    #[test]
+    fn suppresses_a_blur_that_lands_immediately_after_the_reveal() {
+        assert!(blur_hide_is_spurious(Some(Instant::now())));
+    }
+
+    #[test]
+    fn allows_a_blur_once_the_grace_window_has_elapsed() {
+        let long_ago = Instant::now() - (BLUR_HIDE_GRACE + Duration::from_millis(50));
+        assert!(!blur_hide_is_spurious(Some(long_ago)));
+    }
+
+    #[test]
+    fn allows_a_deliberate_click_away_seconds_later() {
+        let earlier = Instant::now() - Duration::from_secs(5);
+        assert!(!blur_hide_is_spurious(Some(earlier)));
     }
 }
 


### PR DESCRIPTION
## Context

Wayland gives no client a global key grab, so the X11 grab behind `tauri-plugin-global-shortcut` never fires there. The launcher currently cannot be summoned at all on Wayland — which is what the README's "❌ Not supported for global hooks" reflects.

The fix isn't to make the grab work; it can't. It's to hand the key to the compositor and give it a way to drive an already-running instance:

```
bind = ALT, SPACE, exec, asyar    # Hyprland; same idea on sway, KDE, GNOME
```

## What's here

Two halves that are useless apart, which is why they're one PR.

**1. Toggle on re-exec.** The `tauri-plugin-single-instance` callback was an empty closure. It now toggles the launcher, so a second launch of the binary reveals or hides the running instance. The toggle body is lifted out of `handle_shortcut` into `toggle_launcher` — a pure move, no behaviour change on the hotkey path.

Instances carrying an `asyar://` URL are skipped: those exist to deliver a deep link, whose handler already decides whether to reveal the window (view commands do, background ones don't). Without the guard, a deep link arriving while the launcher was open would hide it.

**2. Blur grace window.** `set_focus()` cannot focus a window on Wayland — it sends an xdg-activation request and returns `Ok(())` whether or not the compositor honours it. Between `show()` and the compositor granting focus, the window is mapped but unfocused, so the `Focused(false)` handler hides the launcher the instant it's summoned. Under `follow_mouse` the compositor may never grant focus at all, because the pointer is still over whatever the user was looking at.

A blur within 250ms of a reveal is therefore treated as compositor noise. Anything later still hides, so click-away is unchanged.

Without half 2, half 1 produces a launcher that maps and hides itself in the same frame. Without half 1, half 2 fixes a race nobody can reach.

## Scope

Linux-only (`#[cfg(target_os = "linux")]`), so Windows behaviour is untouched. X11 shares the path harmlessly — its grab focuses synchronously, and no human reaches a deliberate click-away inside 250ms.

## Testing

Four unit tests on the grace-window predicate. Verified on Hyprland 0.56.2 / Arch:

- four consecutive toggles alternate cleanly
- the launcher takes keyboard focus when shown (`hyprctl activewindow` → `asyar`)
- the previously focused window regains focus when hidden
- moving focus away still hides it, so click-away survives

Before the grace window, repeated toggles left the launcher permanently hidden.

Cost is ~250ms per press: process spawn plus dynamic linking, against ~12ms for the in-process grab. Unavoidable with a re-exec, and it only applies to compositor-bound summons.

> [!NOTE]
> **Reviewing on Wayland:** the app cannot start on this branch alone because of the snap-guides abort in #610. Apply that first to exercise this. The two don't otherwise depend on each other and can merge in either order.

## Caveats

This does not make Asyar fully work on Wayland. Snippets, selection capture, window management and frontmost-app events remain broken — some by Wayland's security model. What this buys is that the app can be summoned, which is the difference between unusable and usable-with-known-gaps.

I've only tested Hyprland. The mechanisms are compositor-agnostic, but the 250ms constant is tuned against one compositor's timing and may want revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)