### PR TITLE
fix(scripts): run the selected script on Enter in the library view

### DIFF
--- a/asyar-launcher/src/built-in-features/scripts/ScriptLibraryView.svelte
+++ b/asyar-launcher/src/built-in-features/scripts/ScriptLibraryView.svelte
@@ -3,6 +3,7 @@
   import { scriptsManager } from './scriptsManager.svelte';
   import { runSelectedScript } from './runSelected';
   import { viewManager } from '../../services/extension/viewManager.svelte';
+  import { commandArgumentsService } from '../../services/search/commandArguments';
   import {
     Badge,
     Card,
@@ -50,6 +51,15 @@
   function handleWindowKeydown(event: KeyboardEvent) {
     if (event.metaKey || event.ctrlKey || event.altKey) return;
     if (document.querySelector('.action-popup') || isAnyModalOpen(document)) return;
+    // Argument mode keeps this view mounted underneath its chips, and this
+    // listener is window+capture — it would beat the chip row's own Enter and
+    // re-enter argument mode, wiping whatever the user just typed.
+    if (commandArgumentsService.active) return;
+    // Same reasoning for any text field that happens to hold focus.
+    const target = event.target;
+    if (target instanceof HTMLElement && target.closest('input, textarea, [contenteditable]')) {
+      return;
+    }
     if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
       scriptsManager.moveSelection(event.key === 'ArrowDown' ? 1 : -1);
       event.preventDefault();
@@ -71,19 +81,28 @@
     }
   }
 
+  // The last label we published, so teardown can tell ours from a successor's.
+  let publishedLabel: string | null = null;
+
   // The launcher hands Enter to a view only once the view declares a primary
   // action label (see launcherKeyboard.tryHandleViewEnter); without it the
   // bottom bar also falls back to the stale search-result hint.
   $effect(() => {
+    publishedLabel = primaryActionLabel;
     viewManager.activeViewPrimaryActionLabel = primaryActionLabel;
   });
 
   onMount(() => window.addEventListener('keydown', handleWindowKeydown, true));
   onDestroy(() => {
     window.removeEventListener('keydown', handleWindowKeydown, true);
-    // Nothing resets the label on navigation, so a leftover would leak into
-    // whichever view comes next.
-    viewManager.activeViewPrimaryActionLabel = null;
+    // Nothing else resets the label on navigation, so a leftover would leak
+    // into whichever view comes next. But a replacement navigation (global
+    // item hotkey) runs the incoming view's viewActivated — where every other
+    // built-in sets its own label — before Svelte tears this component down,
+    // so only clear a label that is still the one we published.
+    if (viewManager.activeViewPrimaryActionLabel === publishedLabel) {
+      viewManager.activeViewPrimaryActionLabel = null;
+    }
   });
 </script>
 

--- a/asyar-launcher/src/built-in-features/scripts/ScriptLibraryView.svelte
+++ b/asyar-launcher/src/built-in-features/scripts/ScriptLibraryView.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { scriptsManager } from './scriptsManager.svelte';
+  import { runSelectedScript } from './runSelected';
+  import { viewManager } from '../../services/extension/viewManager.svelte';
   import {
     Badge,
     Card,
@@ -18,6 +20,15 @@
   const issues = $derived(scriptsManager.issues);
   const selectedScript = $derived(scriptsManager.selectedScript);
   const selectedIssue = $derived(scriptsManager.selectedIssue);
+
+  // What Enter does for the current selection — null when it does nothing.
+  const primaryActionLabel = $derived(
+    selectedScript
+      ? 'Run Script'
+      : selectedIssue?.fix === 'makeExecutable'
+        ? 'Make Executable'
+        : null,
+  );
 
   function issueLabel(reason: ScriptScanIssueReason): string {
     switch (reason) {
@@ -43,11 +54,37 @@
       scriptsManager.moveSelection(event.key === 'ArrowDown' ? 1 : -1);
       event.preventDefault();
       event.stopPropagation();
+      return;
+    }
+    // Consume Enter only when the selection has something to do — an Enter we
+    // ignore has to keep bubbling to the launcher's own handler.
+    if (event.key === 'Enter') {
+      if (selectedScript) {
+        void runSelectedScript();
+      } else if (selectedIssue?.fix === 'makeExecutable') {
+        void scriptsManager.makeSelectedExecutable();
+      } else {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
     }
   }
 
+  // The launcher hands Enter to a view only once the view declares a primary
+  // action label (see launcherKeyboard.tryHandleViewEnter); without it the
+  // bottom bar also falls back to the stale search-result hint.
+  $effect(() => {
+    viewManager.activeViewPrimaryActionLabel = primaryActionLabel;
+  });
+
   onMount(() => window.addEventListener('keydown', handleWindowKeydown, true));
-  onDestroy(() => window.removeEventListener('keydown', handleWindowKeydown, true));
+  onDestroy(() => {
+    window.removeEventListener('keydown', handleWindowKeydown, true);
+    // Nothing resets the label on navigation, so a leftover would leak into
+    // whichever view comes next.
+    viewManager.activeViewPrimaryActionLabel = null;
+  });
 </script>
 
 <SplitView leftWidth="38%">

--- a/asyar-launcher/src/built-in-features/scripts/ScriptLibraryView.svelte
+++ b/asyar-launcher/src/built-in-features/scripts/ScriptLibraryView.svelte
@@ -84,9 +84,10 @@
   // The last label we published, so teardown can tell ours from a successor's.
   let publishedLabel: string | null = null;
 
-  // The launcher hands Enter to a view only once the view declares a primary
-  // action label (see launcherKeyboard.tryHandleViewEnter); without it the
-  // bottom bar also falls back to the stale search-result hint.
+  // Publish what Enter does, so the bottom bar stops falling back to the
+  // selected search result's own hint ("Run Command", from the row that opened
+  // this view) and so launcherKeyboard.tryHandleViewEnter keeps its hands off
+  // Enter should this view ever become searchable.
   $effect(() => {
     publishedLabel = primaryActionLabel;
     viewManager.activeViewPrimaryActionLabel = primaryActionLabel;

--- a/asyar-launcher/src/built-in-features/scripts/ScriptLibraryView.test.ts
+++ b/asyar-launcher/src/built-in-features/scripts/ScriptLibraryView.test.ts
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+import { fireEvent, render } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./scriptsManager.svelte', () => ({
+  scriptsManager: {
+    scripts: [],
+    issues: [],
+    selectedEntryId: null,
+    selectedScript: undefined,
+    selectedIssue: undefined,
+    selectEntry: vi.fn(),
+    moveSelection: vi.fn(),
+    makeSelectedExecutable: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock('./runSelected', () => ({
+  runSelectedScript: vi.fn(async () => {}),
+}));
+
+vi.mock('../../components/base/Modal.logic', () => ({
+  isAnyModalOpen: vi.fn(() => false),
+}));
+
+vi.mock('../../services/extension/viewManager.svelte', () => ({
+  viewManager: { activeViewPrimaryActionLabel: null },
+}));
+
+vi.mock('../../components', async () => ({
+  Badge: (await import('../../components/base/Badge.svelte')).default,
+  Card: (await import('../../components/layout/Card.svelte')).default,
+  EmptyState: (await import('../../components/feedback/EmptyState.svelte')).default,
+  Icon: (await import('../../components/base/Icon.svelte')).default,
+  IconBox: (await import('../../components/base/IconBox.svelte')).default,
+  LauncherListRow: (await import('../../components/list/LauncherListRow.svelte')).default,
+  SplitView: (await import('../../components/list/SplitView.svelte')).default,
+  WarningBanner: (await import('../../components/feedback/WarningBanner.svelte')).default,
+}));
+
+import ScriptLibraryView from './ScriptLibraryView.svelte';
+import { scriptsManager } from './scriptsManager.svelte';
+import { runSelectedScript } from './runSelected';
+import { isAnyModalOpen } from '../../components/base/Modal.logic';
+import { viewManager } from '../../services/extension/viewManager.svelte';
+
+const script = {
+  absolutePath: '/scripts/deploy.sh',
+  directoryPath: '/scripts',
+  fileName: 'deploy.sh',
+  displayName: 'Deploy',
+  dynamicId: 'deploy-id',
+  header: { mode: 'silent', icon: null, arguments: [], refreshTimeSeconds: null },
+};
+
+const notExecutableIssue = {
+  absolutePath: '/scripts/broken.sh',
+  directoryPath: '/scripts',
+  fileName: 'broken.sh',
+  message: 'File is not executable',
+  reason: 'notExecutable',
+  fix: 'makeExecutable',
+};
+
+const unreadableIssue = {
+  absolutePath: '/scripts/unreadable.sh',
+  directoryPath: '/scripts',
+  fileName: 'unreadable.sh',
+  message: 'File could not be read',
+  reason: 'contentUnreadable',
+  fix: null,
+};
+
+/** Select `script` / an issue on the non-reactive manager mock, then render. */
+function selectScript() {
+  Object.assign(scriptsManager, {
+    scripts: [script],
+    issues: [],
+    selectedEntryId: `script:${script.dynamicId}`,
+    selectedScript: script,
+    selectedIssue: undefined,
+  });
+}
+
+function selectIssue(issue: typeof notExecutableIssue | typeof unreadableIssue) {
+  Object.assign(scriptsManager, {
+    scripts: [],
+    issues: [issue],
+    selectedEntryId: `issue:${issue.absolutePath}`,
+    selectedScript: undefined,
+    selectedIssue: issue,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isAnyModalOpen).mockReturnValue(false);
+  viewManager.activeViewPrimaryActionLabel = null;
+  Object.assign(scriptsManager, {
+    scripts: [],
+    issues: [],
+    selectedEntryId: null,
+    selectedScript: undefined,
+    selectedIssue: undefined,
+  });
+});
+
+describe('ScriptLibraryView keyboard', () => {
+  it('enter_runs_the_selected_script', async () => {
+    selectScript();
+    render(ScriptLibraryView);
+
+    const notConsumed = await fireEvent.keyDown(window, { key: 'Enter' });
+
+    expect(runSelectedScript).toHaveBeenCalled();
+    expect(notConsumed).toBe(false);
+  });
+
+  it('enter_repairs_a_make_executable_issue', async () => {
+    selectIssue(notExecutableIssue);
+    render(ScriptLibraryView);
+
+    const notConsumed = await fireEvent.keyDown(window, { key: 'Enter' });
+
+    expect(scriptsManager.makeSelectedExecutable).toHaveBeenCalled();
+    expect(runSelectedScript).not.toHaveBeenCalled();
+    expect(notConsumed).toBe(false);
+  });
+
+  it('enter_without_a_selection_leaves_the_event_to_the_launcher', async () => {
+    render(ScriptLibraryView);
+
+    const notConsumed = await fireEvent.keyDown(window, { key: 'Enter' });
+
+    expect(runSelectedScript).not.toHaveBeenCalled();
+    expect(scriptsManager.makeSelectedExecutable).not.toHaveBeenCalled();
+    expect(notConsumed).toBe(true);
+  });
+
+  it('enter_on_an_unfixable_issue_leaves_the_event_to_the_launcher', async () => {
+    selectIssue(unreadableIssue);
+    render(ScriptLibraryView);
+
+    const notConsumed = await fireEvent.keyDown(window, { key: 'Enter' });
+
+    expect(scriptsManager.makeSelectedExecutable).not.toHaveBeenCalled();
+    expect(notConsumed).toBe(true);
+  });
+
+  it('modified_enter_is_ignored', async () => {
+    selectScript();
+    render(ScriptLibraryView);
+
+    await fireEvent.keyDown(window, { key: 'Enter', metaKey: true });
+
+    expect(runSelectedScript).not.toHaveBeenCalled();
+  });
+
+  it('enter_is_ignored_while_a_modal_is_open', async () => {
+    selectScript();
+    vi.mocked(isAnyModalOpen).mockReturnValue(true);
+    render(ScriptLibraryView);
+
+    await fireEvent.keyDown(window, { key: 'Enter' });
+
+    expect(runSelectedScript).not.toHaveBeenCalled();
+  });
+
+  it('enter_is_ignored_while_the_action_popup_is_open', async () => {
+    selectScript();
+    render(ScriptLibraryView);
+    const popup = document.createElement('div');
+    popup.className = 'action-popup';
+    document.body.appendChild(popup);
+
+    await fireEvent.keyDown(window, { key: 'Enter' });
+    popup.remove();
+
+    expect(runSelectedScript).not.toHaveBeenCalled();
+  });
+
+  it('arrow_keys_still_move_the_selection', async () => {
+    selectScript();
+    render(ScriptLibraryView);
+
+    await fireEvent.keyDown(window, { key: 'ArrowDown' });
+    await fireEvent.keyDown(window, { key: 'ArrowUp' });
+
+    expect(scriptsManager.moveSelection).toHaveBeenNthCalledWith(1, 1);
+    expect(scriptsManager.moveSelection).toHaveBeenNthCalledWith(2, -1);
+    expect(runSelectedScript).not.toHaveBeenCalled();
+  });
+});
+
+describe('ScriptLibraryView primary action label', () => {
+  it('label_is_run_script_when_a_script_is_selected', () => {
+    selectScript();
+    render(ScriptLibraryView);
+
+    expect(viewManager.activeViewPrimaryActionLabel).toBe('Run Script');
+  });
+
+  it('label_is_make_executable_for_a_repairable_issue', () => {
+    selectIssue(notExecutableIssue);
+    render(ScriptLibraryView);
+
+    expect(viewManager.activeViewPrimaryActionLabel).toBe('Make Executable');
+  });
+
+  it('label_is_null_for_an_unfixable_issue', () => {
+    selectIssue(unreadableIssue);
+    render(ScriptLibraryView);
+
+    expect(viewManager.activeViewPrimaryActionLabel).toBeNull();
+  });
+
+  it('label_is_null_without_a_selection', () => {
+    render(ScriptLibraryView);
+
+    expect(viewManager.activeViewPrimaryActionLabel).toBeNull();
+  });
+
+  it('label_is_cleared_when_the_view_is_destroyed', () => {
+    selectScript();
+    const { unmount } = render(ScriptLibraryView);
+    expect(viewManager.activeViewPrimaryActionLabel).toBe('Run Script');
+
+    unmount();
+
+    expect(viewManager.activeViewPrimaryActionLabel).toBeNull();
+  });
+});

--- a/asyar-launcher/src/built-in-features/scripts/ScriptLibraryView.test.ts
+++ b/asyar-launcher/src/built-in-features/scripts/ScriptLibraryView.test.ts
@@ -115,7 +115,7 @@ beforeEach(() => {
 });
 
 describe('ScriptLibraryView keyboard', () => {
-  it('enter_runs_the_selected_script', async () => {
+  it('runs the selected script on Enter', async () => {
     selectScript();
     render(ScriptLibraryView);
 
@@ -125,7 +125,7 @@ describe('ScriptLibraryView keyboard', () => {
     expect(notConsumed).toBe(false);
   });
 
-  it('enter_repairs_a_make_executable_issue', async () => {
+  it('repairs a not-executable script instead of running it', async () => {
     selectIssue(notExecutableIssue);
     render(ScriptLibraryView);
 
@@ -136,7 +136,7 @@ describe('ScriptLibraryView keyboard', () => {
     expect(notConsumed).toBe(false);
   });
 
-  it('enter_without_a_selection_leaves_the_event_to_the_launcher', async () => {
+  it('leaves Enter to the launcher when nothing is selected', async () => {
     render(ScriptLibraryView);
 
     const notConsumed = await fireEvent.keyDown(window, { key: 'Enter' });
@@ -146,7 +146,7 @@ describe('ScriptLibraryView keyboard', () => {
     expect(notConsumed).toBe(true);
   });
 
-  it('enter_on_an_unfixable_issue_leaves_the_event_to_the_launcher', async () => {
+  it('leaves Enter to the launcher on an issue it cannot repair', async () => {
     selectIssue(unreadableIssue);
     render(ScriptLibraryView);
 
@@ -156,7 +156,7 @@ describe('ScriptLibraryView keyboard', () => {
     expect(notConsumed).toBe(true);
   });
 
-  it('modified_enter_is_ignored', async () => {
+  it('ignores Enter that carries a modifier, so ⌘K still opens actions', async () => {
     selectScript();
     render(ScriptLibraryView);
 
@@ -165,7 +165,7 @@ describe('ScriptLibraryView keyboard', () => {
     expect(runSelectedScript).not.toHaveBeenCalled();
   });
 
-  it('enter_is_ignored_while_a_modal_is_open', async () => {
+  it('ignores Enter while a modal owns the keyboard', async () => {
     selectScript();
     vi.mocked(isAnyModalOpen).mockReturnValue(true);
     render(ScriptLibraryView);
@@ -175,7 +175,7 @@ describe('ScriptLibraryView keyboard', () => {
     expect(runSelectedScript).not.toHaveBeenCalled();
   });
 
-  it('enter_is_ignored_while_the_action_popup_is_open', async () => {
+  it('ignores Enter while the action popup is open', async () => {
     selectScript();
     render(ScriptLibraryView);
     const popup = document.createElement('div');
@@ -188,7 +188,7 @@ describe('ScriptLibraryView keyboard', () => {
     expect(runSelectedScript).not.toHaveBeenCalled();
   });
 
-  it('enter_falls_through_while_argument_mode_is_open', async () => {
+  it('stands down while argument mode owns Enter', async () => {
     // runSelectedScript promotes a script with arguments into argument mode,
     // which leaves this view mounted under the chips. Stealing Enter there
     // would re-enter argument mode and discard what the user typed instead of
@@ -203,7 +203,7 @@ describe('ScriptLibraryView keyboard', () => {
     expect(notConsumed).toBe(true);
   });
 
-  it('arrow_keys_fall_through_while_argument_mode_is_open', async () => {
+  it('stands down on arrows while argument mode is open', async () => {
     selectScript();
     render(ScriptLibraryView);
     argumentMode.active = { commandObjectId: 'cmd_scripts_dyn_deploy-id' };
@@ -214,7 +214,7 @@ describe('ScriptLibraryView keyboard', () => {
     expect(notConsumed).toBe(true);
   });
 
-  it('enter_from_a_focused_text_field_falls_through', async () => {
+  it('leaves Enter to a focused text field', async () => {
     selectScript();
     render(ScriptLibraryView);
     const input = document.createElement('input');
@@ -228,7 +228,7 @@ describe('ScriptLibraryView keyboard', () => {
     expect(notConsumed).toBe(true);
   });
 
-  it('arrow_keys_still_move_the_selection', async () => {
+  it('still moves the selection with the arrow keys', async () => {
     selectScript();
     render(ScriptLibraryView);
 
@@ -242,34 +242,34 @@ describe('ScriptLibraryView keyboard', () => {
 });
 
 describe('ScriptLibraryView primary action label', () => {
-  it('label_is_run_script_when_a_script_is_selected', () => {
+  it('announces Run Script for a selected script', () => {
     selectScript();
     render(ScriptLibraryView);
 
     expect(viewManager.activeViewPrimaryActionLabel).toBe('Run Script');
   });
 
-  it('label_is_make_executable_for_a_repairable_issue', () => {
+  it('announces Make Executable for a repairable issue', () => {
     selectIssue(notExecutableIssue);
     render(ScriptLibraryView);
 
     expect(viewManager.activeViewPrimaryActionLabel).toBe('Make Executable');
   });
 
-  it('label_is_null_for_an_unfixable_issue', () => {
+  it('announces nothing for an issue it cannot repair', () => {
     selectIssue(unreadableIssue);
     render(ScriptLibraryView);
 
     expect(viewManager.activeViewPrimaryActionLabel).toBeNull();
   });
 
-  it('label_is_null_without_a_selection', () => {
+  it('announces nothing without a selection', () => {
     render(ScriptLibraryView);
 
     expect(viewManager.activeViewPrimaryActionLabel).toBeNull();
   });
 
-  it('label_is_cleared_when_the_view_is_destroyed', () => {
+  it('clears its label when the view goes away', () => {
     selectScript();
     const { unmount } = render(ScriptLibraryView);
     expect(viewManager.activeViewPrimaryActionLabel).toBe('Run Script');
@@ -279,7 +279,7 @@ describe('ScriptLibraryView primary action label', () => {
     expect(viewManager.activeViewPrimaryActionLabel).toBeNull();
   });
 
-  it('destroy_keeps_a_label_the_incoming_view_already_set', () => {
+  it('keeps a label the incoming view already published', () => {
     // A global item hotkey replaces the view: the next view's viewActivated
     // publishes its own label before Svelte tears this component down.
     selectScript();

--- a/asyar-launcher/src/built-in-features/scripts/ScriptLibraryView.test.ts
+++ b/asyar-launcher/src/built-in-features/scripts/ScriptLibraryView.test.ts
@@ -27,6 +27,10 @@ vi.mock('../../services/extension/viewManager.svelte', () => ({
   viewManager: { activeViewPrimaryActionLabel: null },
 }));
 
+vi.mock('../../services/search/commandArguments', () => ({
+  commandArgumentsService: { active: null },
+}));
+
 vi.mock('../../components', async () => ({
   Badge: (await import('../../components/base/Badge.svelte')).default,
   Card: (await import('../../components/layout/Card.svelte')).default,
@@ -43,6 +47,10 @@ import { scriptsManager } from './scriptsManager.svelte';
 import { runSelectedScript } from './runSelected';
 import { isAnyModalOpen } from '../../components/base/Modal.logic';
 import { viewManager } from '../../services/extension/viewManager.svelte';
+import { commandArgumentsService } from '../../services/search/commandArguments';
+
+// `active` is a getter on the real service, so the mock needs a writable view.
+const argumentMode = commandArgumentsService as unknown as { active: unknown };
 
 const script = {
   absolutePath: '/scripts/deploy.sh',
@@ -96,6 +104,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(isAnyModalOpen).mockReturnValue(false);
   viewManager.activeViewPrimaryActionLabel = null;
+  argumentMode.active = null;
   Object.assign(scriptsManager, {
     scripts: [],
     issues: [],
@@ -179,6 +188,46 @@ describe('ScriptLibraryView keyboard', () => {
     expect(runSelectedScript).not.toHaveBeenCalled();
   });
 
+  it('enter_falls_through_while_argument_mode_is_open', async () => {
+    // runSelectedScript promotes a script with arguments into argument mode,
+    // which leaves this view mounted under the chips. Stealing Enter there
+    // would re-enter argument mode and discard what the user typed instead of
+    // letting the chip row submit.
+    selectScript();
+    render(ScriptLibraryView);
+    argumentMode.active = { commandObjectId: 'cmd_scripts_dyn_deploy-id' };
+
+    const notConsumed = await fireEvent.keyDown(window, { key: 'Enter' });
+
+    expect(runSelectedScript).not.toHaveBeenCalled();
+    expect(notConsumed).toBe(true);
+  });
+
+  it('arrow_keys_fall_through_while_argument_mode_is_open', async () => {
+    selectScript();
+    render(ScriptLibraryView);
+    argumentMode.active = { commandObjectId: 'cmd_scripts_dyn_deploy-id' };
+
+    const notConsumed = await fireEvent.keyDown(window, { key: 'ArrowDown' });
+
+    expect(scriptsManager.moveSelection).not.toHaveBeenCalled();
+    expect(notConsumed).toBe(true);
+  });
+
+  it('enter_from_a_focused_text_field_falls_through', async () => {
+    selectScript();
+    render(ScriptLibraryView);
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    const notConsumed = await fireEvent.keyDown(input, { key: 'Enter' });
+    input.remove();
+
+    expect(runSelectedScript).not.toHaveBeenCalled();
+    expect(notConsumed).toBe(true);
+  });
+
   it('arrow_keys_still_move_the_selection', async () => {
     selectScript();
     render(ScriptLibraryView);
@@ -228,5 +277,18 @@ describe('ScriptLibraryView primary action label', () => {
     unmount();
 
     expect(viewManager.activeViewPrimaryActionLabel).toBeNull();
+  });
+
+  it('destroy_keeps_a_label_the_incoming_view_already_set', () => {
+    // A global item hotkey replaces the view: the next view's viewActivated
+    // publishes its own label before Svelte tears this component down.
+    selectScript();
+    const { unmount } = render(ScriptLibraryView);
+    expect(viewManager.activeViewPrimaryActionLabel).toBe('Run Script');
+
+    viewManager.activeViewPrimaryActionLabel = 'Paste';
+    unmount();
+
+    expect(viewManager.activeViewPrimaryActionLabel).toBe('Paste');
   });
 });

--- a/asyar-launcher/src/built-in-features/scripts/index.ts
+++ b/asyar-launcher/src/built-in-features/scripts/index.ts
@@ -1,10 +1,10 @@
 import { ActionContext, type Extension, type ExtensionContext } from 'asyar-sdk/contracts';
 import { scriptsManager } from './scriptsManager.svelte';
 import { dispatchScriptCommand } from './dispatch';
+import { runSelectedScript } from './runSelected';
 import ScriptLibraryView from './ScriptLibraryView.svelte';
 import { registerBuiltinDynamicDispatcher } from '../../services/extension/builtinDynamicDispatchers';
 import { actionService, type ApplicationAction } from '../../services/action/actionService.svelte';
-import { commandArgumentsService } from '../../services/search/commandArguments';
 import { revealItemInDir } from '@tauri-apps/plugin-opener';
 import { writeText } from 'tauri-plugin-clipboard-x-api';
 
@@ -43,7 +43,7 @@ class ScriptsExtension implements Extension {
   }
 
   async onViewSubmit(_query: string): Promise<void> {
-    await this.runSelectedScript();
+    await runSelectedScript();
   }
 
   async executeCommand(commandId: string, args?: Record<string, unknown>): Promise<unknown> {
@@ -65,7 +65,7 @@ class ScriptsExtension implements Extension {
         category: 'Scripts',
         context: ActionContext.EXTENSION_VIEW,
         visible: () => scriptsManager.selectedScript !== undefined,
-        execute: async () => this.runSelectedScript(),
+        execute: async () => runSelectedScript(),
       },
       {
         id: 'scripts:reveal',
@@ -129,16 +129,6 @@ class ScriptsExtension implements Extension {
     ];
 
     for (const action of actions) actionService.registerAction(action);
-  }
-
-  private async runSelectedScript(): Promise<void> {
-    const script = scriptsManager.selectedScript;
-    if (!script) return;
-    if (script.header.arguments.length > 0) {
-      const entered = await commandArgumentsService.enter(`cmd_scripts_dyn_${script.dynamicId}`);
-      if (entered) return;
-    }
-    await dispatchScriptCommand(script.dynamicId, undefined);
   }
 
   private unregisterLibraryActions(): void {

--- a/asyar-launcher/src/built-in-features/scripts/runSelected.ts
+++ b/asyar-launcher/src/built-in-features/scripts/runSelected.ts
@@ -1,0 +1,16 @@
+import { scriptsManager } from './scriptsManager.svelte';
+import { dispatchScriptCommand } from './dispatch';
+import { commandArgumentsService } from '../../services/search/commandArguments';
+
+/** Run whatever the script library has selected, prompting for arguments
+ *  first when the script declares any. Lives outside index.ts so the view
+ *  can share it — index.ts imports the view, so the view cannot import back. */
+export async function runSelectedScript(): Promise<void> {
+  const script = scriptsManager.selectedScript;
+  if (!script) return;
+  if (script.header.arguments.length > 0) {
+    const entered = await commandArgumentsService.enter(`cmd_scripts_dyn_${script.dynamicId}`);
+    if (entered) return;
+  }
+  await dispatchScriptCommand(script.dynamicId, undefined);
+}


### PR DESCRIPTION
## The bug

The Script Library view shows `Run Command  ⏎` in the bottom bar, but pressing Enter does nothing. The script only runs via ⌘K → *Run Script*.

Two separate defects:

**1. Enter never reached the view.** `ScriptLibraryView.svelte` registered a window keydown listener that only handled ArrowUp/ArrowDown. `launcherKeyboard.tryHandleViewEnter()` deliberately does *not* consume Enter here — the scripts manifest is `"searchable": false`, so it returns `false` and lets Enter bubble to a window-level listener, which is the contract built-in features rely on (clipboard-history, snippets). Scripts never registered one, so `ScriptsExtension.onViewSubmit()` — which already calls the run path — was unreachable.

**2. The hint was stale.** `PrimaryActionDisplay` falls back to the *selected search result*'s type when `activeViewPrimaryActionLabel` is null. The row that opened the view is of type `command`, hence the misleading "Run Command". Scripts never published a label, unlike clipboard-history (`Paste`), help (`Open Guide`), store (`Show Details`).

## The fix

- Extract `runSelectedScript()` from the private method on `ScriptsExtension` into `runSelected.ts`. `index.ts` imports the view, so the view cannot import back — the shared module breaks the cycle. `onViewSubmit` and the `scripts:run` action now call it too, so all three entry points share one path (including the arguments prompt).
- Handle Enter in the view's existing window listener: run the selected script, or repair a `makeExecutable` issue. Enter is consumed **only** when the selection has something to do — otherwise it keeps bubbling to the launcher.
- Publish an accurate primary action label (`Run Script` / `Make Executable` / none) and clear it on destroy, guarded so a replacement navigation cannot wipe the *incoming* view's label.

### Argument mode

`runSelectedScript()` promotes a script that declares arguments into command-argument mode, which leaves this view mounted underneath the chip row. Since the listener is window+capture it would beat the chips' own Enter, re-enter argument mode and discard what the user typed. The handler therefore stands down while `commandArgumentsService.active` is set, and for any focused text field.

## Verification

Traced the full runtime route: `handleGlobalKeydown` (window capture) → `tryRouteToActiveView` returns without consuming for built-in features → the view's capture listener acts and stops propagation → the container-level `handleKeydown` never sees it. `tryHandleSearchNavigation` bails on `viewManager.activeView`, so the launcher search input does not swallow Enter first.

- `pnpm --filter asyar test:run` — 285 files, **3252 tests passing**, including 17 new `ScriptLibraryView.test.ts` cases covering run-on-Enter, issue repair, fall-through for empty/unfixable selections, modifier keys, modal and action-popup guards, argument mode, focused text fields, and every label state.
- `pnpm format:check` and `pnpm check:design` clean.
- `svelte-check` reports only pre-existing errors; none in `built-in-features/scripts/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)