### PR TITLE
- Add AsyarError, PermissionDeniedError, PermissionConsentRequiredError, and IpcTimeoutError classes to asyar-sdk

### DIFF
--- a/asyar-launcher/src/services/extension/ExtensionIpcRouter.ts
+++ b/asyar-launcher/src/services/extension/ExtensionIpcRouter.ts
@@ -132,7 +132,12 @@ export class ExtensionIpcRouter {
       deps: this.deps,
       result: undefined,
       reply: (result) => post({ result }),
-      replyError: (error) => post({ error }),
+      replyError: (error, errorCode, errorDetails) =>
+        post({
+          error,
+          ...(errorCode ? { errorCode } : {}),
+          ...(errorDetails ? { errorDetails } : {}),
+        }),
     };
   }
 

--- a/asyar-launcher/src/services/extension/ipc/ipcPipeline.test.ts
+++ b/asyar-launcher/src/services/extension/ipc/ipcPipeline.test.ts
@@ -31,6 +31,7 @@ import { feedbackService } from '../../feedback/feedbackService.svelte';
 import { inspectorStore } from '../../dev/inspectorStore.svelte';
 import { isDevInspectorActive } from './devTracing';
 import { ExtensionIpcRouter } from '../ExtensionIpcRouter';
+import { permissionConsentService } from '../permissionConsentService.svelte';
 import { HandledDispatchError } from './errors';
 import { IPC_HANDLERS } from './handlers';
 import { IPC_PIPELINE } from './pipeline';
@@ -107,6 +108,7 @@ beforeEach(() => {
     extension: {},
     commands: {},
   } as never);
+  permissionConsentService.reset();
 });
 
 // ── §3 behavior matrix ──────────────────────────────────────────────────────
@@ -525,6 +527,40 @@ describe('IPC pipeline — denial and error envelopes', () => {
         type: 'asyar:response',
         messageId: 'm-denied',
         error: 'Permission denied: "clipboard:read" is required but not declared in manifest.json',
+        errorCode: 'PERMISSION_DENIED',
+        errorDetails: { permission: 'clipboard:read' },
+      },
+    ]);
+    expect(feedbackService.report).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'permission_denied' }),
+    );
+  });
+
+  it('attaches PERMISSION_CONSENT_REQUIRED when manifest declared permission but consent is pending', async () => {
+    vi.mocked(commands.checkExtensionPermission).mockResolvedValue({
+      allowed: false,
+      requiredPermission: 'fs:watch',
+      reason: 'needs consent',
+    } as never);
+
+    const router = new ExtensionIpcRouter(
+      {} as ServiceRegistry,
+      (id: string) => (id === EXT_ID ? ({ id, permissions: ['fs:watch'] } as never) : undefined),
+      goBack,
+      saveSearchIndex,
+    );
+
+    await router.handleMessage(
+      frameEvent({ type: 'asyar:api:fsWatcher:create', messageId: 'm-consent' }),
+    );
+
+    expect(responsesTo(viewPost)).toEqual([
+      {
+        type: 'asyar:response',
+        messageId: 'm-consent',
+        error: 'Permission consent required: "fs:watch" requires user review in Settings',
+        errorCode: 'PERMISSION_CONSENT_REQUIRED',
+        errorDetails: { permission: 'fs:watch' },
       },
     ]);
     expect(feedbackService.report).toHaveBeenCalledWith(

--- a/asyar-launcher/src/services/extension/ipc/pipeline.ts
+++ b/asyar-launcher/src/services/extension/ipc/pipeline.ts
@@ -5,6 +5,7 @@ import { extensionIframeManager } from '../extensionIframeManager.svelte';
 import { isExternallyConsumedExtensionResponse } from '../../../lib/ipc/extensionMessageProtocol';
 import { HandledDispatchError, classifyProxyError, extractErrorMessage } from './errors';
 import { resolvePreIdentityHandler, resolveTerminalHandler } from './handlers';
+import { permissionConsentService } from '../permissionConsentService.svelte';
 import type { IpcContext, IpcStage } from './types';
 
 /** Search replies are consumed by a dedicated bridge, on every frame, first. */
@@ -111,14 +112,24 @@ const permissionGate: IpcStage = {
     logService.warn(
       `[PermissionGate] BLOCKED: ${permissionResult?.reason ?? 'permission check failed'}`,
     );
-    // Rust sets `requiredPermission` only for calls gated on a real manifest
-    // permission. The fail-closed path sends only `reason` — and a call type is
-    // not a permission name, so "declare it in manifest.json" would be
-    // unfollowable advice there.
-    const permError = permissionResult?.requiredPermission
-      ? `Permission denied: "${permissionResult.requiredPermission}" is required but not declared in manifest.json`
+    const requiredPermission = permissionResult?.requiredPermission;
+    const manifest = ctx.extensionId ? ctx.deps.getManifestById(ctx.extensionId) : undefined;
+    const isConsentRequired =
+      Boolean(ctx.extensionId && permissionConsentService.needsReview.includes(ctx.extensionId)) ||
+      Boolean(requiredPermission && manifest?.permissions?.includes(requiredPermission));
+
+    const errorCode = isConsentRequired ? 'PERMISSION_CONSENT_REQUIRED' : 'PERMISSION_DENIED';
+    const permError = requiredPermission
+      ? isConsentRequired
+        ? `Permission consent required: "${requiredPermission}" requires user review in Settings`
+        : `Permission denied: "${requiredPermission}" is required but not declared in manifest.json`
       : (permissionResult?.reason ?? `Blocked "${ctx.type}": permission check failed`);
-    ctx.replyError(permError);
+
+    ctx.replyError(
+      permError,
+      errorCode,
+      requiredPermission ? { permission: requiredPermission } : undefined,
+    );
     void feedbackService.report({
       source: 'extension',
       kind: classifyProxyError(ctx.type, permError),

--- a/asyar-launcher/src/services/extension/ipc/types.ts
+++ b/asyar-launcher/src/services/extension/ipc/types.ts
@@ -38,7 +38,7 @@ export interface IpcContext {
   role?: IframeRole;
   result: unknown;
   reply: (result: unknown) => void;
-  replyError: (error: string) => void;
+  replyError: (error: string, errorCode?: string, errorDetails?: Record<string, unknown>) => void;
 }
 
 /** Cross-cutting stage. Not calling `next()` ends the message here. */

--- a/asyar-sdk/src/contracts.ts
+++ b/asyar-sdk/src/contracts.ts
@@ -192,3 +192,4 @@ export { injectThemeVariables, injectFontFaceCSS } from './lib/themeInjector';
 export * from './types';
 export * from './icons';
 export * from './search';
+export * from './errors';

--- a/asyar-sdk/src/errors/AsyarError.test.ts
+++ b/asyar-sdk/src/errors/AsyarError.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AsyarError,
+  PermissionDeniedError,
+  PermissionConsentRequiredError,
+  IpcTimeoutError,
+} from './AsyarError';
+
+describe('AsyarError hierarchy', () => {
+  it('instantiates AsyarError with message, code, and details', () => {
+    const err = new AsyarError('Something failed', 'GENERIC_ERROR', { foo: 'bar' });
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AsyarError);
+    expect(err.name).toBe('AsyarError');
+    expect(err.message).toBe('Something failed');
+    expect(err.code).toBe('GENERIC_ERROR');
+    expect(err.details).toEqual({ foo: 'bar' });
+  });
+
+  it('instantiates PermissionDeniedError correctly', () => {
+    const err = new PermissionDeniedError('Permission denied', 'clipboard:read');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AsyarError);
+    expect(err).toBeInstanceOf(PermissionDeniedError);
+    expect(err.name).toBe('PermissionDeniedError');
+    expect(err.message).toBe('Permission denied');
+    expect(err.code).toBe('PERMISSION_DENIED');
+    expect(err.permission).toBe('clipboard:read');
+    expect(err.details).toEqual({ permission: 'clipboard:read' });
+  });
+
+  it('instantiates PermissionDeniedError without permission', () => {
+    const err = new PermissionDeniedError('Permission denied');
+    expect(err.permission).toBeUndefined();
+    expect(err.details).toBeUndefined();
+  });
+
+  it('instantiates PermissionConsentRequiredError correctly', () => {
+    const err = new PermissionConsentRequiredError('Consent required', 'fs:watch');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AsyarError);
+    expect(err).toBeInstanceOf(PermissionConsentRequiredError);
+    expect(err.name).toBe('PermissionConsentRequiredError');
+    expect(err.message).toBe('Consent required');
+    expect(err.code).toBe('PERMISSION_CONSENT_REQUIRED');
+    expect(err.permission).toBe('fs:watch');
+    expect(err.details).toEqual({ permission: 'fs:watch' });
+  });
+
+  it('instantiates PermissionConsentRequiredError without permission', () => {
+    const err = new PermissionConsentRequiredError('Consent required');
+    expect(err.permission).toBeUndefined();
+    expect(err.details).toBeUndefined();
+  });
+
+  it('instantiates IpcTimeoutError correctly', () => {
+    const err = new IpcTimeoutError('IPC timeout', 'storage:get', 5000);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AsyarError);
+    expect(err).toBeInstanceOf(IpcTimeoutError);
+    expect(err.name).toBe('IpcTimeoutError');
+    expect(err.message).toBe('IPC timeout');
+    expect(err.code).toBe('IPC_TIMEOUT');
+    expect(err.command).toBe('storage:get');
+    expect(err.timeoutMs).toBe(5000);
+    expect(err.details).toEqual({ command: 'storage:get', timeoutMs: 5000 });
+  });
+});

--- a/asyar-sdk/src/errors/AsyarError.ts
+++ b/asyar-sdk/src/errors/AsyarError.ts
@@ -1,0 +1,53 @@
+export class AsyarError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = this.constructor.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class PermissionDeniedError extends AsyarError {
+  constructor(
+    message: string,
+    public readonly permission?: string,
+  ) {
+    super(message, 'PERMISSION_DENIED', permission !== undefined ? { permission } : undefined);
+    this.name = this.constructor.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class PermissionConsentRequiredError extends AsyarError {
+  constructor(
+    message: string,
+    public readonly permission?: string,
+  ) {
+    super(
+      message,
+      'PERMISSION_CONSENT_REQUIRED',
+      permission !== undefined ? { permission } : undefined,
+    );
+    this.name = this.constructor.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class IpcTimeoutError extends AsyarError {
+  constructor(
+    message: string,
+    public readonly command?: string,
+    public readonly timeoutMs?: number,
+  ) {
+    super(
+      message,
+      'IPC_TIMEOUT',
+      command !== undefined || timeoutMs !== undefined ? { command, timeoutMs } : undefined,
+    );
+    this.name = this.constructor.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/asyar-sdk/src/errors/index.ts
+++ b/asyar-sdk/src/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './AsyarError';

--- a/asyar-sdk/src/index.ts
+++ b/asyar-sdk/src/index.ts
@@ -1,0 +1,1 @@
+export * from './contracts';

--- a/asyar-sdk/src/ipc/MessageBroker.test.ts
+++ b/asyar-sdk/src/ipc/MessageBroker.test.ts
@@ -91,3 +91,124 @@ describe('MessageBroker.invoke — host dispatcher fast path', () => {
     expect(dispatcher).not.toHaveBeenCalled();
   });
 });
+
+describe('MessageBroker.handleMessage — structured error rejection', () => {
+  it('rejects with PermissionDeniedError when errorCode is PERMISSION_DENIED', async () => {
+    const fakeParent = { postMessage: vi.fn() };
+    Object.defineProperty(window, 'parent', { configurable: true, get: () => fakeParent });
+
+    const broker = freshBroker();
+    const promise = broker.invoke('clipboard:readText');
+
+    expect(fakeParent.postMessage).toHaveBeenCalledOnce();
+    const [message] = fakeParent.postMessage.mock.calls[0];
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          type: 'asyar:response',
+          messageId: message.messageId,
+          error:
+            'Permission denied: "clipboard:read" is required but not declared in manifest.json',
+          errorCode: 'PERMISSION_DENIED',
+          errorDetails: { permission: 'clipboard:read' },
+        },
+      }),
+    );
+
+    await expect(promise).rejects.toSatisfy((err: any) => {
+      expect(err.name).toBe('PermissionDeniedError');
+      expect(err.code).toBe('PERMISSION_DENIED');
+      expect(err.permission).toBe('clipboard:read');
+      expect(err.message).toContain('Permission denied');
+      return true;
+    });
+  });
+
+  it('rejects with PermissionConsentRequiredError when errorCode is PERMISSION_CONSENT_REQUIRED', async () => {
+    const fakeParent = { postMessage: vi.fn() };
+    Object.defineProperty(window, 'parent', { configurable: true, get: () => fakeParent });
+
+    const broker = freshBroker();
+    const promise = broker.invoke('fs:watch');
+
+    expect(fakeParent.postMessage).toHaveBeenCalledOnce();
+    const [message] = fakeParent.postMessage.mock.calls[0];
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          type: 'asyar:response',
+          messageId: message.messageId,
+          error: 'Permission consent required: "fs:watch" requires user review in Settings',
+          errorCode: 'PERMISSION_CONSENT_REQUIRED',
+          errorDetails: { permission: 'fs:watch' },
+        },
+      }),
+    );
+
+    await expect(promise).rejects.toSatisfy((err: any) => {
+      expect(err.name).toBe('PermissionConsentRequiredError');
+      expect(err.code).toBe('PERMISSION_CONSENT_REQUIRED');
+      expect(err.permission).toBe('fs:watch');
+      expect(err.message).toContain('Permission consent required');
+      return true;
+    });
+  });
+
+  it('rejects with AsyarError for other errors with errorCode', async () => {
+    const fakeParent = { postMessage: vi.fn() };
+    Object.defineProperty(window, 'parent', { configurable: true, get: () => fakeParent });
+
+    const broker = freshBroker();
+    const promise = broker.invoke('storage:get');
+
+    expect(fakeParent.postMessage).toHaveBeenCalledOnce();
+    const [message] = fakeParent.postMessage.mock.calls[0];
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          type: 'asyar:response',
+          messageId: message.messageId,
+          error: 'Key not found',
+          errorCode: 'NOT_FOUND',
+          errorDetails: { key: 'foo' },
+        },
+      }),
+    );
+
+    await expect(promise).rejects.toSatisfy((err: any) => {
+      expect(err.name).toBe('AsyarError');
+      expect(err.code).toBe('NOT_FOUND');
+      expect(err.details).toEqual({ key: 'foo' });
+      expect(err.message).toBe('Key not found');
+      return true;
+    });
+  });
+
+  it('rejects with IpcTimeoutError on invoke timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const fakeParent = { postMessage: vi.fn() };
+      Object.defineProperty(window, 'parent', { configurable: true, get: () => fakeParent });
+
+      const broker = freshBroker();
+      const promise = broker.invoke('storage:get', undefined, undefined, 100);
+
+      // Attach reject handler to avoid unhandled rejection during timer advance
+      const rejection = expect(promise).rejects.toSatisfy((err: any) => {
+        expect(err.name).toBe('IpcTimeoutError');
+        expect(err.code).toBe('IPC_TIMEOUT');
+        expect(err.command).toBe('storage:get');
+        expect(err.timeoutMs).toBe(100);
+        return true;
+      });
+
+      vi.advanceTimersByTime(150);
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/asyar-sdk/src/ipc/MessageBroker.ts
+++ b/asyar-sdk/src/ipc/MessageBroker.ts
@@ -1,5 +1,11 @@
 import type { WireCommand } from './namespaces';
 import { emitIpcLog } from './devInspectorBridge';
+import {
+  AsyarError,
+  PermissionDeniedError,
+  PermissionConsentRequiredError,
+  IpcTimeoutError,
+} from '../errors';
 
 export interface IPCMessage<T = any> {
   type: string;
@@ -13,6 +19,8 @@ export interface IPCResponse<T = any> {
   messageId: string;
   result?: T;
   error?: string;
+  errorCode?: string;
+  errorDetails?: Record<string, unknown>;
 }
 
 export type HostDispatcher = (
@@ -101,7 +109,27 @@ export class MessageBroker {
           extensionId: this.extensionId,
         });
         if (response.error) {
-          pending.reject(new Error(response.error));
+          if (response.errorCode === 'PERMISSION_DENIED') {
+            const perm =
+              typeof response.errorDetails?.permission === 'string'
+                ? response.errorDetails.permission
+                : undefined;
+            pending.reject(new PermissionDeniedError(response.error, perm));
+          } else if (response.errorCode === 'PERMISSION_CONSENT_REQUIRED') {
+            const perm =
+              typeof response.errorDetails?.permission === 'string'
+                ? response.errorDetails.permission
+                : undefined;
+            pending.reject(new PermissionConsentRequiredError(response.error, perm));
+          } else {
+            pending.reject(
+              new AsyarError(
+                response.error,
+                response.errorCode ?? 'UNKNOWN_ERROR',
+                response.errorDetails,
+              ),
+            );
+          }
         } else {
           pending.resolve(response.result);
         }
@@ -159,7 +187,13 @@ export class MessageBroker {
           timestamp: Date.now(),
           extensionId: extensionId ?? this.extensionId,
         });
-        reject(new Error(`IPC timeout after ${timeoutMs}ms for command: ${command}`));
+        reject(
+          new IpcTimeoutError(
+            `IPC timeout after ${timeoutMs}ms for command: ${command}`,
+            command,
+            timeoutMs,
+          ),
+        );
       }, timeoutMs);
 
       this.pendingRequests.set(messageId, {

--- a/asyar-sdk/src/worker.ts
+++ b/asyar-sdk/src/worker.ts
@@ -237,3 +237,4 @@ export type { Namespace, WireCommand } from './ipc/namespaces';
 export { extensionBridge, ExtensionBridge } from './ExtensionBridge';
 export { PreferencesFacade } from './PreferencesFacade';
 export type { PreferencesSnapshot } from './PreferencesFacade';
+export * from './errors';

--- a/docs/reference/sdk/README.md
+++ b/docs/reference/sdk/README.md
@@ -123,3 +123,4 @@ expands the placement guidance.
 - **[OpenerService](./opener-service.md)**
 - **[Preferences (declarative settings)](./preferences.md)**
 - **[User-authored templates pattern](./user-templates-pattern.md)**
+- **[Error Handling & Error Classes](./errors.md)**

--- a/docs/reference/sdk/errors.md
+++ b/docs/reference/sdk/errors.md
@@ -1,0 +1,147 @@
+# Error Handling & Error Classes
+
+`asyar-sdk` provides typed error classes for handling IPC errors, permission issues, and timeouts in extensions.
+
+All custom errors inherit from `AsyarError`, which extends the standard JavaScript `Error`.
+
+---
+
+## Error Class Hierarchy
+
+```
+Error
+ └── AsyarError
+      ├── PermissionDeniedError
+      ├── PermissionConsentRequiredError
+      └── IpcTimeoutError
+```
+
+---
+
+## Error Classes
+
+### `AsyarError`
+
+Base error class for all SDK and host IPC errors.
+
+```typescript
+export class AsyarError extends Error {
+  public readonly code: string;
+  public readonly details?: Record<string, unknown>;
+
+  constructor(message: string, code: string, details?: Record<string, unknown>);
+}
+```
+
+- `code`: Machine-readable error code (e.g. `'PERMISSION_DENIED'`, `'IPC_TIMEOUT'`, `'UNKNOWN_ERROR'`).
+- `details`: Optional structured metadata accompanying the error.
+- `message`: Human-readable error message.
+
+---
+
+### `PermissionDeniedError`
+
+Thrown when an IPC call is blocked because the required permission is not declared in `manifest.json`.
+
+```typescript
+export class PermissionDeniedError extends AsyarError {
+  public readonly permission?: string;
+
+  constructor(message: string, permission?: string);
+}
+```
+
+- `code`: `'PERMISSION_DENIED'`
+- `permission`: The name of the missing permission (e.g. `'clipboard:read'`, `'network'`).
+- `details`: `{ permission?: string }`
+
+---
+
+### `PermissionConsentRequiredError`
+
+Thrown when an extension declared a permission in `manifest.json`, but the user has not yet consented to or approved the permission set (or consent was withheld pending review in Settings).
+
+```typescript
+export class PermissionConsentRequiredError extends AsyarError {
+  public readonly permission?: string;
+
+  constructor(message: string, permission?: string);
+}
+```
+
+- `code`: `'PERMISSION_CONSENT_REQUIRED'`
+- `permission`: The permission requiring user consent.
+- `details`: `{ permission?: string }`
+
+---
+
+### `IpcTimeoutError`
+
+Thrown when an IPC call between an extension and the host times out before receiving a response envelope.
+
+```typescript
+export class IpcTimeoutError extends AsyarError {
+  public readonly command?: string;
+  public readonly timeoutMs?: number;
+
+  constructor(message: string, command?: string, timeoutMs?: number);
+}
+```
+
+- `code`: `'IPC_TIMEOUT'`
+- `command`: The wire command that timed out (e.g. `'storage:get'`).
+- `timeoutMs`: The timeout duration in milliseconds.
+- `details`: `{ command?: string, timeoutMs?: number }`
+
+---
+
+## Usage & Catching Errors
+
+Instead of matching brittle error message strings, use standard `instanceof` checks:
+
+```typescript
+import {
+  PermissionDeniedError,
+  PermissionConsentRequiredError,
+  IpcTimeoutError,
+  AsyarError,
+} from 'asyar-sdk/contracts'; // or from 'asyar-sdk/worker' / 'asyar-sdk/view'
+
+try {
+  await clipboard.readCurrentText();
+} catch (err) {
+  if (err instanceof PermissionConsentRequiredError) {
+    // Permission is in manifest.json, but user needs to grant consent in Settings
+    console.warn(`Please grant consent for ${err.permission} in Settings > Extensions.`);
+  } else if (err instanceof PermissionDeniedError) {
+    // Permission was not declared in manifest.json
+    console.error(`Permission ${err.permission} is missing from manifest.json.`);
+  } else if (err instanceof IpcTimeoutError) {
+    // IPC call timed out
+    console.error(`Command ${err.command} timed out after ${err.timeoutMs}ms.`);
+  } else if (err instanceof AsyarError) {
+    // Other structured SDK error
+    console.error(`Asyar error [${err.code}]:`, err.message, err.details);
+  } else {
+    // Non-Asyar generic error
+    console.error('Unexpected error:', err);
+  }
+}
+```
+
+---
+
+## Wire Protocol (`asyar:response`)
+
+When the host IPC pipeline rejects a request, the `asyar:response` envelope carries structured error information:
+
+```typescript
+interface IPCResponse<T = any> {
+  type: 'asyar:response';
+  messageId: string;
+  result?: T;
+  error?: string; // Human-readable error message
+  errorCode?: string; // Machine-readable enum (e.g. 'PERMISSION_DENIED')
+  errorDetails?: Record<string, unknown>; // e.g. { permission: 'clipboard:read' }
+}
+```


### PR DESCRIPTION
- Update MessageBroker to reject with structured error instances on error responses and timeouts
- Update host IPC pipeline to propagate errorCode and errorDetails across asyar:response
- Add unit tests and reference documentation