### PR TITLE
feat(download): add Linux Wayland shortcut setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ brew install --cask asyar
 
 **Linux (Wayland) Shortcut Setup:**
 
-Wayland protocol security prevents background applications from capturing global hotkeys directly. To summon Asyar on Wayland, bind a key shortcut in your desktop compositor (Hyprland, Sway, GNOME, KDE) to execute `asyar`:
+Wayland protocol security prevents background applications from intercepting global keyboard shortcuts directly. To summon or toggle Asyar on Wayland, bind your preferred shortcut in your desktop environment or window manager to execute `asyar`. Re-executing `asyar` automatically toggles the visibility of the already-running background instance:
 
-- **Hyprland:** `bind = ALT, SPACE, exec, asyar`
-- **Sway:** `bindsym Mod1+space exec asyar`
-
-Re-executing `asyar` toggles the visibility of the already-running instance.
+- **GNOME:** Open **Settings** → **Keyboard** → **View and Customize Shortcuts** → **Custom Shortcuts**, click **+**, set Name to `Asyar`, Command to `asyar`, and assign your shortcut (e.g. `Ctrl+Space` or `Super+Space`).
+- **KDE Plasma:** Open **System Settings** → **Shortcuts** → **Custom Shortcuts** (or **Command/URL**), add a new global shortcut for `asyar`, and set your trigger key (e.g. `Alt+Space` or `Meta+Space`).
+- **Hyprland:** Add `bind = ALT, SPACE, exec, asyar` to `~/.config/hypr/hyprland.conf`.
+- **Sway:** Add `bindsym Mod1+space exec asyar` to `~/.config/sway/config`.
 
 ---
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -43,6 +43,8 @@ The global hotkey you chose during setup shows or hides Asyar from anywhere on y
 
 To change your hotkey after setup, open **Settings → General** (or **Settings → Shortcuts**) and click inside the shortcut recorder. Press your new combination and click **Save**.
 
+> **Linux (Wayland) Users:** Wayland compositors do not allow background apps to capture global hotkeys directly. Instead, bind a custom shortcut in your desktop settings (GNOME, KDE Plasma, Hyprland, Sway) to run the `asyar` command. Re-running `asyar` automatically toggles the visibility of the running instance. See [Troubleshooting](./troubleshooting.md#the-hotkey-doesnt-open-asyar) for step-by-step instructions.
+
 If the hotkey stops working, see [Troubleshooting](./troubleshooting.md) for common causes.
 
 ## Your first search

--- a/docs/guide/keyboard-shortcuts.md
+++ b/docs/guide/keyboard-shortcuts.md
@@ -24,6 +24,8 @@ The show/hide hotkey is user-configurable. The exact keys depend on what you set
 
 **Windows & Linux:** Asyar's shortcut display uses macOS symbols (⌘, ⌥, ⌃, ⇧). On Windows and Linux, use **Ctrl** wherever **⌘** is shown, and use the **Windows/Super** key where a Super-key shortcut is shown.
 
+**Linux on Wayland:** Because Wayland protocol security blocks background hotkey grabs, assign your shortcut inside your desktop compositor settings to run the `asyar` command. Executing `asyar` while the daemon is running acts as a toggle.
+
 ## In a view
 
 These shortcuts apply when you have drilled into a result that opens a full view (for example, Clipboard History, Snippets, or an AI agent conversation).

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -12,11 +12,18 @@ If pressing your global hotkey does nothing:
 
 3. **Check for conflicts.** Another app may have claimed the same key combination. Open the shortcut recorder — if a conflict warning appears, choose a different combination that is not already in use.
 
-4. **Check macOS Accessibility permission (macOS only).** Although Accessibility is mainly needed for text expansion, Asyar also needs it for reliable global hotkey registration on some macOS versions. Go to **System Settings → Privacy & Security → Accessibility**, find Asyar in the list, and make sure the toggle is on. Relaunch Asyar after granting access.
+4. **Linux Wayland Shortcut Setup:** On Wayland (GNOME, KDE, Hyprland, Sway), applications cannot intercept global keystrokes in the background. You must create a custom shortcut in your desktop settings that executes `asyar`:
+   - **GNOME:** **Settings** → **Keyboard** → **View and Customize Shortcuts** → **Custom Shortcuts** → Add Name `Asyar`, Command `asyar`, and set your shortcut (e.g. `Ctrl+Space`).
+   - **KDE Plasma:** **System Settings** → **Shortcuts** → **Custom Shortcuts** / **Command/URL** → set Command to `asyar`.
+   - **Hyprland:** Add `bind = ALT, SPACE, exec, asyar` to `hyprland.conf`.
+   - **Sway:** Add `bindsym Mod1+space exec asyar` to your Sway config.
+     Running `asyar` while the app is active will toggle the launcher window.
 
-5. **Restart Asyar.** Search for "Quit Asyar" inside the launcher (if you can open it another way), or quit via the menu bar icon and reopen Asyar.
+5. **Check macOS Accessibility permission (macOS only).** Although Accessibility is mainly needed for text expansion, Asyar also needs it for reliable global hotkey registration on some macOS versions. Go to **System Settings → Privacy & Security → Accessibility**, find Asyar in the list, and make sure the toggle is on. Relaunch Asyar after granting access.
 
-6. **Restart your computer.** Occasionally a fresh login is needed after granting system permissions for the first time.
+6. **Restart Asyar.** Search for "Quit Asyar" inside the launcher (if you can open it another way), or quit via the menu bar / system tray icon and reopen Asyar.
+
+7. **Restart your computer.** Occasionally a fresh login is needed after granting system permissions for the first time.
 
 ## Asyar can't see my apps / accessibility
 


### PR DESCRIPTION
- Add interactive Wayland global shortcut instructions card to the download page
- Document GNOME, KDE, Hyprland, and Sway shortcut setup steps for new Linux users