### PR TITLE
fix(clipboard): preview copied screenshots instead of a bare filename

### DIFF
--- a/asyar-launcher/src/built-in-features/clipboard-history/DefaultView.svelte
+++ b/asyar-launcher/src/built-in-features/clipboard-history/DefaultView.svelte
@@ -11,6 +11,7 @@
   import { clipboardHistoryStore } from '../../services/clipboard/stores/clipboardHistoryStore.svelte';
   import { listen } from '@tauri-apps/api/event';
   import { fetchRawHtml } from './urlFetcher';
+  import { parseFilePaths, fileNameOf, loadFileThumbnails, FILE_THUMB_DIM } from './filePreview';
   import { stripRtf, type ClipboardHistoryItem } from 'asyar-sdk/contracts';
   import type { StoredClipboardItem } from '../../lib/ipc/commands';
   import { readFile } from '@tauri-apps/plugin-fs';
@@ -61,6 +62,13 @@
   let imageLoading = $state(false);
   let imageUrl = $state('');
   let currentImagePath = $state('');
+
+  // Thumbnails for `files` entries. macOS screenshot tools (and Finder)
+  // put a *file reference* on the pasteboard rather than image data, and
+  // handleClipboardChange prefers files over image — so a copied screenshot
+  // arrives here as type `files` and used to render as a bare filename row.
+  let fileThumbnails = $state<Record<string, string | null>>({});
+  let currentFilesContent = $state('');
 
   // URL content fetch state
   let urlBlobUrl = $state('');
@@ -220,6 +228,41 @@
     }
   });
 
+  // Load thumbnails when a files item is selected. Debounced because
+  // holding an arrow key steps through many rows a second, and on macOS
+  // every non-image type is thumbnailed via a `qlmanage` subprocess.
+  let fileThumbTimer: ReturnType<typeof setTimeout> | undefined;
+  $effect(() => {
+    const item = selectedFullItem;
+
+    if (!item || item.type !== 'files' || item.redactedKinds?.length) {
+      clearTimeout(fileThumbTimer);
+      fileThumbnails = {};
+      currentFilesContent = '';
+      return;
+    }
+
+    const content = item.content ?? '';
+    // Already loaded, or a load is already pending, for this exact entry.
+    // Cancelling the timer here would drop a request no later run reschedules.
+    if (content === currentFilesContent) return;
+
+    clearTimeout(fileThumbTimer);
+    currentFilesContent = content;
+    fileThumbnails = {};
+    const paths = parseFilePaths(content);
+    if (paths.length === 0) return;
+
+    fileThumbTimer = setTimeout(() => {
+      void loadFileThumbnails(paths, FILE_THUMB_DIM).then((thumbs) => {
+        // Selection may have moved on while the thumbnails were generating.
+        if (currentFilesContent === content) fileThumbnails = thumbs;
+      });
+    }, 150);
+  });
+
+  onDestroy(() => clearTimeout(fileThumbTimer));
+
   // Fetch URL content when a URL item is selected
   $effect(() => {
     const item = selectedFullItem;
@@ -355,18 +398,6 @@
     return content.length > MAX_PREVIEW_CHARS;
   }
 
-  function getFileName(path: string): string {
-    return path.split('/').pop() || path.split('\\').pop() || path;
-  }
-
-  function getFiles(content: string | null | undefined): string[] {
-    try {
-      return JSON.parse(content || '[]');
-    } catch {
-      return [];
-    }
-  }
-
   function isUrl(text: string | null | undefined): boolean {
     if (!text) return false;
     const trimmed = text.trim();
@@ -429,7 +460,10 @@
       return parts.join(' \u00b7 ') || '';
     }
     if (item.type === 'files' && meta?.fileCount) {
-      return `${meta.fileCount} file${(meta.fileCount as number) !== 1 ? 's' : ''}`;
+      const count = meta.fileCount as number;
+      const parts = [`${count} file${count !== 1 ? 's' : ''}`];
+      if (meta.sizeBytes) parts.push(formatBytes(meta.sizeBytes as number));
+      return parts.join(' · ');
     }
     if (item.content && ['text', 'html', 'rtf'].includes(item.type)) {
       const words = getWordCount(item);
@@ -624,28 +658,54 @@
                   </div>
                 {/if}
               {:else if selectedFullItem.type === 'files'}
+                {@const filePaths = parseFilePaths(selectedFullItem.content)}
+                {@const soloThumb =
+                  filePaths.length === 1 ? (fileThumbnails[filePaths[0]] ?? null) : null}
                 <div class="flex flex-col gap-1.5 p-4">
-                  {#each getFiles(selectedFullItem.content) as filePath}
+                  {#if soloThumb}
+                    <!-- A single copied file that the backend can thumbnail —
+                         a screenshot, in the case that motivated this. Show it
+                         the way an `image` entry is shown rather than as a
+                         one-row filename list. -->
+                    <div class="flex items-center justify-center pb-3">
+                      <img
+                        src={soloThumb}
+                        class="max-w-full object-contain rounded-md shadow-sm border file-solo-thumb"
+                        style="border-color: var(--border-color);"
+                        alt="Preview of {fileNameOf(filePaths[0])}"
+                      />
+                    </div>
+                  {/if}
+                  {#each filePaths as filePath}
                     <div
                       class="flex items-center gap-2 py-1.5 px-2 rounded"
                       style="background: var(--bg-secondary);"
                     >
-                      <svg
-                        class="w-4 h-4 flex-shrink-0 opacity-60"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                        ><path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                        /></svg
-                      >
+                      {#if !soloThumb && fileThumbnails[filePath]}
+                        <img
+                          src={fileThumbnails[filePath]}
+                          class="file-row-thumb flex-shrink-0"
+                          alt=""
+                          aria-hidden="true"
+                        />
+                      {:else}
+                        <svg
+                          class="w-4 h-4 flex-shrink-0 opacity-60"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                          ><path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                          /></svg
+                        >
+                      {/if}
                       <span
                         class="text-sm truncate flex-1"
                         style="color: var(--text-primary); font-family: var(--font-mono);"
-                        >{getFileName(filePath)}</span
+                        >{fileNameOf(filePath)}</span
                       >
                       <IconButton
                         onclick={() => revealFile(filePath)}
@@ -1044,6 +1104,19 @@
   :global(.html-preview pre) {
     padding: var(--space-5) var(--space-6);
     overflow-x: auto;
+  }
+
+  /* Bounded so a tall screenshot still leaves the filename row and the
+     rest of the detail pane visible without scrolling past the image. */
+  .file-solo-thumb {
+    max-height: 60vh;
+  }
+
+  .file-row-thumb {
+    width: var(--size-sm);
+    height: var(--size-sm);
+    object-fit: cover;
+    border-radius: var(--radius-xs);
   }
 
   .source-app-info {

--- a/asyar-launcher/src/built-in-features/clipboard-history/filePreview.test.ts
+++ b/asyar-launcher/src/built-in-features/clipboard-history/filePreview.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseFilePaths, fileNameOf, loadFileThumbnails, MAX_FILE_THUMBNAILS } from './filePreview';
+
+describe('parseFilePaths', () => {
+  it('parses the JSON array a files item stores as content', () => {
+    expect(parseFilePaths(JSON.stringify(['/a/one.png', '/a/two.pdf']))).toEqual([
+      '/a/one.png',
+      '/a/two.pdf',
+    ]);
+  });
+
+  it('returns an empty list for null, empty, or malformed content', () => {
+    expect(parseFilePaths(null)).toEqual([]);
+    expect(parseFilePaths(undefined)).toEqual([]);
+    expect(parseFilePaths('')).toEqual([]);
+    expect(parseFilePaths('not json')).toEqual([]);
+  });
+
+  it('returns an empty list when the JSON is not an array of strings', () => {
+    expect(parseFilePaths('{"a":1}')).toEqual([]);
+    expect(parseFilePaths('[1,2]')).toEqual([]);
+  });
+});
+
+describe('fileNameOf', () => {
+  it('takes the last segment of a POSIX path', () => {
+    expect(fileNameOf('/Users/k/Screenshots/Snapzy_2026.png')).toBe('Snapzy_2026.png');
+  });
+
+  it('takes the last segment of a Windows path', () => {
+    expect(fileNameOf('C:\\Users\\k\\shot.png')).toBe('shot.png');
+  });
+
+  it('falls back to the input when there is no separator', () => {
+    expect(fileNameOf('shot.png')).toBe('shot.png');
+  });
+});
+
+describe('loadFileThumbnails', () => {
+  it('resolves a thumbnail URL per path', async () => {
+    const load = vi.fn((p: string) => Promise.resolve(`asyar-thumb://localhost/${fileNameOf(p)}`));
+    const result = await loadFileThumbnails(['/a/one.png', '/a/two.png'], 800, load);
+    expect(result).toEqual({
+      '/a/one.png': 'asyar-thumb://localhost/one.png',
+      '/a/two.png': 'asyar-thumb://localhost/two.png',
+    });
+    expect(load).toHaveBeenCalledWith('/a/one.png', 800);
+  });
+
+  it('keeps null for file types the backend has no thumbnail strategy for', async () => {
+    const load = vi.fn(() => Promise.resolve(null));
+    expect(await loadFileThumbnails(['/a/notes.txt'], 800, load)).toEqual({
+      '/a/notes.txt': null,
+    });
+  });
+
+  it('maps a rejected load to null instead of failing the whole batch', async () => {
+    const load = vi.fn((p: string) =>
+      p === '/a/bad.png'
+        ? Promise.reject(new Error('boom'))
+        : Promise.resolve('asyar-thumb://localhost/ok.png'),
+    );
+    expect(await loadFileThumbnails(['/a/bad.png', '/a/ok.png'], 800, load)).toEqual({
+      '/a/bad.png': null,
+      '/a/ok.png': 'asyar-thumb://localhost/ok.png',
+    });
+  });
+
+  it('requests each distinct path only once', async () => {
+    const load = vi.fn(() => Promise.resolve('asyar-thumb://localhost/x.png'));
+    await loadFileThumbnails(['/a/one.png', '/a/one.png'], 800, load);
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  // On macOS every non-image type goes through a `qlmanage` subprocess, so a
+  // clipboard entry holding a whole folder's worth of files must not spawn one
+  // generation per file the user never looks at.
+  it('caps how many thumbnails a single entry requests', async () => {
+    const load = vi.fn(() => Promise.resolve('asyar-thumb://localhost/x.png'));
+    const many = Array.from({ length: MAX_FILE_THUMBNAILS + 5 }, (_, i) => `/a/${i}.png`);
+    const result = await loadFileThumbnails(many, 800, load);
+    expect(load).toHaveBeenCalledTimes(MAX_FILE_THUMBNAILS);
+    expect(Object.keys(result)).toHaveLength(MAX_FILE_THUMBNAILS);
+  });
+});

--- a/asyar-launcher/src/built-in-features/clipboard-history/filePreview.ts
+++ b/asyar-launcher/src/built-in-features/clipboard-history/filePreview.ts
@@ -1,0 +1,51 @@
+import { getFileThumbnail } from '../../lib/ipc/thumbnailCommands';
+
+/**
+ * Upper bound on thumbnails requested for one `files` clipboard entry.
+ * On macOS every non-image type is thumbnailed through a `qlmanage`
+ * subprocess, so copying a folder full of files must not spawn one
+ * generation per file the user only glances at.
+ */
+export const MAX_FILE_THUMBNAILS = 12;
+
+/** Detail-pane thumbnail size, matching file-search's detail preview. */
+export const FILE_THUMB_DIM = 800;
+
+/** Loader signature — injectable so the batching logic stays unit-testable. */
+export type ThumbnailLoader = (path: string, maxDim: number) => Promise<string | null>;
+
+/** Paths held by a `files` item, whose content is a JSON string array. */
+export function parseFilePaths(content: string | null | undefined): string[] {
+  if (!content) return [];
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (!Array.isArray(parsed)) return [];
+    const entries = parsed as unknown[];
+    // TS infers a type predicate for the callback, narrowing `entries` to
+    // string[] in the true branch — no assertion needed.
+    return entries.every((p) => typeof p === 'string') ? entries : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Last path segment, handling both POSIX and Windows separators. */
+export function fileNameOf(path: string): string {
+  const segments = path.replace(/\\/g, '/').split('/');
+  return segments[segments.length - 1] || path;
+}
+
+/**
+ * Resolves an `asyar-thumb://` URL per path. Entries stay `null` when the
+ * backend has no thumbnail strategy for that file type (or the generation
+ * failed) — callers keep their file-icon fallback for those.
+ */
+export async function loadFileThumbnails(
+  paths: string[],
+  maxDim: number = FILE_THUMB_DIM,
+  load: ThumbnailLoader = getFileThumbnail,
+): Promise<Record<string, string | null>> {
+  const distinct = [...new Set(paths)].slice(0, MAX_FILE_THUMBNAILS);
+  const urls = await Promise.all(distinct.map((path) => load(path, maxDim).catch(() => null)));
+  return Object.fromEntries(distinct.map((path, i) => [path, urls[i]]));
+}

--- a/asyar-launcher/src/services/clipboard/clipboardHistoryService.test.ts
+++ b/asyar-launcher/src/services/clipboard/clipboardHistoryService.test.ts
@@ -598,6 +598,29 @@ describe('handleClipboardChange', () => {
       );
     });
 
+    // The plugin's `count` on a files entry is the total byte size of the
+    // copied files, not how many there are (readClipboard sets it from
+    // `readFiles().size`). Deriving fileCount from it turned a single copied
+    // screenshot into "288263 files".
+    it('derives fileCount from the paths, not from the plugin byte count', async () => {
+      const svc = getInstance();
+      const { clipboardHistoryStore } = await import('./stores/clipboardHistoryStore.svelte');
+
+      await (svc as any).handleClipboardChange({
+        files: { type: 'files', value: ['/Users/test/shot.png'], count: 288263 },
+      });
+
+      expect(clipboardHistoryStore.addHistoryItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preview: '1 file: shot.png',
+          metadata: expect.objectContaining({
+            fileCount: 1,
+            sizeBytes: 288263,
+          }),
+        }),
+      );
+    });
+
     it('prioritizes files over everything', async () => {
       const svc = getInstance();
       const { clipboardHistoryStore } = await import('./stores/clipboardHistoryStore.svelte');

--- a/asyar-launcher/src/services/clipboard/clipboardHistoryService.ts
+++ b/asyar-launcher/src/services/clipboard/clipboardHistoryService.ts
@@ -356,16 +356,23 @@ export class ClipboardHistoryService implements IClipboardHistoryService {
         return parts[parts.length - 1] || p;
       });
 
+      // `fileData.count` is the plugin's *byte size* of the copied files
+      // (readClipboard fills it from `readFiles().size`), not how many there
+      // are — using it as the count rendered a single copied screenshot as
+      // "288263 files". The paths array is the only source for the count.
+      const fileCount = fileData.value.length;
+
       const item: ClipboardHistoryItem = {
         id: uuidv4(),
         type: ClipboardItemType.Files,
         content: contentStr,
-        preview: `${fileData.count} file${fileData.count !== 1 ? 's' : ''}: ${fileNames.join(', ')}`,
+        preview: `${fileCount} file${fileCount !== 1 ? 's' : ''}: ${fileNames.join(', ')}`,
         createdAt: Date.now(),
         favorite: false,
         metadata: {
-          fileCount: fileData.count,
+          fileCount,
           fileNames,
+          sizeBytes: fileData.count,
         },
         sourceApp,
       };


### PR DESCRIPTION
## Problem

Screenshots copied to the clipboard on macOS show no preview in Clipboard History — just a filename row.


Two defects, both in the `files` capture/render path:

1. **No image preview.** macOS screenshot tools (Snapzy, CleanShot) and Finder put a *file reference* on the pasteboard rather than image data. `handleClipboardChange` prefers `result.files` over `result.image` (`clipboardHistoryService.ts:199`, intentional and covered by the "prioritizes files over everything" test), so a copied screenshot arrives as a `files` entry. The `files` branch of the detail pane only ever rendered a filename row plus a "Reveal in Finder" button — the image was never shown.

2. **"288263 files".** `metadata.fileCount` was taken from `fileData.count`, but the plugin fills that from `readFiles().size` — the total **byte size**, not the number of files (`tauri-plugin-clipboard-x-api/dist-js/index.js:346`). A single copied screenshot rendered as "288263 files" in both the list title and the metadata line.

## Change

- `files` entries are thumbnailed through the existing `get_file_thumbnail` backend — the same one file-search uses, at its 800px detail size. Rust reads the source file directly, so paths outside the webview's fs-scope (which never covered arbitrary `$HOME` paths) still resolve.
  - A lone thumbnailable file renders as a large centered preview, like an `image` entry.
  - Multi-file entries get per-row thumbnails in place of the generic file icon.
  - Requests are debounced 150ms and capped at 12 per entry — on macOS every non-image type goes through a `qlmanage` subprocess, so arrow-key stepping or a copied folder must not spawn one generation per file.
  - Redacted (secret) entries are excluded from thumbnailing.
- `fileCount` now comes from the paths array; the plugin's byte total is kept as `sizeBytes` and shown next to the count, so no information is lost.
- The parse/filename/thumbnail-batch logic moved out of the `.svelte` file into `filePreview.ts` so it is unit-testable — `svelte-check` cannot parse `DefaultView.svelte` at all today (pre-existing `element_unclosed` error on `main`), so nothing in that file is type-checked.

## Testing

- New `filePreview.test.ts` — 10 tests covering parsing, filename extraction, per-path resolution, null-on-unsupported-type, reject→null isolation, dedup, and the cap.
- New service test pinning `fileCount`/`sizeBytes`/`preview` against the byte-count confusion.
- Full workspace suite after rebasing onto current `main`: 3226 launcher + 660 SDK passed.
- `vite build` compiles clean; `pnpm check:design` clean.

### Verified in a running dev build (`pnpm dev`, `org.asyar.dev`)

A PNG was put on the pasteboard as a file reference the way Snapzy does it (`osascript -e 'set the clipboard to POSIX file "…"'` → pasteboard type `«class furl»`), then Clipboard History was opened.

- The detail pane renders the screenshot as a large image preview; the filename row and its "Reveal in Finder" button remain below it.
- Footer metadata reads `1 file · 110.6 KB` — 110.6 KB matches the file's actual 113278 bytes.
- The stored row confirms the metadata fix directly:

  | captured | `fileCount` | `sizeBytes` |
  |---|---|---|
  | before this change | `288263` | – |
  | after this change | `1` | `113278` |

## Known limitations

- `preview` is stored at capture time, so **already-captured** rows keep their old `"<bytes> files: name.png"` title until they age out — visible side by side in the dev run above (today's row reads "1 file: …", yesterday's still read "288263 files: …"). Only the detail-pane metadata line is corrected retroactively; retro-fixing stored previews would need a DB migration.

## Out of scope (found while investigating, follow-up PR)

The `clipboard_cache` mechanism for `image` entries is entirely non-functional, confirmed at runtime:

```
Failed to copy image to cache, using temp path: forbidden path:
…/Application Support/org.asyar.devclipboard_cache, maybe it is not allowed
on the scope for `allow-mkdir` permission in your capability file
```

Three stacked defects: `getCacheDirPath()` concatenates without a path separator (`org.asyar.dev` + `clipboard_cache`); `fs:allow-mkdir`'s scope excludes the directory; and neither `fs:allow-copy-file` nor `fs:allow-remove` is granted at all. So `image` rows fall back to the plugin's own `$APPDATA/tauri-plugin-clipboard-x/images/` path — readable, so previews do work — but nothing is ever cleaned up (122 MB of orphaned PNGs in the production profile), and that path is content-hash-addressed, so duplicate copies share one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


