### PR TITLE
fix(clipboard): give each image row its own file instead of a dead cache

### DIFF
--- a/asyar-launcher/src-tauri/src/clipboard_cache/commands.rs
+++ b/asyar-launcher/src-tauri/src/clipboard_cache/commands.rs
@@ -1,0 +1,39 @@
+//! Thin Tauri command layer for [`crate::clipboard_cache`]. All logic —
+//! including the id and path validation — lives in the parent module so it
+//! is unit testable without a running Tauri app; this only resolves the app
+//! data directory and delegates.
+
+use tauri::{AppHandle, Manager};
+
+fn app_data_dir<R: tauri::Runtime>(app: &AppHandle<R>) -> Result<std::path::PathBuf, String> {
+    app.path()
+        .app_data_dir()
+        .map_err(|e| format!("app data dir unavailable: {e}"))
+}
+
+/// Moves the clipboard plugin's freshly written PNG into the history item's
+/// own cache slot and returns the new absolute path, which the row stores as
+/// its content.
+#[tauri::command]
+pub async fn clipboard_adopt_image<R: tauri::Runtime>(
+    id: String,
+    source_path: String,
+    app: AppHandle<R>,
+) -> Result<String, String> {
+    let root = app_data_dir(&app)?;
+    let dest = crate::clipboard_cache::adopt_image(&root, &id, std::path::Path::new(&source_path))?;
+    Ok(dest.to_string_lossy().into_owned())
+}
+
+/// Deletes a cached image when its history row goes away. Paths outside
+/// `clipboard_cache/` are ignored rather than rejected — legacy rows still
+/// point into the plugin's shared directory, and deleting there would break
+/// other rows holding the same image.
+#[tauri::command]
+pub async fn clipboard_forget_image<R: tauri::Runtime>(
+    path: String,
+    app: AppHandle<R>,
+) -> Result<(), String> {
+    let root = app_data_dir(&app)?;
+    crate::clipboard_cache::forget_image(&root, std::path::Path::new(&path))
+}

--- a/asyar-launcher/src-tauri/src/clipboard_cache/mod.rs
+++ b/asyar-launcher/src-tauri/src/clipboard_cache/mod.rs
@@ -1,0 +1,234 @@
+//! Owns the on-disk file behind an `image` clipboard entry.
+//!
+//! The clipboard plugin writes every copied image to
+//! `$APPDATA/tauri-plugin-clipboard-x/images/<hash>.png`, keyed by a hash of
+//! the pixel bytes — so two history rows holding the same image share one
+//! file, and deleting either row would break the other. It also never cleans
+//! that directory up.
+//!
+//! So each captured image is *moved* out of the plugin's directory into
+//! `$APPDATA/clipboard_cache/<item-id>.png`, giving the row sole ownership of
+//! its file. A move (not a copy) because both live under `$APPDATA`, so the
+//! rename is O(1) and leaves one file on disk instead of two; the plugin
+//! re-encodes on the next identical copy anyway (it only skips writing when
+//! the hash path still exists).
+//!
+//! Like `thumbnail`, this deliberately lives in Rust rather than going
+//! through `@tauri-apps/plugin-fs`: the webview's fs capability grants no
+//! write, copy, rename, or remove anywhere, and widening it to cover this
+//! would hand the webview a general write primitive in the app data
+//! directory for the sake of one internal file move.
+
+use std::path::{Path, PathBuf};
+
+pub mod commands;
+
+/// Directory holding one PNG per `image` clipboard row, named by item id.
+pub fn cache_dir(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join("clipboard_cache")
+}
+
+/// Where the row with `id` keeps its image.
+///
+/// `id` is a uuid minted by the capture path, but it arrives from the
+/// webview, so it is validated rather than trusted: anything that is not a
+/// plain `[A-Za-z0-9_-]` token is rejected so a crafted id cannot escape the
+/// cache directory or overwrite a file elsewhere.
+pub fn cached_image_path(app_data_dir: &Path, id: &str) -> Result<PathBuf, String> {
+    if id.is_empty()
+        || !id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(format!("invalid clipboard item id: {id:?}"));
+    }
+    Ok(cache_dir(app_data_dir).join(format!("{id}.png")))
+}
+
+/// True when `path` is a file directly inside the cache directory.
+///
+/// Guards the delete command: without it, the webview could name any path on
+/// disk and have Rust unlink it.
+pub fn is_cached_image(app_data_dir: &Path, path: &Path) -> bool {
+    path.parent() == Some(cache_dir(app_data_dir).as_path())
+}
+
+/// Moves `source` to the cache slot for `id` and returns that path.
+///
+/// Falls back to copy-then-delete if the rename fails — the plugin's image
+/// directory is normally the same volume as ours, but a user who has
+/// relocated app data (or a `saveImagePath` override) could put them on
+/// different ones, and `rename` cannot cross a filesystem boundary.
+pub fn adopt_image(app_data_dir: &Path, id: &str, source: &Path) -> Result<PathBuf, String> {
+    let dest = cached_image_path(app_data_dir, id)?;
+
+    if source == dest {
+        return Ok(dest);
+    }
+
+    let dir = cache_dir(app_data_dir);
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+
+    if std::fs::rename(source, &dest).is_ok() {
+        return Ok(dest);
+    }
+
+    std::fs::copy(source, &dest)
+        .map_err(|e| format!("copy {} -> {}: {e}", source.display(), dest.display()))?;
+    // Best-effort: the copy is what matters; a leftover source is only
+    // wasted space, and the plugin's directory already accumulates.
+    let _ = std::fs::remove_file(source);
+    Ok(dest)
+}
+
+/// Deletes a cached image. No-op for a path outside the cache directory or a
+/// file that is already gone.
+pub fn forget_image(app_data_dir: &Path, path: &Path) -> Result<(), String> {
+    if !is_cached_image(app_data_dir, path) {
+        return Ok(());
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!("remove {}: {e}", path.display())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_root(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "asyar_clipcache_{tag}_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write(path: &Path, bytes: &[u8]) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, bytes).unwrap();
+    }
+
+    #[test]
+    fn cache_dir_hangs_off_app_data() {
+        let root = Path::new("/some/app/data");
+        assert_eq!(cache_dir(root), Path::new("/some/app/data/clipboard_cache"));
+    }
+
+    #[test]
+    fn cached_image_path_is_the_id_as_png() {
+        let root = Path::new("/some/app/data");
+        assert_eq!(
+            cached_image_path(root, "abc-123").unwrap(),
+            Path::new("/some/app/data/clipboard_cache/abc-123.png")
+        );
+    }
+
+    #[test]
+    fn cached_image_path_rejects_ids_that_would_escape_the_cache() {
+        let root = Path::new("/some/app/data");
+        for bad in ["../../etc/passwd", "a/b", "", "id with space", "id.png"] {
+            assert!(
+                cached_image_path(root, bad).is_err(),
+                "expected {bad:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn adopt_image_moves_the_source_file() {
+        let root = temp_root("adopt");
+        let source = root.join("plugin_images/998877.png");
+        write(&source, b"pixels");
+
+        let dest = adopt_image(&root, "item-1", &source).unwrap();
+
+        assert_eq!(dest, root.join("clipboard_cache/item-1.png"));
+        assert_eq!(std::fs::read(&dest).unwrap(), b"pixels");
+        assert!(
+            !source.exists(),
+            "source should have been moved, not copied"
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn adopt_image_creates_the_cache_directory() {
+        let root = temp_root("mkdir");
+        let source = root.join("plugin_images/1.png");
+        write(&source, b"x");
+
+        assert!(!cache_dir(&root).exists());
+        adopt_image(&root, "item-1", &source).unwrap();
+        assert!(cache_dir(&root).is_dir());
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn adopt_image_is_idempotent_for_an_already_adopted_file() {
+        let root = temp_root("idem");
+        let source = root.join("plugin_images/1.png");
+        write(&source, b"x");
+
+        let first = adopt_image(&root, "item-1", &source).unwrap();
+        let second = adopt_image(&root, "item-1", &first).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(std::fs::read(&second).unwrap(), b"x");
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn adopt_image_reports_a_missing_source() {
+        let root = temp_root("missing");
+        let err = adopt_image(&root, "item-1", &root.join("nope.png")).unwrap_err();
+        assert!(err.contains("nope.png"), "unhelpful error: {err}");
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn forget_image_deletes_a_cached_file() {
+        let root = temp_root("forget");
+        let path = cache_dir(&root).join("item-1.png");
+        write(&path, b"x");
+
+        forget_image(&root, &path).unwrap();
+        assert!(!path.exists());
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn forget_image_ignores_an_already_deleted_file() {
+        let root = temp_root("forget_missing");
+        let path = cache_dir(&root).join("item-1.png");
+        assert!(forget_image(&root, &path).is_ok());
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    // Legacy rows still point at the plugin's shared, hash-addressed file.
+    // Deleting one of those would break every other row holding the same
+    // image, so paths outside the cache must be left alone.
+    #[test]
+    fn forget_image_refuses_paths_outside_the_cache() {
+        let root = temp_root("forget_outside");
+        let outside = root.join("plugin_images/998877.png");
+        write(&outside, b"shared");
+
+        forget_image(&root, &outside).unwrap();
+        assert!(outside.exists(), "must not delete outside the cache dir");
+
+        let nested = cache_dir(&root).join("sub/item.png");
+        write(&nested, b"nested");
+        forget_image(&root, &nested).unwrap();
+        assert!(nested.exists(), "only direct children are cache entries");
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+}

--- a/asyar-launcher/src-tauri/src/lib.rs
+++ b/asyar-launcher/src-tauri/src/lib.rs
@@ -130,6 +130,7 @@ pub mod application;
 pub mod auth;
 pub mod browser;
 pub mod calculator;
+pub mod clipboard_cache;
 pub mod clipboard_markup;
 pub mod clipboard_privacy;
 pub mod color_sampler;
@@ -588,6 +589,8 @@ pub fn run() {
             storage::commands::clipboard_clear_non_favorites,
             commands::clipboard_markup::clipboard_strip_html,
             commands::clipboard_markup::clipboard_strip_rtf,
+            clipboard_cache::commands::clipboard_adopt_image,
+            clipboard_cache::commands::clipboard_forget_image,
             // Storage: snippets
             storage::commands::snippet_upsert,
             storage::commands::snippet_get_all,

--- a/asyar-launcher/src/built-in-features/clipboard-history/DefaultView.svelte
+++ b/asyar-launcher/src/built-in-features/clipboard-history/DefaultView.svelte
@@ -11,6 +11,7 @@
   import { clipboardHistoryStore } from '../../services/clipboard/stores/clipboardHistoryStore.svelte';
   import { listen } from '@tauri-apps/api/event';
   import { fetchRawHtml } from './urlFetcher';
+  import { parseFilePaths, fileNameOf, loadFileThumbnails, FILE_THUMB_DIM } from './filePreview';
   import { stripRtf, type ClipboardHistoryItem } from 'asyar-sdk/contracts';
   import type { StoredClipboardItem } from '../../lib/ipc/commands';
   import { readFile } from '@tauri-apps/plugin-fs';
@@ -61,6 +62,13 @@
   let imageLoading = $state(false);
   let imageUrl = $state('');
   let currentImagePath = $state('');
+
+  // Thumbnails for `files` entries. macOS screenshot tools (and Finder)
+  // put a *file reference* on the pasteboard rather than image data, and
+  // handleClipboardChange prefers files over image — so a copied screenshot
+  // arrives here as type `files` and used to render as a bare filename row.
+  let fileThumbnails = $state<Record<string, string | null>>({});
+  let currentFilesContent = $state('');
 
   // URL content fetch state
   let urlBlobUrl = $state('');
@@ -220,6 +228,41 @@
     }
   });
 
+  // Load thumbnails when a files item is selected. Debounced because
+  // holding an arrow key steps through many rows a second, and on macOS
+  // every non-image type is thumbnailed via a `qlmanage` subprocess.
+  let fileThumbTimer: ReturnType<typeof setTimeout> | undefined;
+  $effect(() => {
+    const item = selectedFullItem;
+
+    if (!item || item.type !== 'files' || item.redactedKinds?.length) {
+      clearTimeout(fileThumbTimer);
+      fileThumbnails = {};
+      currentFilesContent = '';
+      return;
+    }
+
+    const content = item.content ?? '';
+    // Already loaded, or a load is already pending, for this exact entry.
+    // Cancelling the timer here would drop a request no later run reschedules.
+    if (content === currentFilesContent) return;
+
+    clearTimeout(fileThumbTimer);
+    currentFilesContent = content;
+    fileThumbnails = {};
+    const paths = parseFilePaths(content);
+    if (paths.length === 0) return;
+
+    fileThumbTimer = setTimeout(() => {
+      void loadFileThumbnails(paths, FILE_THUMB_DIM).then((thumbs) => {
+        // Selection may have moved on while the thumbnails were generating.
+        if (currentFilesContent === content) fileThumbnails = thumbs;
+      });
+    }, 150);
+  });
+
+  onDestroy(() => clearTimeout(fileThumbTimer));
+
   // Fetch URL content when a URL item is selected
   $effect(() => {
     const item = selectedFullItem;
@@ -355,18 +398,6 @@
     return content.length > MAX_PREVIEW_CHARS;
   }
 
-  function getFileName(path: string): string {
-    return path.split('/').pop() || path.split('\\').pop() || path;
-  }
-
-  function getFiles(content: string | null | undefined): string[] {
-    try {
-      return JSON.parse(content || '[]');
-    } catch {
-      return [];
-    }
-  }
-
   function isUrl(text: string | null | undefined): boolean {
     if (!text) return false;
     const trimmed = text.trim();
@@ -429,7 +460,10 @@
       return parts.join(' \u00b7 ') || '';
     }
     if (item.type === 'files' && meta?.fileCount) {
-      return `${meta.fileCount} file${(meta.fileCount as number) !== 1 ? 's' : ''}`;
+      const count = meta.fileCount as number;
+      const parts = [`${count} file${count !== 1 ? 's' : ''}`];
+      if (meta.sizeBytes) parts.push(formatBytes(meta.sizeBytes as number));
+      return parts.join(' · ');
     }
     if (item.content && ['text', 'html', 'rtf'].includes(item.type)) {
       const words = getWordCount(item);
@@ -624,28 +658,54 @@
                   </div>
                 {/if}
               {:else if selectedFullItem.type === 'files'}
+                {@const filePaths = parseFilePaths(selectedFullItem.content)}
+                {@const soloThumb =
+                  filePaths.length === 1 ? (fileThumbnails[filePaths[0]] ?? null) : null}
                 <div class="flex flex-col gap-1.5 p-4">
-                  {#each getFiles(selectedFullItem.content) as filePath}
+                  {#if soloThumb}
+                    <!-- A single copied file that the backend can thumbnail —
+                         a screenshot, in the case that motivated this. Show it
+                         the way an `image` entry is shown rather than as a
+                         one-row filename list. -->
+                    <div class="flex items-center justify-center pb-3">
+                      <img
+                        src={soloThumb}
+                        class="max-w-full object-contain rounded-md shadow-sm border file-solo-thumb"
+                        style="border-color: var(--border-color);"
+                        alt="Preview of {fileNameOf(filePaths[0])}"
+                      />
+                    </div>
+                  {/if}
+                  {#each filePaths as filePath}
                     <div
                       class="flex items-center gap-2 py-1.5 px-2 rounded"
                       style="background: var(--bg-secondary);"
                     >
-                      <svg
-                        class="w-4 h-4 flex-shrink-0 opacity-60"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                        ><path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                        /></svg
-                      >
+                      {#if !soloThumb && fileThumbnails[filePath]}
+                        <img
+                          src={fileThumbnails[filePath]}
+                          class="file-row-thumb flex-shrink-0"
+                          alt=""
+                          aria-hidden="true"
+                        />
+                      {:else}
+                        <svg
+                          class="w-4 h-4 flex-shrink-0 opacity-60"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                          ><path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                          /></svg
+                        >
+                      {/if}
                       <span
                         class="text-sm truncate flex-1"
                         style="color: var(--text-primary); font-family: var(--font-mono);"
-                        >{getFileName(filePath)}</span
+                        >{fileNameOf(filePath)}</span
                       >
                       <IconButton
                         onclick={() => revealFile(filePath)}
@@ -1044,6 +1104,19 @@
   :global(.html-preview pre) {
     padding: var(--space-5) var(--space-6);
     overflow-x: auto;
+  }
+
+  /* Bounded so a tall screenshot still leaves the filename row and the
+     rest of the detail pane visible without scrolling past the image. */
+  .file-solo-thumb {
+    max-height: 60vh;
+  }
+
+  .file-row-thumb {
+    width: var(--size-sm);
+    height: var(--size-sm);
+    object-fit: cover;
+    border-radius: var(--radius-xs);
   }
 
   .source-app-info {

--- a/asyar-launcher/src/built-in-features/clipboard-history/filePreview.test.ts
+++ b/asyar-launcher/src/built-in-features/clipboard-history/filePreview.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseFilePaths, fileNameOf, loadFileThumbnails, MAX_FILE_THUMBNAILS } from './filePreview';
+
+describe('parseFilePaths', () => {
+  it('parses the JSON array a files item stores as content', () => {
+    expect(parseFilePaths(JSON.stringify(['/a/one.png', '/a/two.pdf']))).toEqual([
+      '/a/one.png',
+      '/a/two.pdf',
+    ]);
+  });
+
+  it('returns an empty list for null, empty, or malformed content', () => {
+    expect(parseFilePaths(null)).toEqual([]);
+    expect(parseFilePaths(undefined)).toEqual([]);
+    expect(parseFilePaths('')).toEqual([]);
+    expect(parseFilePaths('not json')).toEqual([]);
+  });
+
+  it('returns an empty list when the JSON is not an array of strings', () => {
+    expect(parseFilePaths('{"a":1}')).toEqual([]);
+    expect(parseFilePaths('[1,2]')).toEqual([]);
+  });
+});
+
+describe('fileNameOf', () => {
+  it('takes the last segment of a POSIX path', () => {
+    expect(fileNameOf('/Users/k/Screenshots/Snapzy_2026.png')).toBe('Snapzy_2026.png');
+  });
+
+  it('takes the last segment of a Windows path', () => {
+    expect(fileNameOf('C:\\Users\\k\\shot.png')).toBe('shot.png');
+  });
+
+  it('falls back to the input when there is no separator', () => {
+    expect(fileNameOf('shot.png')).toBe('shot.png');
+  });
+});
+
+describe('loadFileThumbnails', () => {
+  it('resolves a thumbnail URL per path', async () => {
+    const load = vi.fn((p: string) => Promise.resolve(`asyar-thumb://localhost/${fileNameOf(p)}`));
+    const result = await loadFileThumbnails(['/a/one.png', '/a/two.png'], 800, load);
+    expect(result).toEqual({
+      '/a/one.png': 'asyar-thumb://localhost/one.png',
+      '/a/two.png': 'asyar-thumb://localhost/two.png',
+    });
+    expect(load).toHaveBeenCalledWith('/a/one.png', 800);
+  });
+
+  it('keeps null for file types the backend has no thumbnail strategy for', async () => {
+    const load = vi.fn(() => Promise.resolve(null));
+    expect(await loadFileThumbnails(['/a/notes.txt'], 800, load)).toEqual({
+      '/a/notes.txt': null,
+    });
+  });
+
+  it('maps a rejected load to null instead of failing the whole batch', async () => {
+    const load = vi.fn((p: string) =>
+      p === '/a/bad.png'
+        ? Promise.reject(new Error('boom'))
+        : Promise.resolve('asyar-thumb://localhost/ok.png'),
+    );
+    expect(await loadFileThumbnails(['/a/bad.png', '/a/ok.png'], 800, load)).toEqual({
+      '/a/bad.png': null,
+      '/a/ok.png': 'asyar-thumb://localhost/ok.png',
+    });
+  });
+
+  it('requests each distinct path only once', async () => {
+    const load = vi.fn(() => Promise.resolve('asyar-thumb://localhost/x.png'));
+    await loadFileThumbnails(['/a/one.png', '/a/one.png'], 800, load);
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  // On macOS every non-image type goes through a `qlmanage` subprocess, so a
+  // clipboard entry holding a whole folder's worth of files must not spawn one
+  // generation per file the user never looks at.
+  it('caps how many thumbnails a single entry requests', async () => {
+    const load = vi.fn(() => Promise.resolve('asyar-thumb://localhost/x.png'));
+    const many = Array.from({ length: MAX_FILE_THUMBNAILS + 5 }, (_, i) => `/a/${i}.png`);
+    const result = await loadFileThumbnails(many, 800, load);
+    expect(load).toHaveBeenCalledTimes(MAX_FILE_THUMBNAILS);
+    expect(Object.keys(result)).toHaveLength(MAX_FILE_THUMBNAILS);
+  });
+});

--- a/asyar-launcher/src/built-in-features/clipboard-history/filePreview.ts
+++ b/asyar-launcher/src/built-in-features/clipboard-history/filePreview.ts
@@ -1,0 +1,51 @@
+import { getFileThumbnail } from '../../lib/ipc/thumbnailCommands';
+
+/**
+ * Upper bound on thumbnails requested for one `files` clipboard entry.
+ * On macOS every non-image type is thumbnailed through a `qlmanage`
+ * subprocess, so copying a folder full of files must not spawn one
+ * generation per file the user only glances at.
+ */
+export const MAX_FILE_THUMBNAILS = 12;
+
+/** Detail-pane thumbnail size, matching file-search's detail preview. */
+export const FILE_THUMB_DIM = 800;
+
+/** Loader signature — injectable so the batching logic stays unit-testable. */
+export type ThumbnailLoader = (path: string, maxDim: number) => Promise<string | null>;
+
+/** Paths held by a `files` item, whose content is a JSON string array. */
+export function parseFilePaths(content: string | null | undefined): string[] {
+  if (!content) return [];
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (!Array.isArray(parsed)) return [];
+    const entries = parsed as unknown[];
+    // TS infers a type predicate for the callback, narrowing `entries` to
+    // string[] in the true branch — no assertion needed.
+    return entries.every((p) => typeof p === 'string') ? entries : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Last path segment, handling both POSIX and Windows separators. */
+export function fileNameOf(path: string): string {
+  const segments = path.replace(/\\/g, '/').split('/');
+  return segments[segments.length - 1] || path;
+}
+
+/**
+ * Resolves an `asyar-thumb://` URL per path. Entries stay `null` when the
+ * backend has no thumbnail strategy for that file type (or the generation
+ * failed) — callers keep their file-icon fallback for those.
+ */
+export async function loadFileThumbnails(
+  paths: string[],
+  maxDim: number = FILE_THUMB_DIM,
+  load: ThumbnailLoader = getFileThumbnail,
+): Promise<Record<string, string | null>> {
+  const distinct = [...new Set(paths)].slice(0, MAX_FILE_THUMBNAILS);
+  const urls = await Promise.all(distinct.map((path) => load(path, maxDim).catch(() => null)));
+  return Object.fromEntries(distinct.map((path, i) => [path, urls[i]]));
+}

--- a/asyar-launcher/src/lib/ipc/clipboardCacheCommands.test.ts
+++ b/asyar-launcher/src/lib/ipc/clipboardCacheCommands.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('../../services/log/logService', () => ({
+  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { invoke } from '@tauri-apps/api/core';
+import { clipboardAdoptImage, clipboardForgetImage } from './clipboardCacheCommands';
+
+const mockInvoke = invoke as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('clipboardAdoptImage', () => {
+  it('passes the item id and source path and returns the new location', async () => {
+    mockInvoke.mockResolvedValue('/app/data/clipboard_cache/item-1.png');
+
+    const result = await clipboardAdoptImage('item-1', '/plugin/images/998877.png');
+
+    expect(mockInvoke).toHaveBeenCalledWith('clipboard_adopt_image', {
+      id: 'item-1',
+      sourcePath: '/plugin/images/998877.png',
+    });
+    expect(result).toBe('/app/data/clipboard_cache/item-1.png');
+  });
+
+  // The caller falls back to the plugin's own path, which stays readable —
+  // so a failed move must not throw and break clipboard capture.
+  it('returns null instead of throwing when the move fails', async () => {
+    mockInvoke.mockRejectedValue(new Error('disk full'));
+    expect(await clipboardAdoptImage('item-1', '/plugin/images/1.png')).toBeNull();
+  });
+});
+
+describe('clipboardForgetImage', () => {
+  it('passes the path and reports success', async () => {
+    mockInvoke.mockResolvedValue(null);
+    expect(await clipboardForgetImage('/app/data/clipboard_cache/item-1.png')).toBe(true);
+    expect(mockInvoke).toHaveBeenCalledWith('clipboard_forget_image', {
+      path: '/app/data/clipboard_cache/item-1.png',
+    });
+  });
+
+  it('returns false instead of throwing when the delete fails', async () => {
+    mockInvoke.mockRejectedValue(new Error('permission denied'));
+    expect(await clipboardForgetImage('/app/data/clipboard_cache/item-1.png')).toBe(false);
+  });
+});

--- a/asyar-launcher/src/lib/ipc/clipboardCacheCommands.ts
+++ b/asyar-launcher/src/lib/ipc/clipboardCacheCommands.ts
@@ -1,0 +1,25 @@
+import { invokeSafe, invokeSafeVoid } from './invokeSafe';
+
+/**
+ * Moves the clipboard plugin's freshly written PNG into this history item's
+ * own slot under `$APPDATA/clipboard_cache/` and resolves to the new path.
+ *
+ * `null` when the move failed — the caller keeps the plugin's original path,
+ * which stays readable, so the preview still works.
+ *
+ * Rust-side because the webview's fs capability grants no write, copy,
+ * rename, or remove anywhere; widening it for one internal file move would
+ * hand the webview a general write primitive in the app data directory.
+ */
+export async function clipboardAdoptImage(id: string, sourcePath: string): Promise<string | null> {
+  return invokeSafe<string>('clipboard_adopt_image', { id, sourcePath });
+}
+
+/**
+ * Deletes a cached image when its history row goes away. Rust ignores paths
+ * outside `clipboard_cache/` — legacy rows still point into the plugin's
+ * content-addressed directory, where duplicate copies share one file.
+ */
+export async function clipboardForgetImage(path: string): Promise<boolean> {
+  return invokeSafeVoid('clipboard_forget_image', { path }, { silent: true });
+}

--- a/asyar-launcher/src/services/clipboard/clipboardHistoryService.test.ts
+++ b/asyar-launcher/src/services/clipboard/clipboardHistoryService.test.ts
@@ -598,6 +598,29 @@ describe('handleClipboardChange', () => {
       );
     });
 
+    // The plugin's `count` on a files entry is the total byte size of the
+    // copied files, not how many there are (readClipboard sets it from
+    // `readFiles().size`). Deriving fileCount from it turned a single copied
+    // screenshot into "288263 files".
+    it('derives fileCount from the paths, not from the plugin byte count', async () => {
+      const svc = getInstance();
+      const { clipboardHistoryStore } = await import('./stores/clipboardHistoryStore.svelte');
+
+      await (svc as any).handleClipboardChange({
+        files: { type: 'files', value: ['/Users/test/shot.png'], count: 288263 },
+      });
+
+      expect(clipboardHistoryStore.addHistoryItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preview: '1 file: shot.png',
+          metadata: expect.objectContaining({
+            fileCount: 1,
+            sizeBytes: 288263,
+          }),
+        }),
+      );
+    });
+
     it('prioritizes files over everything', async () => {
       const svc = getInstance();
       const { clipboardHistoryStore } = await import('./stores/clipboardHistoryStore.svelte');

--- a/asyar-launcher/src/services/clipboard/clipboardHistoryService.test.ts
+++ b/asyar-launcher/src/services/clipboard/clipboardHistoryService.test.ts
@@ -30,15 +30,13 @@ vi.mock('tauri-plugin-clipboard-x-api', () => ({
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 
-vi.mock('@tauri-apps/api/path', () => ({
-  appDataDir: vi.fn().mockResolvedValue('/mock/app/data/'),
-}));
-
-vi.mock('@tauri-apps/plugin-fs', () => ({
-  copyFile: vi.fn().mockResolvedValue(undefined),
-  remove: vi.fn().mockResolvedValue(undefined),
-  mkdir: vi.fn().mockResolvedValue(undefined),
-  exists: vi.fn().mockResolvedValue(false),
+// Default: the move succeeds, mirroring Rust's `$APPDATA/clipboard_cache/<id>.png`.
+// Tests that care about a failed move override this per case.
+vi.mock('../../lib/ipc/clipboardCacheCommands', () => ({
+  clipboardAdoptImage: vi.fn((id: string) =>
+    Promise.resolve(`/app/data/clipboard_cache/${id}.png`),
+  ),
+  clipboardForgetImage: vi.fn(() => Promise.resolve(true)),
 }));
 
 vi.mock('@tauri-apps/plugin-os', () => ({
@@ -87,7 +85,7 @@ import { ClipboardItemType, type ClipboardHistoryItem } from 'asyar-sdk/contract
 import { clipboardPrivacyService } from '../privacy/clipboardPrivacyService.svelte';
 import { secretRedactionService } from '../privacy/secretRedactionService.svelte';
 import { clipboardHistoryStore } from './stores/clipboardHistoryStore.svelte';
-import { remove } from '@tauri-apps/plugin-fs';
+import { clipboardAdoptImage, clipboardForgetImage } from '../../lib/ipc/clipboardCacheCommands';
 
 function getInstance(): ClipboardHistoryService {
   return new ClipboardHistoryService();
@@ -924,40 +922,49 @@ describe('image cache persistence', () => {
     vi.clearAllMocks();
   });
 
-  it('copies image to permanent cache directory', async () => {
-    const { copyFile, mkdir } = await import('@tauri-apps/plugin-fs');
+  it('adopts the image out of the plugin directory and stores the owned path', async () => {
+    vi.mocked(clipboardAdoptImage).mockResolvedValueOnce('/app/data/clipboard_cache/item.png');
     const svc = getInstance();
     const { clipboardHistoryStore } = await import('./stores/clipboardHistoryStore.svelte');
 
     await (svc as any).handleClipboardChange({
       image: {
         type: 'image',
-        value: '/tmp/plugin-temp/img123.png',
+        value: '/plugin/images/998877.png',
         count: 1,
         width: 800,
         height: 600,
       },
     });
 
-    // Should create cache directory
-    expect(mkdir).toHaveBeenCalledWith(
-      expect.stringContaining('clipboard_cache'),
-      expect.objectContaining({ recursive: true }),
+    expect(clipboardAdoptImage).toHaveBeenCalledWith(
+      expect.any(String),
+      '/plugin/images/998877.png',
     );
 
-    // Should copy from temp to permanent location
-    expect(copyFile).toHaveBeenCalledWith(
-      '/tmp/plugin-temp/img123.png',
-      expect.stringContaining('clipboard_cache/'),
-    );
-
-    // The stored item should have the permanent cache path, NOT the temp path
+    // The row must record where its image actually ended up, not the
+    // plugin's shared hash-addressed path.
     expect(clipboardHistoryStore.addHistoryItem).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'image',
-        content: expect.stringContaining('clipboard_cache/'),
+        content: '/app/data/clipboard_cache/item.png',
       }),
     );
+  });
+
+  it('adopts under the item id so each row owns a distinct file', async () => {
+    vi.mocked(clipboardAdoptImage).mockResolvedValueOnce('/app/data/clipboard_cache/x.png');
+    const svc = getInstance();
+    const { clipboardHistoryStore } = await import('./stores/clipboardHistoryStore.svelte');
+
+    await (svc as any).handleClipboardChange({
+      image: { type: 'image', value: '/plugin/images/1.png', count: 1, width: 1, height: 1 },
+    });
+
+    const adoptedId = vi.mocked(clipboardAdoptImage).mock.calls[0][0];
+    const stored = vi.mocked(clipboardHistoryStore.addHistoryItem).mock
+      .calls[0][0] as ClipboardHistoryItem;
+    expect(adoptedId).toBe(stored.id);
   });
 
   it('stores image metadata (width, height, sizeBytes)', async () => {
@@ -982,24 +989,22 @@ describe('image cache persistence', () => {
     const deleteSpy = vi
       .spyOn(clipboardHistoryStore, 'deleteHistoryItem')
       .mockResolvedValue({ imageContentPath: '/cache/foo.png' });
-    vi.mocked(remove).mockClear();
 
     const ok = await getInstance().deleteItem('foo');
 
     expect(ok).toBe(true);
     expect(deleteSpy).toHaveBeenCalledWith('foo');
-    expect(remove).toHaveBeenCalledWith('/cache/foo.png');
+    expect(clipboardForgetImage).toHaveBeenCalledWith('/cache/foo.png');
   });
 
   it('deleteItem does not unlink anything when the IPC response has no image path', async () => {
     vi.spyOn(clipboardHistoryStore, 'deleteHistoryItem').mockResolvedValue({
       imageContentPath: undefined,
     });
-    vi.mocked(remove).mockClear();
 
     await getInstance().deleteItem('text-row');
 
-    expect(remove).not.toHaveBeenCalled();
+    expect(clipboardForgetImage).not.toHaveBeenCalled();
   });
 
   it('clearNonFavorites unlinks every image path returned by the IPC response', async () => {
@@ -1007,28 +1012,28 @@ describe('image cache persistence', () => {
       removedIds: ['a', 'b'],
       removedImagePaths: ['/cache/a.png', '/cache/b.png'],
     });
-    vi.mocked(remove).mockClear();
 
     const ok = await getInstance().clearNonFavorites();
 
     expect(ok).toBe(true);
-    expect(remove).toHaveBeenCalledWith('/cache/a.png');
-    expect(remove).toHaveBeenCalledWith('/cache/b.png');
+    expect(clipboardForgetImage).toHaveBeenCalledWith('/cache/a.png');
+    expect(clipboardForgetImage).toHaveBeenCalledWith('/cache/b.png');
   });
 
-  it('handles copy failure gracefully', async () => {
-    const { copyFile } = await import('@tauri-apps/plugin-fs');
-    vi.mocked(copyFile).mockRejectedValueOnce(new Error('disk full'));
+  // The plugin's own path stays readable, so a failed move must leave a
+  // usable row rather than dropping the capture.
+  it('falls back to the plugin path when the move fails', async () => {
+    vi.mocked(clipboardAdoptImage).mockResolvedValueOnce(null);
     const svc = getInstance();
     const { clipboardHistoryStore } = await import('./stores/clipboardHistoryStore.svelte');
 
-    // Should not throw, should log error and still store with temp path as fallback
     await (svc as any).handleClipboardChange({
-      image: { type: 'image', value: '/tmp/img.png', count: 1, width: 100, height: 100 },
+      image: { type: 'image', value: '/plugin/images/1.png', count: 1, width: 100, height: 100 },
     });
 
-    // Should still store the item (with the temp path as fallback)
-    expect(clipboardHistoryStore.addHistoryItem).toHaveBeenCalled();
+    expect(clipboardHistoryStore.addHistoryItem).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'image', content: '/plugin/images/1.png' }),
+    );
   });
 });
 

--- a/asyar-launcher/src/services/clipboard/clipboardHistoryService.ts
+++ b/asyar-launcher/src/services/clipboard/clipboardHistoryService.ts
@@ -19,9 +19,8 @@ import {
   onClipboardChange,
   type ReadClipboard,
 } from 'tauri-plugin-clipboard-x-api';
-import { copyFile, remove, mkdir } from '@tauri-apps/plugin-fs';
-import { appDataDir } from '@tauri-apps/api/path';
 import { platform } from '@tauri-apps/plugin-os';
+import { clipboardAdoptImage, clipboardForgetImage } from '../../lib/ipc/clipboardCacheCommands';
 import * as commands from '../../lib/ipc/commands';
 import type { ClipboardDeleteResult, ClipboardClearResult } from '../../lib/ipc/commands';
 import { getFrontmostApplication } from '../../lib/ipc/applicationCommands';
@@ -49,36 +48,27 @@ export class ClipboardHistoryService implements IClipboardHistoryService {
   private isAndroid: boolean = false;
   private pollingInterval: number | null = null;
 
-  private static readonly CLIPBOARD_CACHE_DIR = 'clipboard_cache';
-  private cacheDirPath: string | null = null;
-
-  private async getCacheDirPath(): Promise<string> {
-    if (!this.cacheDirPath) {
-      const appData = await appDataDir();
-      this.cacheDirPath = `${appData}${ClipboardHistoryService.CLIPBOARD_CACHE_DIR}`;
-    }
-    return this.cacheDirPath;
-  }
-
-  private async ensureCacheDir(): Promise<void> {
-    const dir = await this.getCacheDirPath();
-    await mkdir(dir, { recursive: true });
-  }
-
-  private async copyImageToCache(id: string, sourcePath: string): Promise<string> {
-    await this.ensureCacheDir();
-    const cacheDir = await this.getCacheDirPath();
-    const destPath = `${cacheDir}/${id}.png`;
-    await copyFile(sourcePath, destPath);
-    return destPath;
+  /**
+   * Gives this history item sole ownership of its image file.
+   *
+   * The clipboard plugin writes every copied image to its own directory
+   * keyed by a hash of the pixel bytes, so two rows holding the same image
+   * share one file and deleting either would break the other. Rust moves it
+   * to `$APPDATA/clipboard_cache/<id>.png` — a rename, so it costs nothing
+   * and leaves one file on disk rather than two. The plugin simply
+   * re-encodes on the next identical copy; it only skips writing while its
+   * hash path still exists.
+   *
+   * Returns the plugin's original path unchanged when the move fails. That
+   * path stays readable, so the preview keeps working — it just goes back to
+   * being shared, exactly as every row captured before this existed.
+   */
+  private async adoptImage(id: string, sourcePath: string): Promise<string> {
+    return (await clipboardAdoptImage(id, sourcePath)) ?? sourcePath;
   }
 
   private async deleteImageFromCache(path: string): Promise<void> {
-    try {
-      await remove(path);
-    } catch {
-      // File may not exist, that's ok
-    }
+    await clipboardForgetImage(path);
   }
 
   /**
@@ -284,13 +274,9 @@ export class ClipboardHistoryService implements IClipboardHistoryService {
       if (!imageData?.value) return;
 
       const imageId = uuidv4();
-      let storedPath = imageData.value; // fallback to temp path
-
-      try {
-        storedPath = await this.copyImageToCache(imageId, imageData.value);
-      } catch (error) {
-        logService.error(`Failed to copy image to cache, using temp path: ${error}`);
-      }
+      // Falls back to the plugin's own path when the move fails; either way
+      // the row records where its image actually is.
+      const storedPath = await this.adoptImage(imageId, imageData.value);
 
       const item: ClipboardHistoryItem = {
         id: imageId,

--- a/asyar-launcher/src/services/clipboard/clipboardHistoryService.ts
+++ b/asyar-launcher/src/services/clipboard/clipboardHistoryService.ts
@@ -356,16 +356,23 @@ export class ClipboardHistoryService implements IClipboardHistoryService {
         return parts[parts.length - 1] || p;
       });
 
+      // `fileData.count` is the plugin's *byte size* of the copied files
+      // (readClipboard fills it from `readFiles().size`), not how many there
+      // are — using it as the count rendered a single copied screenshot as
+      // "288263 files". The paths array is the only source for the count.
+      const fileCount = fileData.value.length;
+
       const item: ClipboardHistoryItem = {
         id: uuidv4(),
         type: ClipboardItemType.Files,
         content: contentStr,
-        preview: `${fileData.count} file${fileData.count !== 1 ? 's' : ''}: ${fileNames.join(', ')}`,
+        preview: `${fileCount} file${fileCount !== 1 ? 's' : ''}: ${fileNames.join(', ')}`,
         createdAt: Date.now(),
         favorite: false,
         metadata: {
-          fileCount: fileData.count,
+          fileCount,
           fileNames,
+          sizeBytes: fileData.count,
         },
         sourceApp,
       };


### PR DESCRIPTION
> **Stacked on #631.** Both touch `clipboardHistoryService`, so this branch is built on top of that one and its commit shows up here too — review/merge #631 first, then this diff reduces to its own single commit (`c88238b`). GitHub would not accept the stacked base directly because #631 is a cross-fork PR.

## Problem

The `clipboard_cache` mechanism for `image` entries has never worked. Confirmed at runtime in a dev build:

```
Failed to copy image to cache, using temp path: forbidden path:
…/Application Support/org.asyar.devclipboard_cache, maybe it is not allowed
on the scope for `allow-mkdir` permission in your capability file
```

Three stacked defects:

1. **Missing path separator.** `getCacheDirPath()` did `` `${appData}${CLIPBOARD_CACHE_DIR}` `` — `appDataDir()` returns no trailing slash, so the path was `org.asyar.dev` + `clipboard_cache` glued together. Invisible in tests because the `appDataDir` mock returned `'/mock/app/data/'` *with* a trailing slash the real API does not.
2. **`fs:allow-mkdir` scope** covered only the extensions directories, never `$APPDATA/clipboard_cache`.
3. **`fs:allow-copy-file` and `fs:allow-remove` were never granted at all** — so the copy failed, and every later `deleteImageFromCache` was a silent no-op.

Consequence: every `image` row pointed at the plugin's own `$APPDATA/tauri-plugin-clipboard-x/images/<hash>.png`. Previews *did* work — that path is readable under `fs:default` — but:

- **Nothing was ever deleted.** 122 MB of orphaned PNGs in the production profile on this machine; `clipboard_cache/` did not exist in either profile.
- **The plugin's path is keyed by a hash of the pixel bytes**, so two rows holding the same image share one file. Naively fixing the delete permission would have made deleting one row break the other.

## Change

Rust **moves** the plugin's freshly written PNG to `$APPDATA/clipboard_cache/<item-id>.png`, so each row owns its file outright.

A move rather than a copy: both directories live under `$APPDATA`, so the rename is O(1) and leaves **one** file on disk instead of two. The plugin re-encodes on the next identical copy anyway — it only skips writing while its hash path still exists ([`commands.rs:325`](https://github.com/cakioe/tauri-plugin-clipboard-x), `if !path.exists()`).

Rust rather than widening the webview's fs capability, matching the choice already made for thumbnails and text previews. Granting copy/rename/remove would hand the webview a general write primitive in the app data directory for the sake of one internal file move. The item id is validated Rust-side rather than trusted, so a crafted id cannot escape the cache directory.

Backward compatible by construction: `forget_image` ignores any path outside `clipboard_cache/`, so a row captured before this can never unlink a file another row still points at. And if the move fails, the row records the plugin's original path — still readable, so the preview keeps working exactly as before.

## Performance

The concern was that this sits on the clipboard capture path, which runs on every copy. Measured on this machine:

| Operation | Cost |
|---|---|
| `rename` within `$APPDATA` | O(1), microseconds |
| (for comparison) full copy of the largest cached clipboard image, 4.0 MB | ~7 ms |
| (already spent per copied image, by the plugin) decode + PNG encode | ~100 ms |

The move is free. Even the copy fallback would have been under 10% of what the plugin already spends on the same image.

## Testing

- **Rust**: 10 unit tests over `clipboard_cache` — path derivation, id validation (rejects `../../etc/passwd`, `a/b`, empty, spaces), move-not-copy, directory creation, idempotence, missing source, delete, delete-already-gone, and **refusal to delete outside the cache directory**.
- **TS**: new `clipboardCacheCommands.test.ts`; the `image cache persistence` suite rewritten against the real IPC surface instead of a `plugin-fs` mock that never matched reality.
- Full frontend suite: 3231 launcher + 660 SDK passed, after rebasing onto current main. `cargo clippy --all-targets` clean.

### Verified in a running dev build

Copying an image:
- creates `clipboard_cache/2404e4aa-6f13-40e5-9ed0-309b91d6a375.png` (named by the row's uuid),
- leaves the plugin's directory at the **same file count** — moved, not duplicated,
- and the detail pane renders the preview from the new path (`Image: 1200×1600`).

## Not included

The existing orphaned PNGs (122 MB in the production profile) are left alone — a startup sweep for files no `clipboard_items` row references is worth doing, but it is a separate change from fixing the broken path.
