### PR TITLE
fix(applications): match localized names keyed by region and script

### DIFF
--- a/asyar-launcher/src-tauri/src/platform/macos/display_name.rs
+++ b/asyar-launcher/src-tauri/src/platform/macos/display_name.rs
@@ -24,28 +24,112 @@ pub fn localized_bundle_name(path: &Path) -> Option<String> {
 
 fn localized_bundle_name_in_locale(path: &Path, locale: &str) -> Option<String> {
     let resources = path.join("Contents/Resources");
+    let loctable = plist::Value::from_file(resources.join("InfoPlist.loctable")).ok();
+    let loctable = loctable.as_ref().and_then(plist::Value::as_dictionary);
     language_candidates(locale).into_iter().find_map(|lang| {
-        name_from_loctable(&resources.join("InfoPlist.loctable"), &lang).or_else(|| {
+        name_from_loctable(loctable, &lang).or_else(|| {
             name_from_info_plist_strings(&resources.join(format!("{lang}.lproj/InfoPlist.strings")))
         })
     })
 }
 
-/// Language keys to try, most specific first — `de-DE` before `de`. Bundles key
-/// their tables either way, and macOS itself falls back along the same chain.
+/// Language keys to try, most specific first — `de-DE` before `de`.
+///
+/// Two shapes of the same locale have to be tried, because the tag macOS
+/// reports and the key a bundle uses are written differently. `sys_locale`
+/// returns the user's preferred language as a BCP-47 tag with hyphens
+/// (`de-DE`, `zh-Hans-CN`), while Apple keys its own tables with underscores
+/// and no script subtag — every one of the 166 system `InfoPlist.loctable`s on
+/// macOS 26 uses `zh_CN`, `zh_HK`, `zh_TW`, `pt_PT`, `pt_BR`, `en_GB`,
+/// `es_419` and never a hyphen. Third-party bundles do use the hyphen form, so
+/// both are emitted, hyphen first.
+///
+/// A script subtag also has to be dropped on the way down, not just truncated
+/// off the end: Chinese arrives as `zh-Hans-CN`, and plain RFC 4647 truncation
+/// (`zh-Hans-CN` → `zh-Hans` → `zh`) never reaches `zh_CN` — and Apple ships no
+/// bare `zh` entry at all, so that chain ends in the English name. The order
+/// below matches what CoreFoundation's own resolver
+/// (`CFBundleCopyLocalizationsForPreferences`) picks when asked with Photos'
+/// real key list: `zh-Hans-CN` → `zh_CN`, `zh-Hant-HK` → `zh_HK` then `zh_TW`,
+/// `de-DE` → `de_DE` then `de`, `pt-BR` → `pt`.
+///
+/// What is deliberately not replicated is CoreFoundation's alias and
+/// likely-subtag data: `nb-NO` → `no`, `yue-Hans-CN` → `zh_CN`, `es-MX` →
+/// `es_419`. Those need a table this crate has no business shipping, and a miss
+/// only costs the fallback that has always applied — the on-disk file stem.
 fn language_candidates(locale: &str) -> Vec<String> {
-    let regional = locale.replace('_', "-");
-    let base = regional.split('-').next().unwrap_or_default().to_string();
-    match () {
-        _ if base.is_empty() => Vec::new(),
-        _ if base == regional => vec![base],
-        _ => vec![regional, base],
+    let mut subtags = locale.split(['-', '_']).filter(|part| !part.is_empty());
+    let Some(language) = subtags.next() else {
+        return Vec::new();
+    };
+    let (mut script, mut region) = (None, None);
+    for subtag in subtags {
+        match subtag {
+            // A one-character subtag opens an extension ("de-DE-u-co-phonebk"),
+            // and what follows it only looks like a region — "-u-ca-chinese"
+            // would otherwise read as Canada.
+            _ if subtag.len() == 1 => break,
+            _ if script.is_none() && is_script(subtag) => script = Some(subtag),
+            _ if region.is_none() && is_region(subtag) => region = Some(subtag),
+            // Variants ("de-DE-1901") never key a table.
+            _ => {}
+        }
+    }
+
+    let mut candidates = Vec::new();
+    if let (Some(script), Some(region)) = (script, region) {
+        push_both_separators(&mut candidates, &format!("{language}-{script}-{region}"));
+    }
+    if let Some(region) = region {
+        push_both_separators(&mut candidates, &format!("{language}-{region}"));
+    }
+    if let Some(script) = script {
+        push_both_separators(&mut candidates, &format!("{language}-{script}"));
+    }
+    if let Some(region) = implied_region(language, script) {
+        push_both_separators(&mut candidates, &format!("{language}-{region}"));
+    }
+    push_both_separators(&mut candidates, language);
+    candidates
+}
+
+/// The region Apple's tables stand in for a script, for the one language where
+/// it matters. There is no `zh_Hans`/`zh_Hant` key anywhere in macOS and no
+/// bare `zh` either, so a `zh-Hans` or `zh-Hant` preference only resolves
+/// through a region. CoreFoundation resolves the same way (`zh-Hans` → `zh_CN`,
+/// `zh-Hant` → `zh_TW`), and it too keeps a Traditional preference away from
+/// the Simplified `zh` entry — hence this runs before the bare language.
+fn implied_region(language: &str, script: Option<&str>) -> Option<&'static str> {
+    match (language, script) {
+        ("zh", Some("Hant")) => Some("TW"),
+        ("zh", Some("Hans") | None) => Some("CN"),
+        _ => None,
     }
 }
 
-fn name_from_loctable(path: &Path, lang: &str) -> Option<String> {
-    let table = plist::Value::from_file(path).ok()?;
-    display_name_in(table.as_dictionary()?.get(lang)?.as_dictionary()?)
+/// Emits a candidate in both the hyphen and the underscore spelling, skipping
+/// duplicates so `zh-Hans-CN` does not try `zh_CN` twice.
+fn push_both_separators(candidates: &mut Vec<String>, stem: &str) {
+    for candidate in [stem.to_owned(), stem.replace('-', "_")] {
+        if !candidates.contains(&candidate) {
+            candidates.push(candidate);
+        }
+    }
+}
+
+/// A script subtag is four letters (`Hans`), a region two letters (`GB`) or
+/// three digits (`419`, Latin America).
+fn is_script(subtag: &str) -> bool {
+    subtag.len() == 4 && subtag.chars().all(|c| c.is_ascii_alphabetic())
+}
+
+fn is_region(subtag: &str) -> bool {
+    (subtag.len() == 2 && subtag.chars().all(|c| c.is_ascii_alphabetic()))
+        || (subtag.len() == 3 && subtag.chars().all(|c| c.is_ascii_digit()))
+}
+
+fn name_from_loctable(table: Option<&plist::Dictionary>, lang: &str) -> Option<String> {
+    display_name_in(table?.get(lang)?.as_dictionary()?)
 }
 
 /// Reads a `<lang>.lproj/InfoPlist.strings`. Modern bundles ship these as
@@ -178,9 +262,144 @@ mod tests {
 
     #[test]
     fn language_candidates_are_ordered_most_specific_first() {
-        assert_eq!(language_candidates("de-DE"), vec!["de-DE", "de"]);
+        assert_eq!(language_candidates("de-DE"), vec!["de-DE", "de_DE", "de"]);
         assert_eq!(language_candidates("de"), vec!["de"]);
         assert!(language_candidates("").is_empty());
+    }
+
+    /// Stock bundles key Chinese as `zh_CN`/`zh_HK`/`zh_TW` and ship no bare
+    /// `zh` entry at all — true for every one of the 166 system
+    /// `InfoPlist.loctable`s on macOS 26. macOS reports the matching user
+    /// language as a script tag (`zh-Hans-CN`), so nothing lines up unless the
+    /// candidate chain bridges both.
+    #[test]
+    fn resolves_chinese_against_apples_underscore_only_keys() {
+        // Names as Photos.app actually ships them.
+        let bundle = bundle_with_loctable(
+            "Chinese.app",
+            &[
+                ("en", "Photos"),
+                ("zh_CN", "照片"),
+                ("zh_HK", "相片"),
+                ("zh_TW", "照片"),
+            ],
+        );
+        for (locale, expected) in [
+            ("zh-Hans-CN", "照片"),
+            ("zh_CN", "照片"),
+            ("zh-CN", "照片"),
+            ("zh-Hant-TW", "照片"),
+            ("zh-Hant-HK", "相片"),
+            ("zh-Hans", "照片"),
+            ("zh-Hant", "照片"),
+            ("zh", "照片"),
+        ] {
+            assert_eq!(
+                localized_bundle_name_in_locale(&bundle, locale).as_deref(),
+                Some(expected),
+                "locale {locale}"
+            );
+        }
+    }
+
+    /// The other regional key shapes Apple ships: `en_GB`, `pt_PT`, `es_419`.
+    #[test]
+    fn resolves_underscore_keyed_regions_and_keeps_the_base_language_for_others() {
+        let bundle = bundle_with_loctable(
+            "Regions.app",
+            &[
+                ("en", "Photos"),
+                ("en_GB", "Photos GB"),
+                ("pt", "Fotos"),
+                ("pt_PT", "Fotografias"),
+                ("es", "Fotos ES"),
+                ("es_419", "Fotos 419"),
+            ],
+        );
+        for (locale, expected) in [
+            ("en-GB", "Photos GB"),
+            ("en_GB", "Photos GB"),
+            ("en-US", "Photos"),
+            ("pt-PT", "Fotografias"),
+            ("pt-BR", "Fotos"),
+            ("es-419", "Fotos 419"),
+            ("es-ES", "Fotos ES"),
+        ] {
+            assert_eq!(
+                localized_bundle_name_in_locale(&bundle, locale).as_deref(),
+                Some(expected),
+                "locale {locale}"
+            );
+        }
+    }
+
+    /// The synthetic bundles above prove the lookup; this proves the key shapes
+    /// were read off the real thing. Apple's own translations are not pinned —
+    /// only that a Chinese preference stops landing on the English name, which
+    /// is the exact symptom of a missed regional key.
+    #[test]
+    fn resolves_a_real_stock_bundle_in_an_injected_locale() {
+        let photos = Path::new("/System/Applications/Photos.app");
+        if !photos.exists() {
+            return; // Not a stock macOS install — nothing to check against.
+        }
+        let english = localized_bundle_name_in_locale(photos, "en-US");
+        for locale in ["zh-Hans-CN", "zh-Hant-TW", "zh-Hant-HK", "pt-PT", "en-GB"] {
+            let name = localized_bundle_name_in_locale(photos, locale);
+            assert!(name.is_some(), "{locale} resolved to nothing");
+            if locale.starts_with("zh") {
+                assert_ne!(name, english, "{locale} fell back to the English name");
+            }
+        }
+    }
+
+    #[test]
+    fn language_candidates_cover_both_separators_and_script_tags() {
+        assert_eq!(language_candidates("en_GB"), vec!["en-GB", "en_GB", "en"]);
+        assert_eq!(
+            language_candidates("es-419"),
+            vec!["es-419", "es_419", "es"]
+        );
+        assert_eq!(
+            language_candidates("zh-Hans-CN"),
+            vec![
+                "zh-Hans-CN",
+                "zh_Hans_CN",
+                "zh-CN",
+                "zh_CN",
+                "zh-Hans",
+                "zh_Hans",
+                "zh"
+            ]
+        );
+        assert_eq!(
+            language_candidates("zh-Hant-HK"),
+            vec![
+                "zh-Hant-HK",
+                "zh_Hant_HK",
+                "zh-HK",
+                "zh_HK",
+                "zh-Hant",
+                "zh_Hant",
+                "zh-TW",
+                "zh_TW",
+                "zh"
+            ]
+        );
+        assert_eq!(
+            language_candidates("zh-Hant"),
+            vec!["zh-Hant", "zh_Hant", "zh-TW", "zh_TW", "zh"]
+        );
+        assert_eq!(language_candidates("zh"), vec!["zh-CN", "zh_CN", "zh"]);
+        assert_eq!(
+            language_candidates("zh-Hans-CN-u-ca-chinese"),
+            language_candidates("zh-Hans-CN"),
+            "an extension subtag must not be mistaken for a region"
+        );
+        assert_eq!(
+            language_candidates("de-DE-1901"),
+            vec!["de-DE", "de_DE", "de"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #626, from your review comment there: Apple keys its localization tables with underscores, and `language_candidates()` normalized them to hyphens — so a `zh_CN`-keyed table never matched and the lookup fell back to the English name.

You were right, and the check turned out worse than "might return `None`": for Chinese it *always* fails today.

## What the real tables contain

Aggregated over every `InfoPlist.loctable` under `/System/Applications`, `/System/Applications/Utilities`, `/System/Library/CoreServices` and `/Applications` on macOS 26.5.1 — 166 tables:

| key | tables |
|---|---|
| `en_GB`, `en_AU`, `fr_CA` | 165 |
| `zh_CN`, `zh_HK`, `zh_TW`, `pt_PT`, `es_419` | 164 |
| `pt_BR` | 136 |
| `es_US` | 60 |
| `yue_CN` | 2 |
| **bare `zh`** | **0** |

Underscore only — not one hyphen, not one script subtag, anywhere. `.lproj` directories follow the same convention (`zh_CN.lproj`, `es_419.lproj`).

## Why a second spelling isn't enough

`sys_locale` returns the preferred language as a BCP-47 tag, and for Chinese that is `zh-Hans-CN`. Plain truncation walks `zh-Hans-CN` → `zh-Hans` → `zh` — and since no bundle ships `zh_Hans` *or* a bare `zh`, every step misses however it is spelled. The script subtag has to be dropped from the middle rather than truncated off the end.

So `language_candidates()` now parses the tag into subtags instead of doing string surgery, and emits, most specific first:

```
language-script-region → language-region → language-script → implied region → language
```

each in both spellings, hyphen first, deduped. `implied_region()` covers the one language where it matters: `zh`+`Hant` → `TW`, `zh`+`Hans`/none → `CN`. It runs *before* the bare language deliberately, so a Traditional preference is never served the Simplified entry.

One parsing detail: a one-character subtag opens an extension sequence (`de-DE-u-ca-chinese`), so parsing stops there — otherwise `ca` reads as Canada.

## Validated against Apple's own resolver

Rather than trust the ordering, I asked CoreFoundation. `CFBundleCopyLocalizationsForPreferences` with Photos' real key list agrees with this chain on 19 of 22 locales — `zh-Hans-CN`→`zh_CN`, `zh-Hant-HK`→`zh_HK`, `zh-Hant`→`zh_TW`, `zh`→`zh_CN`, `de-DE`→`de`, `pt-BR`→`pt`, `en-GB`→`en_GB`, `es-419`→`es_419`, `fr-CA`→`fr_CA`, `en-US`→`en`, `he-IL`→`he`, …

The three misses are alias and likely-subtag data: `nb-NO`→`no`, `yue-Hans-CN`→`zh_CN`, `es-MX`→`es_419`. Replicating those needs CLDR tables I don't think belong in this crate, so they are documented as a known gap in the module doc. A miss costs only the fallback that has always applied — the on-disk file stem — so those users are no worse off than before this PR.

If you'd rather close that gap, the alternative is calling `CFBundleCopyLocalizationsForPreferences` directly instead of building the chain by hand. It would be exactly right, aliases included, and it does *not* have the calling-process localization flaw that made the Cocoa APIs unusable in #626. I skipped it because it costs CF FFI and `unsafe`, but happy to switch if you prefer it.

Also folded in: the loctable is now parsed once per bundle instead of once per candidate. Candidate order and the loctable-before-`.lproj` precedence per candidate are unchanged.

## Tests

Written failing first. Before the change: `zh-Hans-CN` → `None`, `en-GB` → `"Photos"` instead of `"Photos GB"`.

- `resolves_chinese_against_apples_underscore_only_keys` — a table keyed only `zh_CN`/`zh_HK`/`zh_TW`, exercised through 8 locale forms (`zh-Hans-CN`, `zh_CN`, `zh-CN`, `zh-Hant-HK`, `zh-Hans`, `zh-Hant`, `zh`, …)
- `resolves_underscore_keyed_regions_and_keeps_the_base_language_for_others` — `en_GB`/`pt_PT`/`es_419`, plus the counter-check that `en-US`, `pt-BR`, `es-ES` still land on the base language
- `language_candidates_cover_both_separators_and_script_tags` — exact ordering, dedup, extension and variant subtags
- `resolves_a_real_stock_bundle_in_an_injected_locale` — against the real `/System/Applications/Photos.app`, existence-guarded; pins no Apple translation, only that Chinese no longer resolves to the English name

Every test injects the locale rather than reading it from the host, so they are deterministic on any machine and in CI.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and `cargo doc --no-deps --document-private-items` clean. `cargo test --lib`: 3373 passed, 1 failed — `file_index::deep::mdfind::tests::probe_succeeds_on_a_real_mac`, which fails identically on an unmodified checkout of `main` here; pre-existing and environmental.

## What is not verified

This machine is `de-DE`. There was **no manual test under a Chinese, British or Portuguese system locale** — the fix is evidenced by the injected unit tests, the key inventory of the 166 system bundles, and the CoreFoundation comparison, not by an actual language switch. Worth a smoke test on your side if you have a `zh` install handy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
