### PR TITLE
fix(calculator): read and render numbers in the user's notation

### DIFF
--- a/asyar-launcher/src-tauri/src/calculator/locale.rs
+++ b/asyar-launcher/src-tauri/src/calculator/locale.rs
@@ -1,0 +1,312 @@
+//! Locale-aware number notation for the calculator.
+//!
+//! Roughly half the world writes `61,78` where the other half writes
+//! `61.78`. fend — like every expression parser — only understands the
+//! `1,234.56` convention, so a query typed in a comma-decimal locale is
+//! silently misread: `61,78*1,19` parses as `6178 * 119`.
+//!
+//! Two conversions fix that, and the pipeline in between stays entirely
+//! in the canonical `1,234.56` notation:
+//!
+//! - [`canonicalize_input`] rewrites the query before evaluation
+//!   (`61,78*1,19` → `61.78*1.19`, `1.234,56` → `1234.56`).
+//! - [`localize_output`] rewrites the answer after evaluation
+//!   (`73.5182` → `73,5182`, `1,234,567` → `1.234.567`).
+
+/// Which convention a number is written in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NumberFormat {
+    /// `1,234.56` — point decimal, comma grouping.
+    #[default]
+    Point,
+    /// `1.234,56` — comma decimal, point grouping.
+    Comma,
+}
+
+/// Regions whose CLDR decimal separator is a comma. Everything else is
+/// treated as point-decimal, which is the safe default: a point-decimal
+/// query needs no rewriting at all.
+///
+/// Deliberate exclusions: `CH`/`LI` (German- and French-speaking, but
+/// point-decimal), `MX`/`PE`/`PA`/`PR`/`DO`/`GT`/`HN`/`NI`/`SV`
+/// (Spanish-speaking, but point-decimal).
+const COMMA_DECIMAL_REGIONS: &[&str] = &[
+    "AD", "AL", "AM", "AO", "AR", "AT", "AX", "AZ", "BA", "BE", "BF", "BG", "BI", "BJ", "BO", "BR",
+    "BY", "CD", "CF", "CG", "CI", "CL", "CM", "CO", "CR", "CU", "CV", "CY", "CZ", "DE", "DK", "DZ",
+    "EC", "EE", "ES", "FI", "FO", "FR", "GA", "GE", "GF", "GL", "GN", "GP", "GQ", "GR", "GW", "HR",
+    "HT", "HU", "ID", "IS", "IT", "KG", "KZ", "LT", "LU", "LV", "MA", "MC", "MD", "ME", "MK", "ML",
+    "MN", "MQ", "MZ", "NC", "NE", "NL", "NO", "PF", "PL", "PT", "PY", "RE", "RO", "RS", "RU", "RW",
+    "SE", "SI", "SK", "SM", "SN", "SR", "ST", "TD", "TG", "TJ", "TM", "TN", "TR", "UA", "UY", "UZ",
+    "VA", "VE", "VN", "ZA",
+];
+
+/// Languages that write comma-decimal wherever they are spoken. Only
+/// consulted when the locale tag carries no region (`"de"`, not
+/// `"de-DE"`), since the region is the stronger signal — macOS reports
+/// `en-DE` for an English UI set to the German region, and it is the
+/// region that decides how numbers are written.
+const COMMA_DECIMAL_LANGUAGES: &[&str] = &[
+    "af", "az", "be", "bg", "bs", "ca", "cs", "da", "de", "el", "es", "et", "eu", "fi", "fr", "gl",
+    "hr", "hu", "hy", "id", "is", "it", "ka", "kk", "ky", "lt", "lv", "mk", "mn", "nb", "nl", "nn",
+    "no", "pl", "pt", "ro", "ru", "sk", "sl", "sq", "sr", "sv", "tr", "uk", "uz", "vi",
+];
+
+/// The format implied by a BCP 47-ish locale tag (`de-DE`, `en_DE`, `fr`).
+pub fn from_locale_tag(tag: &str) -> NumberFormat {
+    let mut parts = tag.split(['-', '_']).filter(|p| !p.is_empty());
+    let language = parts.next().unwrap_or_default().to_ascii_lowercase();
+    // Skip a script subtag (`zh-Hans-CN`) to reach the region.
+    let region = parts
+        .find(|p| p.len() == 2 && p.chars().all(|c| c.is_ascii_alphabetic()))
+        .map(|p| p.to_ascii_uppercase());
+
+    match region.as_deref() {
+        // Canada is split down the language line: fr-CA writes `1 234,56`.
+        Some("CA") => {
+            if language == "fr" {
+                NumberFormat::Comma
+            } else {
+                NumberFormat::Point
+            }
+        }
+        Some(r) if COMMA_DECIMAL_REGIONS.contains(&r) => NumberFormat::Comma,
+        Some(_) => NumberFormat::Point,
+        None if COMMA_DECIMAL_LANGUAGES.contains(&language.as_str()) => NumberFormat::Comma,
+        None => NumberFormat::Point,
+    }
+}
+
+/// The format the host system is configured for.
+pub fn detect() -> NumberFormat {
+    sys_locale::get_locale()
+        .map(|tag| from_locale_tag(&tag))
+        .unwrap_or_default()
+}
+
+/// Parse the user's `numberFormat` preference. `"auto"` (and anything
+/// unrecognized) yields `None`, meaning "fall back to [`detect`]".
+pub fn from_preference(value: &str) -> Option<NumberFormat> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "point" => Some(NumberFormat::Point),
+        "comma" => Some(NumberFormat::Comma),
+        _ => None,
+    }
+}
+
+/// Color functions are the one place where a comma between digits is a
+/// list separator, not a decimal mark: `rgb(255,0,0)`.
+fn is_color_function(q: &str) -> bool {
+    let lower = q.to_ascii_lowercase();
+    ["rgb(", "rgba(", "hsl(", "hsla("]
+        .iter()
+        .any(|f| lower.contains(f))
+}
+
+/// Grouped thousands written point-style, but only where the reading is
+/// unambiguous: a comma decimal behind the groups (`1.234,56`) or two or
+/// more groups (`1.234.567`). Every group must be exactly three digits,
+/// which is what keeps dotted dates (`25.12.2026`) out of the match.
+fn grouped_thousands() -> &'static regex::Regex {
+    static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    RE.get_or_init(|| {
+        regex::Regex::new(r"\b\d{1,3}(?:\.\d{3})+,\d+\b|\b\d{1,3}(?:\.\d{3}){2,}\b").unwrap()
+    })
+}
+
+/// Rewrite a query written in `fmt` into the canonical `1,234.56`
+/// notation the rest of the pipeline (and fend) expects.
+///
+/// A lone `1.234` is left alone on purpose: read as grouping it would
+/// turn `3.14 * 2` into `314 * 2`, and a decimal reading is both the
+/// safer and the far more common intent. Grouping is only honored once
+/// it is unambiguous — two or more groups (`1.234.567`) or a comma
+/// decimal behind it (`1.234,56`).
+pub fn canonicalize_input(query: &str, fmt: NumberFormat) -> String {
+    if fmt == NumberFormat::Point || is_color_function(query) {
+        return query.to_string();
+    }
+
+    let s = grouped_thousands().replace_all(query, |c: &regex::Captures| {
+        c[0].replace('.', "").replace(',', ".")
+    });
+
+    // Any remaining comma between two digits is a decimal mark.
+    let chars: Vec<char> = s.chars().collect();
+    chars
+        .iter()
+        .enumerate()
+        .map(|(i, &c)| {
+            if c == ',' && is_digit_at(&chars, i.wrapping_sub(1)) && is_digit_at(&chars, i + 1) {
+                '.'
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+/// Rewrite a canonical `1,234.56` answer into `fmt` for display.
+///
+/// Only separators sitting between two digits are swapped, so list
+/// commas (`rgb(255, 0, 0)`, `Fri, 25 Dec`) survive untouched.
+pub fn localize_output(text: &str, fmt: NumberFormat) -> String {
+    if fmt == NumberFormat::Point {
+        return text.to_string();
+    }
+    let chars: Vec<char> = text.chars().collect();
+    chars
+        .iter()
+        .enumerate()
+        .map(|(i, &c)| {
+            let between_digits =
+                is_digit_at(&chars, i.wrapping_sub(1)) && is_digit_at(&chars, i + 1);
+            match c {
+                ',' if between_digits => '.',
+                '.' if between_digits => ',',
+                other => other,
+            }
+        })
+        .collect()
+}
+
+fn is_digit_at(chars: &[char], i: usize) -> bool {
+    chars.get(i).is_some_and(|c| c.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_comma_locales_from_the_region() {
+        for tag in [
+            "de-DE", "de_DE", "fr-FR", "pt-BR", "es-ES", "tr-TR", "nl-NL",
+        ] {
+            assert_eq!(from_locale_tag(tag), NumberFormat::Comma, "{tag}");
+        }
+    }
+
+    #[test]
+    fn detects_point_locales_from_the_region() {
+        for tag in ["en-US", "en-GB", "en-AU", "ja-JP", "zh-Hans-CN", "es-MX"] {
+            assert_eq!(from_locale_tag(tag), NumberFormat::Point, "{tag}");
+        }
+    }
+
+    #[test]
+    fn region_beats_language() {
+        // macOS reports `en-DE` for an English UI in the German region,
+        // and it is the region that decides how numbers are written.
+        assert_eq!(from_locale_tag("en-DE"), NumberFormat::Comma);
+        // …and the other way round.
+        assert_eq!(from_locale_tag("de-US"), NumberFormat::Point);
+        // Swiss German writes `1'234.56`, not `1.234,56`.
+        assert_eq!(from_locale_tag("de-CH"), NumberFormat::Point);
+    }
+
+    #[test]
+    fn canada_is_decided_by_language() {
+        assert_eq!(from_locale_tag("fr-CA"), NumberFormat::Comma);
+        assert_eq!(from_locale_tag("en-CA"), NumberFormat::Point);
+    }
+
+    #[test]
+    fn falls_back_to_the_language_without_a_region() {
+        assert_eq!(from_locale_tag("de"), NumberFormat::Comma);
+        assert_eq!(from_locale_tag("en"), NumberFormat::Point);
+        assert_eq!(from_locale_tag(""), NumberFormat::Point);
+    }
+
+    #[test]
+    fn preference_overrides_are_parsed() {
+        assert_eq!(from_preference("comma"), Some(NumberFormat::Comma));
+        assert_eq!(from_preference(" Point "), Some(NumberFormat::Point));
+        assert_eq!(from_preference("auto"), None);
+        assert_eq!(from_preference("nonsense"), None);
+    }
+
+    fn canon(q: &str) -> String {
+        canonicalize_input(q, NumberFormat::Comma)
+    }
+
+    #[test]
+    fn reads_comma_as_the_decimal_mark() {
+        assert_eq!(canon("61,78*1,19"), "61.78*1.19");
+        assert_eq!(canon("0,5 + 0,25"), "0.5 + 0.25");
+        // Three digits behind the comma are still decimals here.
+        assert_eq!(canon("1,234"), "1.234");
+    }
+
+    #[test]
+    fn reads_unambiguous_point_grouping() {
+        assert_eq!(canon("1.234,56"), "1234.56");
+        assert_eq!(canon("1.234.567"), "1234567");
+        assert_eq!(canon("1.234.567,89 EUR in USD"), "1234567.89 EUR in USD");
+    }
+
+    #[test]
+    fn leaves_a_lone_dotted_number_as_a_decimal() {
+        // Reading `3.14` as grouping would silently turn it into 314.
+        assert_eq!(canon("3.14 * 2"), "3.14 * 2");
+        assert_eq!(canon("1.234 * 2"), "1.234 * 2");
+    }
+
+    #[test]
+    fn leaves_dotted_dates_alone() {
+        // Groups are not three digits wide, so this is not grouping.
+        assert_eq!(canon("25.12.2026"), "25.12.2026");
+    }
+
+    #[test]
+    fn leaves_color_list_commas_alone() {
+        assert_eq!(canon("rgb(255,0,0)"), "rgb(255,0,0)");
+        assert_eq!(canon("hsl(210,50%,50%) to hex"), "hsl(210,50%,50%) to hex");
+    }
+
+    #[test]
+    fn leaves_list_commas_with_spaces_alone() {
+        assert_eq!(canon("days until dec 25, 2026"), "days until dec 25, 2026");
+    }
+
+    #[test]
+    fn point_format_never_rewrites_the_query() {
+        assert_eq!(
+            canonicalize_input("1,234.56 + 3.14", NumberFormat::Point),
+            "1,234.56 + 3.14"
+        );
+    }
+
+    fn local(s: &str) -> String {
+        localize_output(s, NumberFormat::Comma)
+    }
+
+    #[test]
+    fn swaps_separators_for_display() {
+        assert_eq!(local("73.5182"), "73,5182");
+        assert_eq!(local("1,234,567"), "1.234.567");
+        assert_eq!(local("1,234.5678"), "1.234,5678");
+        assert_eq!(local("≈ 3.1415926536"), "≈ 3,1415926536");
+        assert_eq!(local("6.32 GBP/hour"), "6,32 GBP/hour");
+    }
+
+    #[test]
+    fn leaves_non_numeric_separators_alone() {
+        assert_eq!(local("rgb(255, 0, 0)"), "rgb(255, 0, 0)");
+        assert_eq!(local("Fri, 25 Dec 2026"), "Fri, 25 Dec 2026");
+        assert_eq!(local("0x11111"), "0x11111");
+        assert_eq!(local("17:30"), "17:30");
+    }
+
+    #[test]
+    fn point_format_never_rewrites_the_answer() {
+        assert_eq!(localize_output("1,234.56", NumberFormat::Point), "1,234.56");
+    }
+
+    #[test]
+    fn input_and_output_round_trip() {
+        let typed = "61,78*1,19";
+        let canonical = canon(typed);
+        assert_eq!(canonical, "61.78*1.19");
+        assert_eq!(local(&canonical), typed);
+    }
+}

--- a/asyar-launcher/src-tauri/src/calculator/mod.rs
+++ b/asyar-launcher/src-tauri/src/calculator/mod.rs
@@ -13,6 +13,7 @@ pub mod dates;
 pub mod engine;
 pub mod extras;
 pub mod format;
+pub mod locale;
 pub mod normalize;
 pub mod percent;
 pub mod timezone;

--- a/asyar-launcher/src-tauri/src/calculator/mod.rs
+++ b/asyar-launcher/src-tauri/src/calculator/mod.rs
@@ -70,6 +70,8 @@ pub struct EvalContext {
     pub rates_age: Option<String>,
     /// Target for bare-amount queries like `50 usd` (user preference).
     pub preferred_currency: String,
+    /// How the user writes numbers: `1,234.56` or `1.234,56`.
+    pub number_format: locale::NumberFormat,
     pub today: NaiveDate,
     pub now_time: NaiveTime,
     pub now_utc: DateTime<Utc>,
@@ -82,6 +84,7 @@ impl EvalContext {
         rates: Option<Arc<HashMap<String, f64>>>,
         rates_age: Option<String>,
         preferred_currency: String,
+        number_format: locale::NumberFormat,
     ) -> Self {
         let local_now = chrono::Local::now();
         let local_tz: Tz = iana_time_zone::get_timezone()
@@ -92,6 +95,7 @@ impl EvalContext {
             rates,
             rates_age,
             preferred_currency,
+            number_format,
             today: local_now.date_naive(),
             now_time: local_now.time(),
             now_utc: Utc::now(),
@@ -167,7 +171,22 @@ pub fn should_attempt(query: &str) -> bool {
 }
 
 /// Full evaluation pipeline. Returns zero or more display-ready results.
+///
+/// The query is rewritten into the canonical `1,234.56` notation on the
+/// way in and the answers are rewritten back into the user's notation on
+/// the way out, so every handler in between — and fend itself — only
+/// ever sees numbers written the one way it understands.
 pub fn evaluate_query(raw: &str, ctx: &EvalContext) -> Vec<CalcResult> {
+    let canonical = locale::canonicalize_input(raw, ctx.number_format);
+    let mut results = evaluate_canonical(&canonical, ctx);
+    for r in &mut results {
+        r.value = locale::localize_output(&r.value, ctx.number_format);
+        r.detail = locale::localize_output(&r.detail, ctx.number_format);
+    }
+    results
+}
+
+fn evaluate_canonical(raw: &str, ctx: &EvalContext) -> Vec<CalcResult> {
     if !should_attempt(raw) {
         return Vec::new();
     }
@@ -298,6 +317,8 @@ pub struct CalculatorState {
     pub ttl_hours: RwLock<f64>,
     /// Target currency for bare-amount queries (user preference).
     pub preferred_currency: RwLock<String>,
+    /// Number notation override. `None` means "follow the host locale".
+    pub number_format: RwLock<Option<locale::NumberFormat>>,
     /// True while a background fetch is in flight.
     pub fetching: std::sync::atomic::AtomicBool,
     /// True once the disk cache has been loaded.
@@ -310,6 +331,7 @@ impl Default for CalculatorState {
             rates: RwLock::new(None),
             ttl_hours: RwLock::new(currency::DEFAULT_TTL_HOURS),
             preferred_currency: RwLock::new("USD".to_string()),
+            number_format: RwLock::new(None),
             fetching: std::sync::atomic::AtomicBool::new(false),
             disk_loaded: std::sync::atomic::AtomicBool::new(false),
         }
@@ -317,6 +339,15 @@ impl Default for CalculatorState {
 }
 
 impl CalculatorState {
+    /// The notation to render in: the user's override when set,
+    /// otherwise whatever the host locale is configured for.
+    pub fn number_format(&self) -> locale::NumberFormat {
+        self.number_format
+            .read()
+            .unwrap()
+            .unwrap_or_else(locale::detect)
+    }
+
     /// Snapshot of the current rates map and its human-readable age.
     pub fn rates_snapshot(&self) -> (Option<Arc<HashMap<String, f64>>>, Option<String>) {
         let guard = self.rates.read().unwrap();
@@ -334,6 +365,13 @@ impl CalculatorState {
 mod tests {
     use super::*;
 
+    fn comma_ctx() -> EvalContext {
+        EvalContext {
+            number_format: locale::NumberFormat::Comma,
+            ..test_ctx()
+        }
+    }
+
     fn test_ctx() -> EvalContext {
         let mut rates = HashMap::new();
         rates.insert("USD".to_string(), 1.0);
@@ -345,6 +383,7 @@ mod tests {
             rates: Some(Arc::new(rates)),
             rates_age: Some("2 h".to_string()),
             preferred_currency: "IQD".to_string(),
+            number_format: locale::NumberFormat::Point,
             today: NaiveDate::from_ymd_opt(2026, 7, 11).unwrap(),
             now_time: NaiveTime::from_hms_opt(15, 0, 0).unwrap(),
             now_utc: DateTime::parse_from_rfc3339("2026-07-11T12:00:00Z")
@@ -382,6 +421,56 @@ mod tests {
         assert!(!should_attempt("pixel"));
         assert!(!should_attempt("pin"));
         assert!(!should_attempt("pipe"));
+    }
+
+    #[test]
+    fn comma_locale_reads_commas_as_decimals() {
+        // The bug: fend reads `61,78` as grouped `6178`, so the answer
+        // came back as 6178 * 119 = 735182.
+        let res = evaluate_query("61,78*1,19", &comma_ctx());
+        assert_eq!(res[0].value, "73,5182");
+        assert_eq!(res[0].detail, "61,78*1,19");
+        assert_eq!(res[0].kind, CalcKind::Math);
+    }
+
+    #[test]
+    fn comma_locale_groups_the_answer_with_points() {
+        let res = evaluate_query("1234 * 1000", &comma_ctx());
+        assert_eq!(res[0].value, "1.234.000");
+    }
+
+    #[test]
+    fn comma_locale_reads_point_grouped_input() {
+        let res = evaluate_query("1.234,5 + 0,5", &comma_ctx());
+        assert_eq!(res[0].value, "1.235");
+    }
+
+    #[test]
+    fn comma_locale_handles_percent_phrases() {
+        let res = evaluate_query("19% of 61,78", &comma_ctx());
+        assert_eq!(res[0].kind, CalcKind::Percent);
+        assert_eq!(res[0].value, "11,7382");
+    }
+
+    #[test]
+    fn comma_locale_leaves_color_lists_alone() {
+        let res = evaluate_query("rgb(255,0,0) to hex", &comma_ctx());
+        assert_eq!(res[0].kind, CalcKind::Color);
+        assert_eq!(res[0].value, "#FF0000");
+    }
+
+    #[test]
+    fn comma_locale_leaves_dates_alone() {
+        let point = evaluate_query("days until dec 25, 2026", &test_ctx());
+        let comma = evaluate_query("days until dec 25, 2026", &comma_ctx());
+        assert!(!point.is_empty());
+        assert_eq!(point[0].value, comma[0].value);
+    }
+
+    #[test]
+    fn point_locale_is_unchanged() {
+        let res = evaluate_query("1234 * 1000", &test_ctx());
+        assert_eq!(res[0].value, "1,234,000");
     }
 
     #[test]

--- a/asyar-launcher/src-tauri/src/calculator/mod.rs
+++ b/asyar-launcher/src-tauri/src/calculator/mod.rs
@@ -467,6 +467,50 @@ mod tests {
         assert_eq!(point[0].value, comma[0].value);
     }
 
+    /// Every handler must answer a comma-decimal query with exactly the
+    /// point-decimal answer, re-spelled. Anything else means a handler
+    /// is reading or writing separators behind the pipeline's back.
+    #[test]
+    fn comma_locale_answers_match_the_point_locale_answers() {
+        for (point_query, comma_query) in [
+            ("61.78*1.19", "61,78*1,19"),
+            ("1234567 + 1", "1.234.567 + 1"),
+            ("1.5 km in miles", "1,5 km in miles"),
+            ("100.50 usd in eur", "100,50 usd in eur"),
+            ("20% of 61.78", "20% of 61,78"),
+            ("12.5% off 80", "12,5% off 80"),
+            ("increase 61.78 by 19%", "increase 61,78 by 19%"),
+            (
+                "% change from 61.78 to 73.52",
+                "% change from 61,78 to 73,52",
+            ),
+            ("1.5 cups to ml", "1,5 cups to ml"),
+            ("1.5 hours to timespan", "1,5 hours to timespan"),
+            // Queries with no separators at all must survive untouched.
+            ("sqrt(2)", "sqrt(2)"),
+            ("0xFF", "0xFF"),
+            ("#ff8800", "#ff8800"),
+            ("rgb(255,0,0) to hex", "rgb(255,0,0) to hex"),
+            ("ratio of 16 to 9", "ratio of 16 to 9"),
+            ("days until dec 25", "days until dec 25"),
+            ("today + 45 days", "today + 45 days"),
+            ("5pm ldn in sf", "5pm ldn in sf"),
+            ("5'10\" to cm", "5'10\" to cm"),
+            ("10km in miles", "10km in miles"),
+            ("50 usd", "50 usd"),
+        ] {
+            let point = evaluate_query(point_query, &test_ctx());
+            let comma = evaluate_query(comma_query, &comma_ctx());
+            assert!(!point.is_empty(), "no answer for {point_query:?}");
+            assert!(!comma.is_empty(), "no answer for {comma_query:?}");
+            assert_eq!(
+                comma[0].value,
+                locale::localize_output(&point[0].value, locale::NumberFormat::Comma),
+                "{comma_query:?} must answer what {point_query:?} answers"
+            );
+        }
+    }
+
     #[test]
     fn point_locale_is_unchanged() {
         let res = evaluate_query("1234 * 1000", &test_ctx());

--- a/asyar-launcher/src-tauri/src/commands/calculator.rs
+++ b/asyar-launcher/src-tauri/src/commands/calculator.rs
@@ -19,16 +19,17 @@ pub async fn calculator_evaluate(
     let preferred = state.preferred_currency.read().unwrap().clone();
     Ok(calculator::evaluate_query(
         &query,
-        &EvalContext::current(rates, rates_age, preferred),
+        &EvalContext::current(rates, rates_age, preferred, state.number_format()),
     ))
 }
 
-/// Applies the user's preferences: currency refresh interval (hours) and
-/// preferred currency for bare-amount queries.
+/// Applies the user's preferences: currency refresh interval (hours),
+/// preferred currency for bare-amount queries, and number notation.
 #[tauri::command]
 pub async fn calculator_configure(
     ttl_hours: Option<f64>,
     preferred_currency: Option<String>,
+    number_format: Option<String>,
     state: State<'_, CalculatorState>,
 ) -> Result<(), AppError> {
     if let Some(ttl) = ttl_hours {
@@ -39,6 +40,10 @@ pub async fn calculator_configure(
         if code.len() == 3 && code.chars().all(|c| c.is_ascii_alphabetic()) {
             *state.preferred_currency.write().unwrap() = code;
         }
+    }
+    if let Some(format) = number_format {
+        // Anything unrecognized — "auto" included — means follow the host locale.
+        *state.number_format.write().unwrap() = calculator::locale::from_preference(&format);
     }
     Ok(())
 }
@@ -55,6 +60,7 @@ pub async fn calculator_refresh_rates(
 
 #[cfg(test)]
 mod tests {
+    use crate::calculator::locale::NumberFormat;
     use crate::calculator::CalculatorState;
 
     #[test]
@@ -64,5 +70,23 @@ mod tests {
         assert_eq!(*state.ttl_hours.read().unwrap(), 24.0);
         *state.ttl_hours.write().unwrap() = 0.5_f64.clamp(1.0, 24.0);
         assert_eq!(*state.ttl_hours.read().unwrap(), 1.0);
+    }
+
+    #[test]
+    fn number_format_defaults_to_the_host_locale() {
+        let state = CalculatorState::default();
+        assert!(state.number_format.read().unwrap().is_none());
+        assert_eq!(
+            state.number_format(),
+            crate::calculator::locale::detect(),
+            "an unset preference must follow the host locale"
+        );
+    }
+
+    #[test]
+    fn number_format_override_wins_over_the_host_locale() {
+        let state = CalculatorState::default();
+        *state.number_format.write().unwrap() = Some(NumberFormat::Comma);
+        assert_eq!(state.number_format(), NumberFormat::Comma);
     }
 }

--- a/asyar-launcher/src/built-in-features/calculator/index.test.ts
+++ b/asyar-launcher/src/built-in-features/calculator/index.test.ts
@@ -63,10 +63,23 @@ describe('calculator extension (thin presenter)', () => {
   });
 
   it('initialize pushes preferences to Rust', async () => {
-    await calculator.initialize(makeContext({ refreshInterval: 12, preferredCurrency: 'iqd' }));
+    await calculator.initialize(
+      makeContext({ refreshInterval: 12, preferredCurrency: 'iqd', numberFormat: 'comma' }),
+    );
     expect(invokeSafe).toHaveBeenCalledWith(
       'calculator_configure',
-      { ttlHours: 12, preferredCurrency: 'iqd' },
+      { ttlHours: 12, preferredCurrency: 'iqd', numberFormat: 'comma' },
+      { silent: true },
+    );
+  });
+
+  it('initialize forwards a return to the automatic number format', async () => {
+    // Rust reads "auto" as "follow the host locale", so switching back
+    // has to reach it — skipping it would strand the old override.
+    await calculator.initialize(makeContext({ numberFormat: 'auto' }));
+    expect(invokeSafe).toHaveBeenCalledWith(
+      'calculator_configure',
+      { numberFormat: 'auto' },
       { silent: true },
     );
   });

--- a/asyar-launcher/src/built-in-features/calculator/index.ts
+++ b/asyar-launcher/src/built-in-features/calculator/index.ts
@@ -38,12 +38,19 @@ class CalculatorExtension implements Extension {
     // its TTL policy, and the implicit-conversion target currency.
     const interval = context.preferences.values.refreshInterval;
     const preferred = context.preferences.values.preferredCurrency;
+    const numberFormat = context.preferences.values.numberFormat;
     const args: Record<string, unknown> = {};
     if (typeof interval === 'number' && Number.isFinite(interval)) {
       args.ttlHours = interval;
     }
     if (typeof preferred === 'string' && preferred.trim()) {
       args.preferredCurrency = preferred.trim();
+    }
+    // Always forwarded, including "auto": Rust reads anything it does not
+    // recognize as "follow the host locale", so switching back to
+    // Automatic has to reach it too.
+    if (typeof numberFormat === 'string' && numberFormat.trim()) {
+      args.numberFormat = numberFormat.trim();
     }
     if (Object.keys(args).length > 0) {
       await invokeSafe('calculator_configure', args, { silent: true });

--- a/asyar-launcher/src/built-in-features/calculator/manifest.json
+++ b/asyar-launcher/src/built-in-features/calculator/manifest.json
@@ -16,6 +16,18 @@
       "default": 6
     },
     {
+      "name": "numberFormat",
+      "type": "dropdown",
+      "title": "Number format",
+      "description": "How you write decimals. \"Automatic\" follows your system's region setting.",
+      "default": "auto",
+      "data": [
+        { "value": "auto", "title": "Automatic (system region)" },
+        { "value": "point", "title": "1,234.56 — point decimal" },
+        { "value": "comma", "title": "1.234,56 — comma decimal" }
+      ]
+    },
+    {
       "name": "preferredCurrency",
       "type": "textfield",
       "title": "Preferred currency",

--- a/docs/guide/features/calculator.md
+++ b/docs/guide/features/calculator.md
@@ -53,7 +53,8 @@ The calculator result row has no action panel (⌘K) entries — its single acti
 - **Rate units convert too** — `8 dollars/hour in gbp` converts per-unit rates, not just flat amounts.
 - **Date anchor** — use the word `today` in date math, for example `today + 45 days`.
 - **Base literals** — paste a hex color like `0xFF8C00` and see its decimal, binary, and octal values side by side.
-- **Currency refresh interval & preferred currency** — go to Settings → Extensions → Calculator to change how often rates refresh (1–24 hours, default 6) and which currency bare amounts convert to.
+- **Your decimal mark** — type `61,78 * 1,19` and it means what you wrote. Asyar follows your system's region setting, so a comma-decimal locale reads commas as decimals and gets its answers grouped the same way (`73,5182`, `1.234.567`).
+- **Currency refresh interval, preferred currency & number format** — go to Settings → Extensions → Calculator to change how often rates refresh (1–24 hours, default 6), which currency bare amounts convert to, and — if the detected region is not how you actually write numbers — the number format to read and render (Automatic, `1,234.56`, or `1.234,56`).
 
 ## Related
 


### PR DESCRIPTION
## The bug

Typing `61,78*1,19` into the search bar returns **735,182**.

fend — like every expression parser — only understands the `1,234.56`
convention, so it read both commas as thousands grouping and evaluated
`6178 * 119`. The answer was then grouped back with commas for display,
which is what makes the wrong number look like a plausible right one:
`735,182` reads as "735.182" to exactly the user who typed the query
that produced it.

Nothing in the calculator pipeline knew what the host locale writes, so
this was silent for every comma-decimal locale — most of Europe and
Latin America.

## The fix

The pipeline keeps a single internal notation and translates at its two
ends:

- **In** — `canonicalize_input` rewrites the query before evaluation:
  `61,78*1,19` → `61.78*1.19`, `1.234,56` → `1234.56`.
- **Out** — `localize_output` rewrites the answers after evaluation:
  `73.5182` → `73,5182`, `1,234,567` → `1.234.567`.

Every handler in between — colors, bases, percent, ratios, cooking,
dates, timezones — and fend itself keeps seeing numbers written the one
way it already understands. No handler had to learn about separators.

Two conversion rules are deliberately conservative:

- Only separators sitting **between two digits** are touched, so list
  commas survive: `rgb(255, 0, 0)`, `days until dec 25, 2026`.
- Point grouping is only honored where the reading is unambiguous —
  two or more groups (`1.234.567`) or a comma decimal behind it
  (`1.234,56`). A lone `1.234` stays a decimal, because reading it as
  grouping would turn `3.14 * 2` into `314 * 2`. Dotted dates
  (`25.12.2026`) fall out of the same rule, their groups not being
  three digits wide.

## Detection

The notation comes from the host locale via the `sys-locale` crate
already in the tree, using a CLDR-derived region table. **Region beats
language**: macOS reports `en-DE` for an English UI set to the German
region, and it is the region that decides how numbers are written. The
language is only consulted for a tag that carries no region (`de`), and
Canada is split down the language line (`fr-CA` writes `1 234,56`).

Point-decimal is the default for anything unrecognized, which is the
safe direction — a point-decimal query needs no rewriting at all, so an
undetected locale behaves exactly as it does today.

Detection is right for almost everyone and wrong for the people whose
system region and typing habits disagree. A **Number format** dropdown
(Automatic / `1,234.56` / `1.234,56`) in Settings → Extensions →
Calculator lets them say so directly.

## Tests

`cargo test calculator` — 163 passing (was 129).

Beyond the unit tests for detection, canonicalization, and
localization, `comma_locale_answers_match_the_point_locale_answers`
walks one query per handler through both notations and asserts the
comma answer is the point answer re-spelled. The pipeline only holds
together as long as every handler stays out of the separator business,
so a handler that starts reading or writing separators on its own gets
caught there rather than in a bug report.

Also run: full `pnpm --filter asyar test:run` (3274 passing),
`cargo clippy --all-targets -D warnings` (clean), `pnpm check:design`
(clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
