### PR TITLE
feat(launcher): auto-register extension preferences action (#625)

### DIFF
--- a/asyar-launcher/src/services/extension/ExtensionLoader.test.ts
+++ b/asyar-launcher/src/services/extension/ExtensionLoader.test.ts
@@ -72,6 +72,7 @@ vi.mock('../envService', () => ({ envService: { isDev: vi.fn().mockReturnValue(f
 vi.mock('../../lib/ipc/commands', () => ({
   syncSearchIndex: vi.fn().mockResolvedValue(undefined),
   syncCommandIndex: vi.fn().mockResolvedValue(undefined),
+  showSettingsWindow: vi.fn().mockResolvedValue(undefined),
 }));
 const mockCommandHandlers = vi.hoisted(() => new Map<string, any>());
 vi.mock('./commandService.svelte', () => ({
@@ -271,6 +272,92 @@ describe('ExtensionLoader.registerManifestActions', () => {
       mockSearchStores.selectedIndex = 0;
       mockSearchOrchestrator.items = [
         { type: 'command', extensionId: 'test-ext', objectId: 'cmd_test-ext_do-thing' },
+      ];
+      expect(action.visible()).toBe(true);
+    });
+  });
+
+  describe('Extension preferences action auto-registration', () => {
+    it('auto-registers act_<ext>_open_preferences when manifest has preferences', async () => {
+      const manifest = {
+        ...makeManifest('pref-ext'),
+        preferences: [{ name: 'apiKey', type: 'textfield' as const, title: 'API Key' }],
+      };
+      const loader = makeLoader([{ cmd: makeCommand('my-cmd'), manifest, isBuiltIn: true }]);
+
+      loader.registerManifestActions();
+
+      const action = registeredActions.find((a) => a.id === 'act_pref-ext_open_preferences');
+      expect(action).toBeDefined();
+      expect(action.label).toBe('Extension Preferences');
+      expect(action.category).toBe('Preferences');
+      expect(action.icon).toBe('icon:sliders');
+      expect(action.extensionId).toBe('pref-ext');
+      expect(action.context).toBe(ActionContext.CORE);
+
+      // Visibility: true when a command from this extension is selected
+      mockSearchStores.selectedIndex = 0;
+      mockSearchOrchestrator.items = [
+        { type: 'command', extensionId: 'pref-ext', objectId: 'cmd_pref-ext_my-cmd' },
+      ];
+      expect(action.visible()).toBe(true);
+
+      // Visibility: false when a different extension is selected
+      mockSearchOrchestrator.items = [
+        { type: 'command', extensionId: 'other-ext', objectId: 'cmd_other-ext_my-cmd' },
+      ];
+      expect(action.visible()).toBe(false);
+
+      // Execution calls showSettingsWindow('extensions', 'pref-ext')
+      const { showSettingsWindow } = await import('../../lib/ipc/commands');
+      await action.execute();
+      expect(showSettingsWindow).toHaveBeenCalledWith('extensions', 'pref-ext');
+    });
+
+    it('auto-registers act_<ext>_open_preferences when a command has preferences', () => {
+      const manifest = makeManifest('cmd-pref-ext');
+      const cmd = {
+        ...makeCommand('cmd-with-pref'),
+        preferences: [{ name: 'token', type: 'password' as const, title: 'Token' }],
+      };
+      const loader = makeLoader([{ cmd, manifest, isBuiltIn: true }]);
+
+      loader.registerManifestActions();
+
+      const action = registeredActions.find((a) => a.id === 'act_cmd-pref-ext_open_preferences');
+      expect(action).toBeDefined();
+    });
+
+    it('does not register act_<ext>_open_preferences when no preferences are declared', () => {
+      const manifest = makeManifest('no-pref-ext');
+      const cmd = makeCommand('plain-cmd');
+      const loader = makeLoader([{ cmd, manifest, isBuiltIn: true }]);
+
+      loader.registerManifestActions();
+
+      const action = registeredActions.find((a) => a.id === 'act_no-pref-ext_open_preferences');
+      expect(action).toBeUndefined();
+    });
+
+    it('remains visible even when allowExtensionActions = false (because it is a host platform action)', () => {
+      mockSettingsGetSettings.mockReturnValue({
+        search: { enableExtensionSearch: false, allowExtensionActions: false },
+      });
+
+      const manifest = {
+        ...makeManifest('pref-ext'),
+        preferences: [{ name: 'apiKey', type: 'textfield' as const, title: 'API Key' }],
+      };
+      const loader = makeLoader([{ cmd: makeCommand('my-cmd'), manifest, isBuiltIn: true }]);
+
+      loader.registerManifestActions();
+
+      const action = registeredActions.find((a) => a.id === 'act_pref-ext_open_preferences');
+      expect(action).toBeDefined();
+
+      mockSearchStores.selectedIndex = 0;
+      mockSearchOrchestrator.items = [
+        { type: 'command', extensionId: 'pref-ext', objectId: 'cmd_pref-ext_my-cmd' },
       ];
       expect(action.visible()).toBe(true);
     });

--- a/asyar-launcher/src/services/extension/ExtensionLoader.ts
+++ b/asyar-launcher/src/services/extension/ExtensionLoader.ts
@@ -400,27 +400,61 @@ export class ExtensionLoader {
       const extensionId = manifest.id;
 
       // Register extension-level actions once per extension
-      if (!seenExtensions.has(extensionId) && manifest.actions?.length) {
-        for (const action of manifest.actions) {
-          const fullActionId = `act_${extensionId}_${action.id}`;
+      if (!seenExtensions.has(extensionId)) {
+        if (manifest.actions?.length) {
+          for (const action of manifest.actions) {
+            const fullActionId = `act_${extensionId}_${action.id}`;
+            actionService.registerAction({
+              id: fullActionId,
+              label: action.title,
+              description: action.description,
+              icon: action.icon,
+              shortcut: action.shortcut,
+              category: action.category,
+              extensionId,
+              context: ActionContext.CORE,
+              visible: () => {
+                if (settingsService.getSettings().search.allowExtensionActions === false)
+                  return false;
+                const idx = searchStores.selectedIndex;
+                if (idx < 0) return false;
+                const item = searchOrchestrator.items[idx];
+                return item?.type === 'command' && item.extensionId === extensionId;
+              },
+              // execute intentionally omitted — triggers sendToExtension fallback
+            } as any);
+          }
+        }
+
+        // Auto-register built-in "Extension Preferences" action if the extension declares preferences
+        const hasPreferences =
+          (manifest.preferences?.length ?? 0) > 0 ||
+          this.allLoadedCommands.some(
+            (c) => c.manifest.id === extensionId && (c.cmd.preferences?.length ?? 0) > 0,
+          );
+
+        if (hasPreferences) {
+          const prefActionId = `act_${extensionId}_open_preferences`;
           actionService.registerAction({
-            id: fullActionId,
-            label: action.title,
-            description: action.description,
-            icon: action.icon,
-            shortcut: action.shortcut,
-            category: action.category,
+            id: prefActionId,
+            label: 'Extension Preferences',
+            description: `Configure preferences for ${manifest.name || extensionId}`,
+            icon: 'icon:sliders',
+            category: 'Preferences',
             extensionId,
             context: ActionContext.CORE,
             visible: () => {
-              if (settingsService.getSettings().search.allowExtensionActions === false)
-                return false;
               const idx = searchStores.selectedIndex;
               if (idx < 0) return false;
               const item = searchOrchestrator.items[idx];
-              return item?.type === 'command' && item.extensionId === extensionId;
+              return (
+                (item?.type === 'command' && item.extensionId === extensionId) ||
+                item?.objectId?.startsWith(`cmd_${extensionId}_`) === true
+              );
             },
-            // execute intentionally omitted — triggers sendToExtension fallback
+            execute: async () => {
+              await commands.showSettingsWindow('extensions', extensionId);
+            },
           } as any);
         }
       }

--- a/asyar-sdk/src/icons/IconRenderer.test.ts
+++ b/asyar-sdk/src/icons/IconRenderer.test.ts
@@ -104,6 +104,13 @@ describe('IconRenderer', () => {
       expect(data).toBeDefined();
       expect(data).toMatch(/<polyline|<path|<line/);
     });
+
+    it('includes sliders icon (used for preferences action)', () => {
+      expect(hasIcon('sliders')).toBe(true);
+      const data = getIconData('sliders');
+      expect(data).toBeDefined();
+      expect(data).toMatch(/<line/);
+    });
   });
 
   describe('ICON_NAMES', () => {

--- a/asyar-sdk/src/icons/iconData.ts
+++ b/asyar-sdk/src/icons/iconData.ts
@@ -254,6 +254,17 @@ export const ICON_DATA: Record<string, string> = {
     <circle cx="11" cy="11" r="8" />
     <path d="m21 21-4.35-4.35" />
   `,
+  sliders: `
+    <line x1="4" y1="21" x2="4" y2="14" />
+    <line x1="4" y1="10" x2="4" y2="3" />
+    <line x1="12" y1="21" x2="12" y2="12" />
+    <line x1="12" y1="8" x2="12" y2="3" />
+    <line x1="20" y1="21" x2="20" y2="16" />
+    <line x1="20" y1="12" x2="20" y2="3" />
+    <line x1="1" y1="14" x2="7" y2="14" />
+    <line x1="9" y1="8" x2="15" y2="8" />
+    <line x1="17" y1="16" x2="23" y2="16" />
+  `,
 };
 
 export const ICON_NAMES: readonly string[] = Object.keys(ICON_DATA);


### PR DESCRIPTION
- Auto-register 'Extension Preferences' action for extensions declaring preferences
- Deep-link to Settings > Extensions tab with target extension preselected
- Add sliders icon to SDK ICON_DATA