### PR TITLE
fix(applications): resolve and propagate localized macOS app names

### DIFF
--- a/asyar-launcher/src-tauri/Cargo.lock
+++ b/asyar-launcher/src-tauri/Cargo.lock
@@ -265,6 +265,7 @@ dependencies = [
  "sha2",
  "specta",
  "specta-typescript",
+ "sys-locale",
  "sysinfo",
  "tar",
  "tauri",

--- a/asyar-launcher/src-tauri/Cargo.toml
+++ b/asyar-launcher/src-tauri/Cargo.toml
@@ -43,6 +43,9 @@ r2d2 = "0.8"
 # track newer rusqlite majors and will not link against the pin above.
 r2d2_sqlite = "0.24"
 plist = "1.7"
+# The user's language preference, which is what bundle display names must be
+# resolved against — Cocoa's own lookups answer in the host process's language.
+sys-locale = "0.3"
 tauri-plugin-notification = "2"
 tokio = { version = "1.0", features = ["full"] }
 tauri-plugin-clipboard-x = "2"

--- a/asyar-launcher/src-tauri/src/application/service.rs
+++ b/asyar-launcher/src-tauri/src/application/service.rs
@@ -567,39 +567,13 @@ pub(crate) fn bundle_file_name(path: &Path) -> String {
         .to_string()
 }
 
-/// The name macOS presents for a bundle, which is localized — `Photos.app`
-/// reads as "Fotos" on a German system. Returns `None` when the OS has
-/// nothing to add, so callers fall back to the file name.
-#[cfg(target_os = "macos")]
-pub(crate) fn localized_display_name(path: &Path) -> Option<String> {
-    use objc2_foundation::{NSFileManager, NSString};
-
-    let path_str = path.to_str()?;
-    let ns_path = NSString::from_str(path_str);
-    let display = unsafe { NSFileManager::defaultManager().displayNameAtPath(&ns_path) };
-    // Finder hides the extension by default but honours the user's
-    // "show all filename extensions" setting, so it may come back either way.
-    let display = display.to_string();
-    let trimmed = display.strip_suffix(".app").unwrap_or(&display).trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
-}
-
-/// What the user sees for this app. Localized on macOS, the plain file name
-/// everywhere else. Deliberately separate from [`bundle_file_name`] — search
-/// matches both, but only the file name may reach `build_app_id`.
+/// What the user sees for this app: the name translated into the user's
+/// language where the bundle ships one, the plain file name otherwise.
+///
+/// Deliberately separate from [`bundle_file_name`] — search matches both, but
+/// only the file name may reach `build_app_id`.
 pub(crate) fn display_name(path: &Path) -> String {
-    #[cfg(target_os = "macos")]
-    {
-        localized_display_name(path).unwrap_or_else(|| bundle_file_name(path))
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        bundle_file_name(path)
-    }
+    crate::platform::localized_bundle_name(path).unwrap_or_else(|| bundle_file_name(path))
 }
 
 pub(crate) fn extract_bundle_id(path: &Path) -> Option<String> {
@@ -910,16 +884,17 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "macos")]
-    fn test_localized_display_name_resolves_system_app() {
-        // Locale-independent on purpose: an English system answers "Photos",
-        // a German one "Fotos". Asserting either would fail on the other, so
-        // only assert the properties that must hold in every locale.
-        let name = localized_display_name(Path::new("/System/Applications/Photos.app"))
-            .expect("macOS must resolve a display name for a stock system app");
+    fn test_display_name_resolves_a_stock_system_app() {
+        // Whether the answer reads "Photos" or "Fotos" depends on the machine
+        // running the suite, so only the locale-independent properties are
+        // asserted here. That the *right* translation is picked is covered
+        // deterministically in `platform::macos::display_name`, where the
+        // locale is injected instead of read from the host.
+        let name = display_name(Path::new("/System/Applications/Photos.app"));
         assert!(!name.is_empty());
         assert!(
             !name.ends_with(".app"),
-            "extension must be stripped, got {name}"
+            "the extension must never leak into a display name, got {name}"
         );
     }
 

--- a/asyar-launcher/src-tauri/src/application/service.rs
+++ b/asyar-launcher/src-tauri/src/application/service.rs
@@ -150,7 +150,11 @@ pub fn sync_application_index<R: tauri::Runtime>(
     let removed = to_remove.len() as u32;
 
     // 5. Update SearchState
-    if !to_add.is_empty() || !to_remove.is_empty() {
+    //
+    // The write lock is taken unconditionally: an app can need updating without
+    // being added or removed, and `refresh_display_names` below is the only
+    // thing that catches it.
+    let renamed = {
         let mut items = search_state
             .items
             .write()
@@ -161,12 +165,16 @@ pub fn sync_application_index<R: tauri::Runtime>(
             items.retain(|item| !remove_set.contains(item.id()));
         }
 
+        let renamed = refresh_display_names(&mut items, &current_apps);
+
         for id in to_add {
             if let Some(app) = current_apps.remove(&id) {
                 items.push(SearchableItem::Application(app));
             }
         }
-    }
+
+        renamed
+    };
 
     // 6. Persist
     search_state
@@ -182,14 +190,48 @@ pub fn sync_application_index<R: tauri::Runtime>(
     };
 
     info!(
-        "App sync complete: {} added, {} removed, {} total apps",
-        added, removed, total
+        "App sync complete: {} added, {} removed, {} renamed, {} total apps",
+        added, removed, renamed, total
     );
     Ok(SyncResult {
         added,
         removed,
         total,
     })
+}
+
+/// Brings the names of already-indexed apps back in line with what a fresh
+/// scan reports, returning how many changed.
+///
+/// The add/remove diff cannot do this. An app's id is built from its bundle
+/// file name (see [`bundle_file_name`]), which no rename of the *displayed*
+/// name touches — so such an app sits in both the indexed and the scanned set
+/// and is neither added nor removed. Without this pass it would keep whatever
+/// name it was first indexed under for the lifetime of the index: a user
+/// switching macOS to German would go on seeing "Photos", and so would every
+/// install that was indexed before this resolution was fixed.
+///
+/// Only the name is copied over. `usage_count` and `last_used_at` live on the
+/// indexed item and are absent from a freshly scanned one, so swapping the
+/// whole struct would silently reset every app's frecency on each scan.
+fn refresh_display_names(
+    items: &mut [SearchableItem],
+    scanned: &HashMap<String, Application>,
+) -> u32 {
+    let mut renamed = 0;
+    for item in items.iter_mut() {
+        let SearchableItem::Application(indexed) = item else {
+            continue;
+        };
+        let Some(fresh) = scanned.get(&indexed.id) else {
+            continue;
+        };
+        if indexed.name != fresh.name {
+            indexed.name.clone_from(&fresh.name);
+            renamed += 1;
+        }
+    }
+    renamed
 }
 
 pub fn list_applications<R: tauri::Runtime>(
@@ -880,6 +922,87 @@ mod tests {
     fn test_is_default_app_location_macos_matches_applications_dir() {
         assert!(is_default_app_location("/Applications/Finder.app"));
         assert!(is_default_app_location("/System/Applications/Calendar.app"));
+    }
+
+    /// An app as the index holds it, carrying frecency data a scan never has.
+    fn indexed_app(id: &str, name: &str, usage_count: u32) -> SearchableItem {
+        SearchableItem::Application(Application {
+            id: id.to_string(),
+            name: name.to_string(),
+            path: format!("/Applications/{name}.app"),
+            usage_count,
+            icon: None,
+            last_used_at: Some(1_700_000_000),
+            bundle_id: None,
+        })
+    }
+
+    /// The same app as a fresh scan reports it: no usage history.
+    fn scanned_app(id: &str, name: &str) -> (String, Application) {
+        (
+            id.to_string(),
+            Application {
+                id: id.to_string(),
+                name: name.to_string(),
+                path: format!("/Applications/{name}.app"),
+                usage_count: 0,
+                icon: None,
+                last_used_at: None,
+                bundle_id: None,
+            },
+        )
+    }
+
+    #[test]
+    fn test_refresh_display_names_updates_a_stale_name() {
+        // The reported bug: an app indexed as "Photos" before the localized
+        // name resolved correctly keeps its id, so the add/remove diff never
+        // touches it. This pass is what makes the new name reach the index.
+        let mut items = vec![indexed_app("app_Photos", "Photos", 0)];
+        let scanned = HashMap::from([scanned_app("app_Photos", "Fotos")]);
+
+        assert_eq!(refresh_display_names(&mut items, &scanned), 1);
+        assert_eq!(items[0].get_name(), "Fotos");
+    }
+
+    #[test]
+    fn test_refresh_display_names_preserves_frecency() {
+        // Guards the reason only the name is copied: replacing the indexed
+        // item with the scanned one would zero the usage history of every
+        // renamed app on the very next scan.
+        let mut items = vec![indexed_app("app_Photos", "Photos", 42)];
+        let scanned = HashMap::from([scanned_app("app_Photos", "Fotos")]);
+
+        refresh_display_names(&mut items, &scanned);
+
+        let SearchableItem::Application(app) = &items[0] else {
+            panic!("item must stay an application");
+        };
+        assert_eq!(app.usage_count, 42, "usage count must survive a rename");
+        assert_eq!(
+            app.last_used_at,
+            Some(1_700_000_000),
+            "last use must survive a rename"
+        );
+    }
+
+    #[test]
+    fn test_refresh_display_names_leaves_matching_and_unscanned_items_alone() {
+        let mut items = vec![
+            indexed_app("app_Safari", "Safari", 7),
+            // Not in the scan — e.g. an app on a scan path the user just
+            // removed. Untouched here; the remove diff owns that case.
+            indexed_app("app_Ghost", "Ghost", 3),
+        ];
+        let scanned = HashMap::from([scanned_app("app_Safari", "Safari")]);
+
+        assert_eq!(
+            refresh_display_names(&mut items, &scanned),
+            0,
+            "an unchanged name must not count as a rename"
+        );
+        assert_eq!(items[0].get_name(), "Safari");
+        assert_eq!(items[1].get_name(), "Ghost");
     }
 
     #[test]

--- a/asyar-launcher/src-tauri/src/platform/macos.rs
+++ b/asyar-launcher/src-tauri/src/platform/macos.rs
@@ -1,6 +1,7 @@
 #![allow(deprecated)]
 //! macOS platform integration, split by concern:
 //! - `appearance` — theme resolution + panel appearance/material
+//! - `display_name` — the localized name a bundle presents to the user
 //! - `window`     — spotlight/HUD/sticky panels, geometry, resize, WebKit tuning
 //! - `icon`       — app-icon extraction (.icns fast path + NSWorkspace fallback)
 //! - `haptics`    — trackpad haptic feedback (drag-to-snap)
@@ -19,6 +20,7 @@ pub enum ResolvedTheme {
 }
 
 mod appearance;
+mod display_name;
 mod haptics;
 mod icon;
 mod input;
@@ -26,6 +28,7 @@ mod system;
 mod window;
 
 pub use appearance::*;
+pub use display_name::*;
 pub use haptics::*;
 pub use icon::*;
 pub use input::*;

--- a/asyar-launcher/src-tauri/src/platform/macos/display_name.rs
+++ b/asyar-launcher/src-tauri/src/platform/macos/display_name.rs
@@ -1,0 +1,204 @@
+use std::path::Path;
+
+/// The name macOS shows for a bundle in Finder and Spotlight.
+///
+/// On a German system `/System/Applications/Photos.app` displays as "Fotos"
+/// while its on-disk file stem stays "Photos". Apple ships that translation
+/// inside the bundle itself:
+/// - modern bundles: `Contents/Resources/InfoPlist.loctable`, one plist keyed
+///   by language code, each value an Info.plist fragment;
+/// - older bundles: `Contents/Resources/<lang>.lproj/InfoPlist.strings`.
+///
+/// Cocoa's own lookups are deliberately not used here. Both `NSFileManager
+/// displayNameAtPath:` and `NSBundle localizedInfoDictionary` resolve against
+/// the *calling process's* effective localization rather than the user's
+/// language preference, so an unlocalized host process — which is what this
+/// binary is — gets "Photos" back on a German machine. Reading the table
+/// against the user's locale gives the name the user actually sees.
+///
+/// Returns `None` when the bundle ships no translation for the user's locale,
+/// which is the common case: callers fall back to the on-disk file stem.
+pub fn localized_bundle_name(path: &Path) -> Option<String> {
+    localized_bundle_name_in_locale(path, &sys_locale::get_locale()?)
+}
+
+fn localized_bundle_name_in_locale(path: &Path, locale: &str) -> Option<String> {
+    let resources = path.join("Contents/Resources");
+    language_candidates(locale).into_iter().find_map(|lang| {
+        name_from_loctable(&resources.join("InfoPlist.loctable"), &lang).or_else(|| {
+            name_from_info_plist_strings(&resources.join(format!("{lang}.lproj/InfoPlist.strings")))
+        })
+    })
+}
+
+/// Language keys to try, most specific first — `de-DE` before `de`. Bundles key
+/// their tables either way, and macOS itself falls back along the same chain.
+fn language_candidates(locale: &str) -> Vec<String> {
+    let regional = locale.replace('_', "-");
+    let base = regional.split('-').next().unwrap_or_default().to_string();
+    match () {
+        _ if base.is_empty() => Vec::new(),
+        _ if base == regional => vec![base],
+        _ => vec![regional, base],
+    }
+}
+
+fn name_from_loctable(path: &Path, lang: &str) -> Option<String> {
+    let table = plist::Value::from_file(path).ok()?;
+    display_name_in(table.as_dictionary()?.get(lang)?.as_dictionary()?)
+}
+
+/// Reads a `<lang>.lproj/InfoPlist.strings`. Modern bundles ship these as
+/// binary plists, which `plist` parses; the legacy UTF-16 text form is left
+/// alone, since any bundle old enough to use it predates the loctable that
+/// covers everything else.
+fn name_from_info_plist_strings(path: &Path) -> Option<String> {
+    let strings = plist::Value::from_file(path).ok()?;
+    display_name_in(strings.as_dictionary()?)
+}
+
+/// `CFBundleDisplayName` is the user-facing name; `CFBundleName` is the
+/// shorter menu-bar variant and stands in when no display name is translated.
+fn display_name_in(dict: &plist::Dictionary) -> Option<String> {
+    ["CFBundleDisplayName", "CFBundleName"]
+        .into_iter()
+        .filter_map(|key| dict.get(key)?.as_string())
+        .map(strip_invisible_marks)
+        .find(|name| !name.is_empty())
+}
+
+/// Removes zero-width typographic marks from a translated name.
+///
+/// Apple embeds a soft hyphen in some of them — German "System\u{ad}einstellungen"
+/// is a real example — purely as a line-breaking hint. It is invisible on
+/// screen, so a user never types it, and leaving it in would keep an exact
+/// query from matching exactly.
+fn strip_invisible_marks(name: &str) -> String {
+    name.chars()
+        .filter(|c| {
+            !matches!(
+                c,
+                '\u{ad}' | '\u{200b}' | '\u{200e}' | '\u{200f}' | '\u{feff}'
+            )
+        })
+        .collect::<String>()
+        .trim()
+        .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Writes a bundle carrying an `InfoPlist.loctable` with the given
+    /// language → display-name pairs.
+    fn bundle_with_loctable(dir_name: &str, entries: &[(&str, &str)]) -> std::path::PathBuf {
+        let bundle = std::env::temp_dir()
+            .join("asyar_test_display_name")
+            .join(dir_name);
+        let _ = std::fs::remove_dir_all(&bundle);
+        let resources = bundle.join("Contents/Resources");
+        std::fs::create_dir_all(&resources).unwrap();
+
+        let mut table = plist::Dictionary::new();
+        for (lang, name) in entries {
+            let mut fragment = plist::Dictionary::new();
+            fragment.insert(
+                "CFBundleDisplayName".into(),
+                plist::Value::String((*name).into()),
+            );
+            table.insert((*lang).into(), plist::Value::Dictionary(fragment));
+        }
+        plist::to_file_binary(resources.join("InfoPlist.loctable"), &table).unwrap();
+
+        bundle
+    }
+
+    #[test]
+    fn reads_the_translated_name_from_the_loctable() {
+        // The reported bug: on a German system Photos.app must read as "Fotos".
+        let bundle = bundle_with_loctable("Photos.app", &[("de", "Fotos"), ("en", "Photos")]);
+        assert_eq!(
+            localized_bundle_name_in_locale(&bundle, "de-DE").as_deref(),
+            Some("Fotos")
+        );
+        assert_eq!(
+            localized_bundle_name_in_locale(&bundle, "en-US").as_deref(),
+            Some("Photos")
+        );
+    }
+
+    #[test]
+    fn prefers_a_regional_table_over_the_base_language() {
+        let bundle = bundle_with_loctable(
+            "Regional.app",
+            &[("pt-BR", "Brasileiro"), ("pt", "Português")],
+        );
+        assert_eq!(
+            localized_bundle_name_in_locale(&bundle, "pt-BR").as_deref(),
+            Some("Brasileiro")
+        );
+    }
+
+    #[test]
+    fn falls_back_from_a_regional_locale_to_the_base_language() {
+        // macOS reports "de-DE" while most bundles key their table on "de".
+        let bundle = bundle_with_loctable("BaseOnly.app", &[("de", "Fotos")]);
+        assert_eq!(
+            localized_bundle_name_in_locale(&bundle, "de-DE").as_deref(),
+            Some("Fotos")
+        );
+        assert_eq!(
+            localized_bundle_name_in_locale(&bundle, "de_DE").as_deref(),
+            Some("Fotos"),
+            "underscore locale forms must normalize to the same candidates"
+        );
+    }
+
+    #[test]
+    fn returns_none_when_the_locale_is_untranslated() {
+        // No guess, no wrong-language name — the caller keeps the file stem.
+        let bundle = bundle_with_loctable("Untranslated.app", &[("de", "Fotos")]);
+        assert_eq!(localized_bundle_name_in_locale(&bundle, "ja-JP"), None);
+    }
+
+    #[test]
+    fn returns_none_for_a_bundle_without_any_translation() {
+        let bundle = std::env::temp_dir().join("asyar_test_display_name/Plain.app");
+        let _ = std::fs::remove_dir_all(&bundle);
+        std::fs::create_dir_all(bundle.join("Contents/Resources")).unwrap();
+        assert_eq!(localized_bundle_name_in_locale(&bundle, "de-DE"), None);
+    }
+
+    #[test]
+    fn returns_none_for_a_missing_path() {
+        let missing = Path::new("/nonexistent/asyar/Ghost.app");
+        assert_eq!(localized_bundle_name_in_locale(missing, "de-DE"), None);
+    }
+
+    #[test]
+    fn language_candidates_are_ordered_most_specific_first() {
+        assert_eq!(language_candidates("de-DE"), vec!["de-DE", "de"]);
+        assert_eq!(language_candidates("de"), vec!["de"]);
+        assert!(language_candidates("").is_empty());
+    }
+
+    #[test]
+    fn strips_the_soft_hyphen_apple_embeds_in_translated_names() {
+        // macOS ships German System Settings as "System\u{ad}einstellungen".
+        // The mark is invisible, so a user typing the name never produces it —
+        // keeping it would deny the query an exact-title match.
+        let bundle =
+            bundle_with_loctable("SystemSettings.app", &[("de", "System\u{ad}einstellungen")]);
+        assert_eq!(
+            localized_bundle_name_in_locale(&bundle, "de-DE").as_deref(),
+            Some("Systemeinstellungen")
+        );
+    }
+
+    #[test]
+    fn treats_a_name_of_only_invisible_marks_as_absent() {
+        let bundle = bundle_with_loctable("Blank.app", &[("de", "\u{ad}\u{200b}")]);
+        assert_eq!(localized_bundle_name_in_locale(&bundle, "de-DE"), None);
+    }
+}

--- a/asyar-launcher/src-tauri/src/platform/mod.rs
+++ b/asyar-launcher/src-tauri/src/platform/mod.rs
@@ -22,3 +22,15 @@ pub use linux::extract_icon;
 pub use macos::extract_icon;
 #[cfg(target_os = "windows")]
 pub use windows::extract_icon;
+
+// Likewise for the localized bundle display name.
+#[cfg(target_os = "macos")]
+pub use macos::localized_bundle_name;
+
+/// Non-macOS builds have no bundle-level display-name lookup, so callers fall
+/// back to the file stem. Linux `.desktop` files do carry `Name[<lang>]=`
+/// entries — wiring those up is a separate change.
+#[cfg(not(target_os = "macos"))]
+pub fn localized_bundle_name(_path: &std::path::Path) -> Option<String> {
+    None
+}


### PR DESCRIPTION
## What

Follow-up to #590. That PR made macOS apps searchable under their localized name, but on a German system Photos.app is still indexed and displayed as "Photos", never "Fotos". Two independent defects stand in the way — the second one means fixing the first alone would change nothing for existing users.

---

## 1. The name lookup cannot return a localized name

`NSFileManager displayNameAtPath:` resolves against the **calling process's** effective localization, not the user's language preference. Asyar ships English only, so macOS answers in English regardless of system language. Measured on a `de-DE` machine:

```
FileManager.displayName(atPath: "/System/Applications/Photos.app")  = "Photos.app"
Locale.preferredLanguages                                           = ["de-DE"]
Bundle.main.preferredLocalizations                                  = ["en"]   ← the cause
Bundle(path:).localizedInfoDictionary["CFBundleDisplayName"]         = "Photos"
```

Stripping `.app` then yields `"Photos"` — identical to the file stem we already had. `NSBundle localizedInfoDictionary` shares the flaw, so it is not an alternative. Both APIs look correct in isolation, which is why this slipped through.

**Fix:** read the name from where Apple actually stores it — inside the bundle:

- `Contents/Resources/InfoPlist.loctable`, one plist per language code
- `<lang>.lproj/InfoPlist.strings` for bundles predating the loctable

resolved against `sys_locale::get_locale()` — the user's preference — so the result no longer depends on how the host process is localized. Returns `None` when a bundle ships no translation for the locale, and callers keep the file stem exactly as before.

Three details the real tables force:

- **`de-DE` before `de`.** macOS reports the regional form; most bundles key on the base language, some (pt-BR) on both.
- **`CFBundleName` as fallback.** System Settings.app ships no German `CFBundleDisplayName`, only `CFBundleName`.
- **Soft hyphen stripped.** Apple embeds `U+00AD` in some names (`System\u{ad}einstellungen`). It is invisible, so a user never types it — leaving it in denies the query an exact-title match.

The lookup moves to `platform/macos/display_name.rs`, next to the other OS-level wrappers, with a `None` stub for other platforms. Linux `.desktop` files carry `Name[<lang>]=` entries and could use the same treatment later.

## 2. A corrected name never reaches an existing index

`sync_application_index` is a pure add/remove diff keyed on the app id, and the id is built from the bundle **file** name — which no change to the displayed name touches. An app already in the index appears in both the indexed and the scanned set, so it is neither added nor removed, and its stored `name` is never written again.

Verified against a real index built by a released build:

```
name    | id
Photos  | app_Photos__System_Applications_Photos.app
```

So without this second commit, part 1 changes nothing for anyone who has already run Asyar — only a fresh install or a newly installed app would pick the translation up. The same blind spot hits a user who switches macOS to another language after the first scan.

**Fix:** `refresh_display_names` reconciles the names of entries that stay. It copies the name and nothing else — `usage_count` and `last_used_at` live on the indexed item and are zero on a freshly scanned one, so swapping the whole struct (the obvious shortcut) would wipe every renamed app's frecency on the next scan. A test pins that. The write lock is now taken on every sync, since a rename-only sync must still persist.

---

## Tests

The previous test asserted only locale-independent properties, which the broken implementation satisfied — it could not have caught this. The new unit tests **inject the locale** rather than reading it from the host, so the German case is asserted on every machine and in CI:

- translated name is read from the loctable (`de` → Fotos, `en` → Photos)
- regional table wins over the base language (pt-BR)
- regional locale falls back to the base language (`de-DE`/`de_DE` → `de`)
- untranslated locale, translation-less bundle, and missing path all yield `None`
- soft hyphen stripped; a name of only invisible marks counts as absent
- a stale indexed name is refreshed; frecency survives it; unchanged and unscanned entries are left alone

Verified end-to-end on a `de-DE` system through the real code path:

```
/System/Applications/Photos.app          -> Some("Fotos")
/System/Applications/Notes.app           -> Some("Notizen")
/System/Applications/System Settings.app -> Some("Systemeinstellungen")
/System/Applications/Calendar.app        -> Some("Kalender")
/Applications/Safari.app                 -> Some("Safari")
```

Both spellings stay searchable via the existing `search_names()` plumbing from #590, which is unchanged.

`cargo fmt --check` and `cargo clippy` clean. Full suite passes apart from `file_index::deep::mdfind::tests::probe_succeeds_on_a_real_mac`, which fails identically on unmodified `main` — pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)