### PR TITLE
fix(applications): index Finder on macOS

### DIFF
--- a/asyar-launcher/src-tauri/src/application/service.rs
+++ b/asyar-launcher/src-tauri/src/application/service.rs
@@ -267,18 +267,32 @@ impl AppScanner {
         }
     }
 
+    /// Records a discovered bundle, skipping one an earlier scan root already
+    /// yielded (#410).
+    fn record(&mut self, path: &Path) {
+        if let Some(path_str) = path.to_str() {
+            if self.seen.insert(path_str.to_string()) {
+                self.paths.push(path_str.to_string());
+            }
+        }
+    }
+
     fn scan_directory(&mut self, dir_path: &Path) -> Result<(), AppError> {
+        // A scan root may name a single bundle rather than a folder of them —
+        // the Finder entry in the macOS defaults, or a custom path a user
+        // aimed straight at one app. That bundle *is* the app: record it and
+        // stop, because descending would index the helper apps nested in it.
+        if is_app_bundle(dir_path) && dir_path.exists() {
+            self.record(dir_path);
+            return Ok(());
+        }
         if !dir_path.is_dir() {
             return Ok(());
         }
         for entry in fs::read_dir(dir_path)?.filter_map(Result::ok) {
             let path = entry.path();
             if is_app_bundle(&path) {
-                if let Some(path_str) = path.to_str() {
-                    if self.seen.insert(path_str.to_string()) {
-                        self.paths.push(path_str.to_string());
-                    }
-                }
+                self.record(&path);
             } else if path.is_dir() {
                 let _ = self.scan_directory(&path);
             }
@@ -454,6 +468,14 @@ pub fn get_default_app_scan_paths() -> Vec<PathBuf> {
         let mut paths = vec![
             PathBuf::from("/Applications"),
             PathBuf::from("/System/Applications"),
+            // Finder lives in neither app folder. Named as a single bundle
+            // rather than scanning its directory: /System/Library/CoreServices
+            // holds ~150 bundles, nearly all background agents and helpers no
+            // one launches (rcd, PIPAgent, liquiddetectiond, …). Filtering
+            // those by LSUIElement/LSBackgroundOnly still leaves a couple of
+            // dozen, so the whole directory is not worth its noise for the one
+            // app users actually ask for by name.
+            PathBuf::from("/System/Library/CoreServices/Finder.app"),
         ];
         // Installers that don't ask for admin rights write here instead of
         // /Applications. Same rationale as the per-user locations the Linux
@@ -904,8 +926,104 @@ mod tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn test_is_default_app_location_macos_matches_applications_dir() {
-        assert!(is_default_app_location("/Applications/Finder.app"));
+        // Not Finder.app — no such path exists. Finder has its own tests below.
+        assert!(is_default_app_location("/Applications/Safari.app"));
         assert!(is_default_app_location("/System/Applications/Calendar.app"));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_default_scan_paths_include_finder() {
+        // Finder ships in /System/Library/CoreServices, which is neither
+        // /Applications nor /System/Applications nor ~/Applications, so no
+        // scan ever reached it and searching "finder" returned no application.
+        let finder = Path::new("/System/Library/CoreServices/Finder.app");
+        let paths = get_default_app_scan_paths();
+        assert!(
+            paths.iter().any(|p| p == finder),
+            "Finder must be a default scan target, got {:?}",
+            paths
+        );
+        assert!(
+            is_default_app_location(finder.to_str().unwrap()),
+            "Finder must count as a default location, so its row shows no path subtitle"
+        );
+    }
+
+    #[test]
+    fn test_scanner_records_a_scan_root_that_is_itself_a_bundle() {
+        // A scan entry may name a single bundle rather than a folder of them —
+        // the Finder entry above, or a custom path a user aimed straight at one
+        // app. Only a root's children were ever considered, so such an entry
+        // yielded nothing at all.
+        let tmp = std::env::temp_dir().join("asyar_test_bundle_root");
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).unwrap();
+
+        #[cfg(target_os = "macos")]
+        let app_path = tmp.join("Rooted.app");
+        #[cfg(target_os = "linux")]
+        let app_path = tmp.join("rooted.desktop");
+        #[cfg(target_os = "windows")]
+        let app_path = tmp.join("Rooted.lnk");
+
+        #[cfg(target_os = "macos")]
+        fs::create_dir_all(&app_path).unwrap();
+        #[cfg(not(target_os = "macos"))]
+        fs::write(&app_path, b"fake").unwrap();
+
+        let mut scanner = AppScanner::new();
+        scanner.scan_directory(&app_path).unwrap();
+
+        assert_eq!(
+            scanner.paths,
+            vec![app_path.to_str().unwrap().to_string()],
+            "a scan root that is itself a bundle must be recorded"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_scanner_does_not_descend_into_a_bundle_root() {
+        // Bundles nest helper apps under Contents/. Recursing into a bundle
+        // root would index those helpers in place of the app itself.
+        let tmp = std::env::temp_dir().join("asyar_test_bundle_root_nested");
+        let _ = fs::remove_dir_all(&tmp);
+        let outer = tmp.join("Outer.app");
+        fs::create_dir_all(outer.join("Contents/Library/Helper.app")).unwrap();
+
+        let mut scanner = AppScanner::new();
+        scanner.scan_directory(&outer).unwrap();
+
+        assert_eq!(
+            scanner.paths,
+            vec![outer.to_str().unwrap().to_string()],
+            "nested helper bundles must not be indexed, got {:?}",
+            scanner.paths
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_scanner_ignores_a_bundle_scan_root_that_is_absent() {
+        // The Finder entry is an absolute path we assume exists. A macOS
+        // release that moves or drops it must degrade to "not indexed", not to
+        // a row pointing at nothing.
+        #[cfg(target_os = "macos")]
+        let missing = std::env::temp_dir().join("asyar_absent_bundle.app");
+        #[cfg(target_os = "linux")]
+        let missing = std::env::temp_dir().join("asyar_absent_bundle.desktop");
+        #[cfg(target_os = "windows")]
+        let missing = std::env::temp_dir().join("asyar_absent_bundle.lnk");
+        let _ = fs::remove_dir_all(&missing);
+
+        let mut scanner = AppScanner::new();
+        scanner.scan_directory(&missing).unwrap();
+
+        assert!(scanner.paths.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## The problem

Searching `finder` returns no application at all.

Finder ships in `/System/Library/CoreServices`, which is none of the three roots `get_default_app_scan_paths` returns — `/Applications`, `/System/Applications`, `~/Applications`. No scan ever reached it.

A stale assertion hid this: the location test claimed `/Applications/Finder.app`, a path that exists on no macOS install.

## The fix

**Name the bundle directly rather than adding its directory.** `/System/Library/CoreServices` holds ~150 bundles, nearly all background agents and helpers nobody launches (`rcd`, `PIPAgent`, `liquiddetectiond`, …). Filtering by `LSUIElement`/`LSBackgroundOnly` still leaves a couple of dozen, which is not worth the noise for the one app users ask for by name.

That required teaching the scanner about **a scan root that is itself a bundle**. It only ever looked at a root's *children*, so such an entry yielded nothing — which also silently swallowed any custom scan path a user aimed straight at a single app.

Such a root is now recorded and **not descended into**. Bundles nest helper apps under `Contents/`, so recursing would index those in place of the app itself. A test pins this, because the naive fix indexes `Outer.app/Contents/Library/Helper.app` instead of `Outer.app`.

A missing bundle degrades to "not indexed" rather than to a row pointing at nothing — the entry is an absolute path we assume exists, and a future macOS release may move it.

## Verification

On macOS 26, scanning the real filesystem:

```
gescannt: 256 Bundles          (was 255 — exactly one addition)
aus CoreServices: ["/System/Library/CoreServices/Finder.app"]
is_default_app_location: true   → row shows no path subtitle
```

New tests, each red before the change:

- `test_default_scan_paths_include_finder`
- `test_scanner_records_a_scan_root_that_is_itself_a_bundle`
- `test_scanner_does_not_descend_into_a_bundle_root`
- `test_scanner_ignores_a_bundle_scan_root_that_is_absent`

`cargo test --lib`, `cargo clippy --all-targets`, `cargo fmt --check` all clean.

## Relation to #626

Independent. #626 fixes how a name is *resolved* (localized display names); this fixes which paths are *scanned*. Both branch off `main` and can merge in either order. Together they close the two halves of a report where neither Fotos nor Finder could be found on a German system.
