### PR TITLE
fix(ai): resolve provider engine type by provider_type, not connection id

### DIFF
--- a/asyar-launcher/src-tauri/src/agents/runner.rs
+++ b/asyar-launcher/src-tauri/src/agents/runner.rs
@@ -533,8 +533,12 @@ pub(crate) fn resolve_provider_config<'a>(
             "provider '{provider_id}' is disabled"
         )));
     }
+    // Named connections carry an opaque id like "custom_60f9a975"; the
+    // engine that actually handles the request lives in `provider_type`,
+    // falling back to `provider_id` for legacy configs that predate it.
+    let engine_type = config.provider_type.as_deref().unwrap_or(provider_id);
     if !matches!(
-        provider_id,
+        engine_type,
         "openai" | "anthropic" | "google" | "ollama" | "openrouter" | "custom"
     ) {
         return Err(AppError::Validation(format!(
@@ -542,7 +546,7 @@ pub(crate) fn resolve_provider_config<'a>(
         )));
     }
     if matches!(
-        provider_id,
+        engine_type,
         "openai" | "anthropic" | "google" | "openrouter"
     ) && config
         .api_key
@@ -555,7 +559,7 @@ pub(crate) fn resolve_provider_config<'a>(
             "API key for provider '{provider_id}' is not configured"
         )));
     }
-    if matches!(provider_id, "ollama" | "custom")
+    if matches!(engine_type, "ollama" | "custom")
         && config
             .base_url
             .as_deref()

--- a/asyar-launcher/src-tauri/src/agents/runner_test.rs
+++ b/asyar-launcher/src-tauri/src/agents/runner_test.rs
@@ -982,6 +982,19 @@ fn resolve_provider_config_errors_for_an_unregistered_provider_id() {
 }
 
 #[test]
+fn resolve_provider_config_succeeds_for_a_named_connection_id() {
+    // Named connections (added via the "multiple provider connections"
+    // feature) get an opaque id like "custom_60f9a975" — the real engine
+    // lives in `provider_type`, not the map key.
+    let mut config = valid_openai_config();
+    config.provider_type = Some("custom".to_string());
+    config.base_url = Some("https://example.com/v1".to_string());
+    let configs = std::collections::HashMap::from([("custom_60f9a975".to_string(), config)]);
+    let resolved = resolve_provider_config("custom_60f9a975", &configs).unwrap();
+    assert_eq!(resolved.provider_type.as_deref(), Some("custom"));
+}
+
+#[test]
 fn resolve_provider_config_errors_when_api_key_is_missing() {
     let mut config = valid_openai_config();
     config.api_key = Some("   ".to_string());


### PR DESCRIPTION
Named provider connections (e.g. custom_60f9a975) never matched the
hardcoded engine whitelist in resolve_provider_config, so any run
against a named connection failed with "provider '...' is not
registered" even though model listing worked fine.