### PR TITLE
feat(window-management): fix shortcut execution, add layout indexing, renaming and save command

### DIFF
--- a/asyar-launcher/src/built-in-features/window-management/ManageView.svelte
+++ b/asyar-launcher/src/built-in-features/window-management/ManageView.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
-  import { ListItem, EmptyState, ActionFooter } from '../../components';
+  import { onDestroy, onMount, tick } from 'svelte';
+  import { ListItem, EmptyState, ActionFooter, Input } from '../../components';
   import { windowManagementState } from './state.svelte';
   import { windowManagementService } from '../../services/windowManagement/windowManagementService';
   import { feedbackService } from '../../services/feedback/feedbackService.svelte';
   import { actionService } from '../../services/action/actionService.svelte';
+  import {
+    applyCustomLayout,
+    deleteLayout,
+    renameLayout,
+    syncLayoutToIndex,
+  } from './layoutLifecycle';
   import type { IStorageService } from 'asyar-sdk/contracts';
   import { ActionContext } from 'asyar-sdk/contracts';
 
@@ -14,39 +20,214 @@
   let { store }: Props = $props();
 
   let selectedId = $state<string | null>(null);
+  let editingId = $state<string | null>(null);
+  let editingName = $state('');
+  let editInputEl = $state<HTMLInputElement | null>(null);
+
   let layouts = $derived(windowManagementState.customLayouts);
 
+  // Auto-select first item if current selection is invalid
   $effect(() => {
+    if (layouts.length > 0 && (!selectedId || !layouts.some((l) => l.id === selectedId))) {
+      selectedId = layouts[0].id;
+    } else if (layouts.length === 0) {
+      selectedId = null;
+    }
+  });
+
+  async function handleApply(id: string) {
+    const layout = layouts.find((l) => l.id === id);
+    if (!layout) return;
+    await applyCustomLayout(layout, store);
+  }
+
+  async function handleSaveCurrent() {
+    if (!store) return;
+    try {
+      const bounds = await windowManagementService.getWindowBounds();
+      const name = `${Math.round(bounds.width)}x${Math.round(bounds.height)}`;
+      await windowManagementState.addCustomLayout(name, bounds, store);
+      const created =
+        windowManagementState.customLayouts.find(
+          (l) => l.name === name && l.bounds.x === bounds.x && l.bounds.y === bounds.y,
+        ) ?? windowManagementState.customLayouts[windowManagementState.customLayouts.length - 1];
+      if (created) {
+        await syncLayoutToIndex(created, store);
+        selectedId = created.id;
+      }
+      await feedbackService.showHUD(`Saved "${name}"`);
+    } catch (err: any) {
+      await feedbackService.report({
+        source: 'frontend',
+        kind: 'manual',
+        severity: 'error',
+        retryable: false,
+        context: { message: `Could not save layout${err.message ? ' — ' + err.message : ''}` },
+      });
+    }
+  }
+
+  function startRename(id: string) {
+    const layout = layouts.find((l) => l.id === id);
+    if (!layout) return;
+    editingId = id;
+    editingName = layout.name;
+    void tick().then(() => {
+      if (editInputEl) {
+        editInputEl.focus();
+        editInputEl.select();
+      }
+    });
+  }
+
+  async function commitRename() {
+    if (!editingId || !store) {
+      editingId = null;
+      return;
+    }
+    const id = editingId;
+    const newName = editingName.trim();
+    editingId = null;
+    if (newName) {
+      await renameLayout(id, newName, store);
+      await feedbackService.showHUD(`Renamed to "${newName}"`);
+    }
+  }
+
+  function cancelRename() {
+    editingId = null;
+    editingName = '';
+  }
+
+  async function handleDelete(id: string) {
+    if (!store) return;
+    const layout = layouts.find((l) => l.id === id);
+    if (!layout) return;
+    const name = layout.name;
+    await deleteLayout(id, store);
+    await feedbackService.showHUD(`Deleted "${name}"`);
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (editingId) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        void commitRename();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        cancelRename();
+      }
+      return;
+    }
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (!selectedId && layouts.length > 0) {
+        selectedId = layouts[0].id;
+        return;
+      }
+      const idx = layouts.findIndex((l) => l.id === selectedId);
+      if (idx < layouts.length - 1) {
+        selectedId = layouts[idx + 1].id;
+      }
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (!selectedId && layouts.length > 0) {
+        selectedId = layouts[0].id;
+        return;
+      }
+      const idx = layouts.findIndex((l) => l.id === selectedId);
+      if (idx > 0) {
+        selectedId = layouts[idx - 1].id;
+      }
+    } else if (e.key === 'Enter' && selectedId) {
+      e.preventDefault();
+      void handleApply(selectedId);
+    } else if ((e.metaKey || e.ctrlKey) && e.key === 'r' && selectedId) {
+      e.preventDefault();
+      startRename(selectedId);
+    } else if ((e.metaKey || e.ctrlKey) && e.key === 'n') {
+      e.preventDefault();
+      void handleSaveCurrent();
+    }
+  }
+
+  $effect(() => {
+    // Register base save action
+    actionService.registerAction({
+      id: 'window-management:save-current-window',
+      title: 'Save Current Window as Layout',
+      description: 'Capture the frontmost window position and size as a custom layout',
+      icon: 'icon:plus',
+      shortcut: '⌘N',
+      extensionId: 'window-management',
+      category: 'window-management',
+      context: ActionContext.EXTENSION_VIEW,
+      execute: () => handleSaveCurrent(),
+    });
+
     if (!selectedId) {
+      actionService.unregisterAction('window-management:apply-layout');
+      actionService.unregisterAction('window-management:rename-layout');
       actionService.unregisterAction('window-management:delete-layout');
       return;
     }
+
     const id = selectedId;
     const layout = layouts.find((l) => l.id === id);
     if (!layout) return;
 
     actionService.registerAction({
-      id: 'window-management:delete-layout',
-      title: `Delete "${layout.name}"`,
-      icon: 'icon:trash',
+      id: 'window-management:apply-layout',
+      title: `Apply "${layout.name}"`,
+      icon: 'icon:play',
+      shortcut: '↵',
       extensionId: 'window-management',
       category: 'window-management',
       context: ActionContext.EXTENSION_VIEW,
-      execute: async () => {
-        if (!store) return;
-        const name = layout.name;
-        await windowManagementState.deleteCustomLayout(id, store);
-        selectedId = null;
-        await feedbackService.showHUD(`Deleted "${name}"`);
-      },
+      execute: () => handleApply(id),
+    });
+
+    actionService.registerAction({
+      id: 'window-management:rename-layout',
+      title: `Rename "${layout.name}"`,
+      icon: 'icon:edit',
+      shortcut: '⌘R',
+      extensionId: 'window-management',
+      category: 'window-management',
+      context: ActionContext.EXTENSION_VIEW,
+      execute: () => startRename(id),
+    });
+
+    actionService.registerAction({
+      id: 'window-management:delete-layout',
+      title: `Delete "${layout.name}"`,
+      icon: 'icon:trash',
+      shortcut: '⌘⌫',
+      extensionId: 'window-management',
+      category: 'window-management',
+      context: ActionContext.EXTENSION_VIEW,
+      execute: () => handleDelete(id),
     });
 
     return () => {
+      actionService.unregisterAction('window-management:apply-layout');
+      actionService.unregisterAction('window-management:rename-layout');
       actionService.unregisterAction('window-management:delete-layout');
     };
   });
 
+  onMount(() => {
+    window.addEventListener('keydown', handleKeydown);
+    return () => {
+      window.removeEventListener('keydown', handleKeydown);
+    };
+  });
+
   onDestroy(() => {
+    actionService.unregisterAction('window-management:save-current-window');
+    actionService.unregisterAction('window-management:apply-layout');
+    actionService.unregisterAction('window-management:rename-layout');
     actionService.unregisterAction('window-management:delete-layout');
   });
 </script>
@@ -56,21 +237,38 @@
     {#if layouts.length === 0}
       <EmptyState
         message="No custom layouts yet"
-        description="Use ⌘K → Save Current Window as Layout to capture a window position."
+        description="Position any window on screen and press ⌘N (or ⌘K → Save Current Window as Layout) to capture it."
       />
     {:else}
       <div class="section-header">Custom Layouts</div>
       {#each layouts as layout (layout.id)}
         <ListItem
           title={layout.name}
-          subtitle={`${Math.round(layout.bounds.width)}x${Math.round(layout.bounds.height)} at (${Math.round(layout.bounds.x)}, ${Math.round(layout.bounds.y)})`}
+          subtitle={`${Math.round(layout.bounds.width)}×${Math.round(layout.bounds.height)} at (${Math.round(layout.bounds.x)}, ${Math.round(layout.bounds.y)})`}
           selected={selectedId === layout.id}
           onclick={() => {
             selectedId = layout.id;
           }}
+          ondblclick={() => {
+            startRename(layout.id);
+          }}
         >
           {#snippet leading()}
             <div class="layout-icon">⊞</div>
+          {/snippet}
+          {#snippet content()}
+            {#if editingId === layout.id}
+              <div class="inline-rename-wrapper" onclick={(e) => e.stopPropagation()}>
+                <input
+                  bind:this={editInputEl}
+                  type="text"
+                  class="rename-input"
+                  bind:value={editingName}
+                  onblur={() => void commitRename()}
+                  onkeydown={handleKeydown}
+                />
+              </div>
+            {/if}
           {/snippet}
         </ListItem>
       {/each}
@@ -87,6 +285,12 @@
 </div>
 
 <style>
+  .view-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
   .list {
     flex: 1;
     overflow-y: auto;
@@ -99,18 +303,36 @@
     font-weight: 600;
     color: var(--text-tertiary);
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: var(--tracking-wide);
   }
 
   .layout-icon {
-    width: 32px;
-    height: 32px;
+    width: var(--size-xl);
+    height: var(--size-xl);
     border-radius: var(--radius-md);
     background: var(--bg-tertiary);
+    color: var(--text-secondary);
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: var(--font-size-lg);
+  }
+
+  .inline-rename-wrapper {
+    margin-top: var(--space-1);
+  }
+
+  .rename-input {
+    width: 100%;
+    max-width: 280px;
+    padding: var(--space-1) var(--space-2);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-sm);
+    color: var(--text-primary);
+    background: var(--bg-secondary);
+    border: 1px solid var(--accent-primary);
+    border-radius: var(--radius-sm);
+    outline: none;
   }
 
   .count-label {

--- a/asyar-launcher/src/built-in-features/window-management/ManageView.svelte
+++ b/asyar-launcher/src/built-in-features/window-management/ManageView.svelte
@@ -199,11 +199,7 @@
   onEscape={cancelRename}
 >
   <div class="modal-body">
-    <Input
-      label="Layout Name"
-      placeholder="e.g. Work Setup, Right Focus..."
-      bind:value={editingName}
-    />
+    <Input placeholder="e.g. Work Setup, Right Focus..." bind:value={editingName} />
   </div>
   {#snippet actions()}
     <div class="modal-actions">

--- a/asyar-launcher/src/built-in-features/window-management/ManageView.svelte
+++ b/asyar-launcher/src/built-in-features/window-management/ManageView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { onDestroy, onMount, tick } from 'svelte';
-  import { ListItem, EmptyState, ActionFooter, Input } from '../../components';
+  import { onDestroy } from 'svelte';
+  import { ListItem, EmptyState, Modal, Input, Button } from '../../components';
   import { windowManagementState } from './state.svelte';
   import { windowManagementService } from '../../services/windowManagement/windowManagementService';
   import { feedbackService } from '../../services/feedback/feedbackService.svelte';
@@ -19,21 +19,13 @@
   }
   let { store }: Props = $props();
 
-  let selectedId = $state<string | null>(null);
+  let isRenameModalOpen = $state(false);
   let editingId = $state<string | null>(null);
   let editingName = $state('');
-  let editInputEl = $state<HTMLInputElement | null>(null);
 
   let layouts = $derived(windowManagementState.customLayouts);
-
-  // Auto-select first item if current selection is invalid
-  $effect(() => {
-    if (layouts.length > 0 && (!selectedId || !layouts.some((l) => l.id === selectedId))) {
-      selectedId = layouts[0].id;
-    } else if (layouts.length === 0) {
-      selectedId = null;
-    }
-  });
+  let selectedIndex = $derived(windowManagementState.selectedIndex);
+  let selectedLayout = $derived(windowManagementState.selectedLayout);
 
   async function handleApply(id: string) {
     const layout = layouts.find((l) => l.id === id);
@@ -42,19 +34,11 @@
   }
 
   async function handleSaveCurrent() {
-    if (!store) return;
     try {
       const bounds = await windowManagementService.getWindowBounds();
       const name = `${Math.round(bounds.width)}x${Math.round(bounds.height)}`;
-      await windowManagementState.addCustomLayout(name, bounds, store);
-      const created =
-        windowManagementState.customLayouts.find(
-          (l) => l.name === name && l.bounds.x === bounds.x && l.bounds.y === bounds.y,
-        ) ?? windowManagementState.customLayouts[windowManagementState.customLayouts.length - 1];
-      if (created) {
-        await syncLayoutToIndex(created, store);
-        selectedId = created.id;
-      }
+      const created = await windowManagementState.addCustomLayout(name, bounds, store);
+      await syncLayoutToIndex(created, store);
       await feedbackService.showHUD(`Saved "${name}"`);
     } catch (err: any) {
       await feedbackService.report({
@@ -72,21 +56,17 @@
     if (!layout) return;
     editingId = id;
     editingName = layout.name;
-    void tick().then(() => {
-      if (editInputEl) {
-        editInputEl.focus();
-        editInputEl.select();
-      }
-    });
+    isRenameModalOpen = true;
   }
 
   async function commitRename() {
-    if (!editingId || !store) {
-      editingId = null;
+    if (!editingId) {
+      isRenameModalOpen = false;
       return;
     }
     const id = editingId;
     const newName = editingName.trim();
+    isRenameModalOpen = false;
     editingId = null;
     if (newName) {
       await renameLayout(id, newName, store);
@@ -95,61 +75,17 @@
   }
 
   function cancelRename() {
+    isRenameModalOpen = false;
     editingId = null;
     editingName = '';
   }
 
   async function handleDelete(id: string) {
-    if (!store) return;
     const layout = layouts.find((l) => l.id === id);
     if (!layout) return;
     const name = layout.name;
     await deleteLayout(id, store);
     await feedbackService.showHUD(`Deleted "${name}"`);
-  }
-
-  function handleKeydown(e: KeyboardEvent) {
-    if (editingId) {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        void commitRename();
-      } else if (e.key === 'Escape') {
-        e.preventDefault();
-        cancelRename();
-      }
-      return;
-    }
-
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      if (!selectedId && layouts.length > 0) {
-        selectedId = layouts[0].id;
-        return;
-      }
-      const idx = layouts.findIndex((l) => l.id === selectedId);
-      if (idx < layouts.length - 1) {
-        selectedId = layouts[idx + 1].id;
-      }
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      if (!selectedId && layouts.length > 0) {
-        selectedId = layouts[0].id;
-        return;
-      }
-      const idx = layouts.findIndex((l) => l.id === selectedId);
-      if (idx > 0) {
-        selectedId = layouts[idx - 1].id;
-      }
-    } else if (e.key === 'Enter' && selectedId) {
-      e.preventDefault();
-      void handleApply(selectedId);
-    } else if ((e.metaKey || e.ctrlKey) && e.key === 'r' && selectedId) {
-      e.preventDefault();
-      startRename(selectedId);
-    } else if ((e.metaKey || e.ctrlKey) && e.key === 'n') {
-      e.preventDefault();
-      void handleSaveCurrent();
-    }
   }
 
   $effect(() => {
@@ -166,20 +102,20 @@
       execute: () => handleSaveCurrent(),
     });
 
-    if (!selectedId) {
+    const current = selectedLayout;
+    if (!current) {
       actionService.unregisterAction('window-management:apply-layout');
       actionService.unregisterAction('window-management:rename-layout');
       actionService.unregisterAction('window-management:delete-layout');
       return;
     }
 
-    const id = selectedId;
-    const layout = layouts.find((l) => l.id === id);
-    if (!layout) return;
+    const id = current.id;
+    const name = current.name;
 
     actionService.registerAction({
       id: 'window-management:apply-layout',
-      title: `Apply "${layout.name}"`,
+      title: `Apply "${name}"`,
       icon: 'icon:play',
       shortcut: '↵',
       extensionId: 'window-management',
@@ -190,7 +126,7 @@
 
     actionService.registerAction({
       id: 'window-management:rename-layout',
-      title: `Rename "${layout.name}"`,
+      title: `Rename "${name}"`,
       icon: 'icon:edit',
       shortcut: '⌘R',
       extensionId: 'window-management',
@@ -201,7 +137,7 @@
 
     actionService.registerAction({
       id: 'window-management:delete-layout',
-      title: `Delete "${layout.name}"`,
+      title: `Delete "${name}"`,
       icon: 'icon:trash',
       shortcut: '⌘⌫',
       extensionId: 'window-management',
@@ -214,13 +150,6 @@
       actionService.unregisterAction('window-management:apply-layout');
       actionService.unregisterAction('window-management:rename-layout');
       actionService.unregisterAction('window-management:delete-layout');
-    };
-  });
-
-  onMount(() => {
-    window.addEventListener('keydown', handleKeydown);
-    return () => {
-      window.removeEventListener('keydown', handleKeydown);
     };
   });
 
@@ -241,13 +170,13 @@
       />
     {:else}
       <div class="section-header">Custom Layouts</div>
-      {#each layouts as layout (layout.id)}
+      {#each layouts as layout, index (layout.id)}
         <ListItem
           title={layout.name}
           subtitle={`${Math.round(layout.bounds.width)}×${Math.round(layout.bounds.height)} at (${Math.round(layout.bounds.x)}, ${Math.round(layout.bounds.y)})`}
-          selected={selectedId === layout.id}
+          selected={selectedIndex === index}
           onclick={() => {
-            selectedId = layout.id;
+            windowManagementState.setIndex(index);
           }}
           ondblclick={() => {
             startRename(layout.id);
@@ -256,33 +185,33 @@
           {#snippet leading()}
             <div class="layout-icon">⊞</div>
           {/snippet}
-          {#snippet content()}
-            {#if editingId === layout.id}
-              <div class="inline-rename-wrapper" onclick={(e) => e.stopPropagation()}>
-                <input
-                  bind:this={editInputEl}
-                  type="text"
-                  class="rename-input"
-                  bind:value={editingName}
-                  onblur={() => void commitRename()}
-                  onkeydown={handleKeydown}
-                />
-              </div>
-            {/if}
-          {/snippet}
         </ListItem>
       {/each}
     {/if}
   </div>
-
-  <ActionFooter>
-    {#snippet right()}
-      <span class="count-label">
-        {layouts.length} custom {layouts.length === 1 ? 'layout' : 'layouts'}
-      </span>
-    {/snippet}
-  </ActionFooter>
 </div>
+
+<Modal
+  bind:isOpen={isRenameModalOpen}
+  title="Rename Layout"
+  subtitle="Give this window layout a recognizable name"
+  onEnter={commitRename}
+  onEscape={cancelRename}
+>
+  <div class="modal-body">
+    <Input
+      label="Layout Name"
+      placeholder="e.g. Work Setup, Right Focus..."
+      bind:value={editingName}
+    />
+  </div>
+  {#snippet actions()}
+    <div class="modal-actions">
+      <Button onclick={cancelRename}>Cancel</Button>
+      <Button variant="primary" onclick={commitRename} disabled={!editingName.trim()}>Save</Button>
+    </div>
+  {/snippet}
+</Modal>
 
 <style>
   .view-container {
@@ -318,25 +247,14 @@
     font-size: var(--font-size-lg);
   }
 
-  .inline-rename-wrapper {
-    margin-top: var(--space-1);
+  .modal-body {
+    padding: var(--space-4) 0;
   }
 
-  .rename-input {
-    width: 100%;
-    max-width: 280px;
-    padding: var(--space-1) var(--space-2);
-    font-family: var(--font-ui);
-    font-size: var(--font-size-sm);
-    color: var(--text-primary);
-    background: var(--bg-secondary);
-    border: 1px solid var(--accent-primary);
-    border-radius: var(--radius-sm);
-    outline: none;
-  }
-
-  .count-label {
-    font-size: var(--font-size-xs);
-    color: var(--text-tertiary);
+  .modal-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--space-3);
   }
 </style>

--- a/asyar-launcher/src/built-in-features/window-management/index.test.ts
+++ b/asyar-launcher/src/built-in-features/window-management/index.test.ts
@@ -30,10 +30,16 @@ vi.mock('./state.svelte', () => ({
   windowManagementState: {
     customLayouts: [],
     previousBounds: null,
+    selectedIndex: 0,
+    selectedLayout: null,
+    setStore: vi.fn(),
     loadFromStorage: vi.fn(),
     savePreviousBounds: vi.fn(),
     addCustomLayout: vi.fn(),
     deleteCustomLayout: vi.fn(),
+    renameCustomLayout: vi.fn(),
+    setIndex: vi.fn(),
+    moveSelection: vi.fn(),
   },
 }));
 vi.mock('./layoutLifecycle', () => ({

--- a/asyar-launcher/src/built-in-features/window-management/index.test.ts
+++ b/asyar-launcher/src/built-in-features/window-management/index.test.ts
@@ -36,6 +36,11 @@ vi.mock('./state.svelte', () => ({
     deleteCustomLayout: vi.fn(),
   },
 }));
+vi.mock('./layoutLifecycle', () => ({
+  applyCustomLayout: vi.fn(),
+  syncLayoutToIndex: vi.fn(),
+  removeLayoutFromIndex: vi.fn(),
+}));
 vi.mock('./ManageView.svelte', () => ({ default: {} }));
 
 import extension from './index';
@@ -81,11 +86,12 @@ describe('WindowManagementExtension', () => {
       vi.mocked(feedbackService.showHUD).mockResolvedValue();
     });
 
-    it('left-half saves previous bounds then calls applyPreset', async () => {
-      await extension.executeCommand('left-half');
+    it('left-half saves previous bounds then calls applyPreset and returns no-view', async () => {
+      const result = await extension.executeCommand('left-half');
       expect(windowManagementState.savePreviousBounds).toHaveBeenCalled();
       expect(windowManagementService.applyPreset).toHaveBeenCalledWith('left-half');
       expect(feedbackService.showHUD).toHaveBeenCalledWith('Left Half');
+      expect(result).toEqual({ type: 'no-view' });
     });
 
     it('reports error diagnostic when getWindowBounds throws', async () => {
@@ -93,7 +99,7 @@ describe('WindowManagementExtension', () => {
         new Error('Accessibility permission required'),
       );
       vi.mocked(feedbackService.report).mockResolvedValue();
-      await extension.executeCommand('left-half');
+      const result = await extension.executeCommand('left-half');
       expect(feedbackService.report).toHaveBeenCalledWith(
         expect.objectContaining({
           kind: 'manual',
@@ -103,6 +109,32 @@ describe('WindowManagementExtension', () => {
           }),
         }),
       );
+      expect(result).toEqual({ type: 'no-view' });
+    });
+  });
+
+  describe('executeCommand — save-current-layout', () => {
+    beforeEach(async () => {
+      await extension.initialize(makeContext());
+      vi.mocked(windowManagementService.getWindowBounds).mockResolvedValue({
+        x: 100,
+        y: 100,
+        width: 1200,
+        height: 800,
+      });
+      vi.mocked(feedbackService.showHUD).mockResolvedValue();
+    });
+
+    it('captures window bounds, adds custom layout and returns no-view', async () => {
+      const result = await extension.executeCommand('save-current-layout');
+      expect(windowManagementService.getWindowBounds).toHaveBeenCalled();
+      expect(windowManagementState.addCustomLayout).toHaveBeenCalledWith(
+        '1200x800',
+        { x: 100, y: 100, width: 1200, height: 800 },
+        expect.anything(),
+      );
+      expect(feedbackService.showHUD).toHaveBeenCalledWith('Saved "1200x800"');
+      expect(result).toEqual({ type: 'no-view' });
     });
   });
 
@@ -111,7 +143,7 @@ describe('WindowManagementExtension', () => {
       await extension.initialize(makeContext());
     });
 
-    it('calls setWindowBounds with previousBounds when available', async () => {
+    it('calls setWindowBounds with previousBounds when available and returns no-view', async () => {
       const prev = { x: 100, y: 100, width: 800, height: 600 };
       Object.defineProperty(windowManagementState, 'previousBounds', {
         value: prev,
@@ -119,17 +151,18 @@ describe('WindowManagementExtension', () => {
       });
       vi.mocked(windowManagementService.setWindowBounds).mockResolvedValue();
       vi.mocked(feedbackService.showHUD).mockResolvedValue();
-      await extension.executeCommand('restore');
+      const result = await extension.executeCommand('restore');
       expect(windowManagementService.setWindowBounds).toHaveBeenCalledWith(prev);
+      expect(result).toEqual({ type: 'no-view' });
     });
 
-    it('reports error diagnostic when nothing to restore', async () => {
+    it('reports error diagnostic when nothing to restore and returns no-view', async () => {
       Object.defineProperty(windowManagementState, 'previousBounds', {
         value: null,
         configurable: true,
       });
       vi.mocked(feedbackService.report).mockResolvedValue();
-      await extension.executeCommand('restore');
+      const result = await extension.executeCommand('restore');
       expect(feedbackService.report).toHaveBeenCalledWith(
         expect.objectContaining({
           kind: 'manual',
@@ -139,6 +172,7 @@ describe('WindowManagementExtension', () => {
           }),
         }),
       );
+      expect(result).toEqual({ type: 'no-view' });
     });
   });
 

--- a/asyar-launcher/src/built-in-features/window-management/index.ts
+++ b/asyar-launcher/src/built-in-features/window-management/index.ts
@@ -5,6 +5,7 @@ import { actionService } from '../../services/action/actionService.svelte';
 import { windowManagementState } from './state.svelte';
 import { getPresetBounds, PRESET_IDS } from './presets';
 import { applyCustomLayout, syncLayoutToIndex, removeLayoutFromIndex } from './layoutLifecycle';
+import { isAnyModalOpen } from '../../components/base/Modal.logic';
 import ManageView from './ManageView.svelte';
 import {
   type Extension,
@@ -26,6 +27,7 @@ class WindowManagementExtension implements Extension {
     this.store = context.getService<IStorageService>('storage');
     this.extensionManager = context.getService<IExtensionManager>('extensions');
     if (this.store) {
+      windowManagementState.setStore(this.store);
       await windowManagementState.loadFromStorage(this.store);
       for (const layout of windowManagementState.customLayouts) {
         await syncLayoutToIndex(layout, this.store);
@@ -132,16 +134,41 @@ class WindowManagementExtension implements Extension {
     }));
   }
 
+  private handleKeydownBound = (event: KeyboardEvent) => this.handleKeydown(event);
+
   async viewActivated(viewPath: string): Promise<void> {
     this.inView = true;
+    window.addEventListener('keydown', this.handleKeydownBound);
     this.registerManageActions();
+    this.extensionManager?.setActiveViewActionLabel('Apply');
     logService.debug(`[WindowManagement] View activated: ${viewPath}`);
   }
 
   async viewDeactivated(viewPath: string): Promise<void> {
     this.inView = false;
+    window.removeEventListener('keydown', this.handleKeydownBound);
     this.unregisterManageActions();
     logService.debug(`[WindowManagement] View deactivated: ${viewPath}`);
+  }
+
+  private handleKeydown(event: KeyboardEvent): void {
+    if (!this.inView) return;
+    if (isAnyModalOpen(document)) return;
+    const layouts = windowManagementState.customLayouts;
+    if (!layouts.length) return;
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      event.stopPropagation();
+      windowManagementState.moveSelection(event.key === 'ArrowUp' ? 'up' : 'down');
+    } else if (event.key === 'Enter') {
+      const selected = windowManagementState.selectedLayout;
+      if (selected) {
+        event.preventDefault();
+        event.stopPropagation();
+        void applyCustomLayout(selected, this.store);
+      }
+    }
   }
 
   private registerManageActions(): void {

--- a/asyar-launcher/src/built-in-features/window-management/index.ts
+++ b/asyar-launcher/src/built-in-features/window-management/index.ts
@@ -4,6 +4,7 @@ import { feedbackService } from '../../services/feedback/feedbackService.svelte'
 import { actionService } from '../../services/action/actionService.svelte';
 import { windowManagementState } from './state.svelte';
 import { getPresetBounds, PRESET_IDS } from './presets';
+import { applyCustomLayout, syncLayoutToIndex, removeLayoutFromIndex } from './layoutLifecycle';
 import ManageView from './ManageView.svelte';
 import {
   type Extension,
@@ -26,13 +27,17 @@ class WindowManagementExtension implements Extension {
     this.extensionManager = context.getService<IExtensionManager>('extensions');
     if (this.store) {
       await windowManagementState.loadFromStorage(this.store);
+      for (const layout of windowManagementState.customLayouts) {
+        await syncLayoutToIndex(layout, this.store);
+      }
     }
     logService.info('[WindowManagement] Initialized');
   }
 
   async executeCommand(commandId: string, _args?: Record<string, any>): Promise<any> {
     if (commandId === 'restore') {
-      return this.restorePreviousBounds();
+      await this.restorePreviousBounds();
+      return { type: 'no-view' };
     }
 
     if (commandId === 'manage-layouts') {
@@ -40,11 +45,18 @@ class WindowManagementExtension implements Extension {
       return { type: 'view', viewPath: 'window-management/ManageView' };
     }
 
+    if (commandId === 'save-current-layout') {
+      await this.saveCurrentWindowLayout();
+      return { type: 'no-view' };
+    }
+
     if ((PRESET_IDS as readonly string[]).includes(commandId)) {
-      return this.applyPreset(commandId);
+      await this.applyPreset(commandId);
+      return { type: 'no-view' };
     }
 
     logService.warn(`[WindowManagement] Unknown command: ${commandId}`);
+    return { type: 'no-view' };
   }
 
   private async applyPreset(presetId: string): Promise<void> {
@@ -107,32 +119,17 @@ class WindowManagementExtension implements Extension {
     const matched = customLayouts.filter((l) => l.name.toLowerCase().includes(q));
 
     return matched.map((layout) => ({
+      id: `cmd_window-management_layout_${layout.id}`,
       title: layout.name,
       subtitle: `${Math.round(layout.bounds.width)}x${Math.round(layout.bounds.height)} at (${Math.round(layout.bounds.x)}, ${Math.round(layout.bounds.y)})`,
       score: 0.7,
       type: 'result' as const,
       icon: 'icon:store',
-      action: () => this.applyCustomLayout(layout),
+      action: async () => {
+        await applyCustomLayout(layout, this.store);
+        return { type: 'no-view' };
+      },
     }));
-  }
-
-  private async applyCustomLayout(layout: import('./state.svelte').CustomLayout): Promise<void> {
-    try {
-      const current = await windowManagementService.getWindowBounds();
-      if (this.store) {
-        await windowManagementState.savePreviousBounds(current, this.store);
-      }
-      await windowManagementService.setWindowBounds(layout.bounds);
-      await feedbackService.showHUD(layout.name);
-    } catch (err: any) {
-      await feedbackService.report({
-        source: 'frontend',
-        kind: 'manual',
-        severity: 'error',
-        retryable: false,
-        context: { message: `Could not apply layout${err.message ? ' — ' + err.message : ''}` },
-      });
-    }
   }
 
   async viewActivated(viewPath: string): Promise<void> {
@@ -170,6 +167,13 @@ class WindowManagementExtension implements Extension {
       const bounds = await windowManagementService.getWindowBounds();
       const name = `${Math.round(bounds.width)}x${Math.round(bounds.height)}`;
       await windowManagementState.addCustomLayout(name, bounds, this.store);
+      const created =
+        windowManagementState.customLayouts.find(
+          (l) => l.name === name && l.bounds.x === bounds.x && l.bounds.y === bounds.y,
+        ) ?? windowManagementState.customLayouts[windowManagementState.customLayouts.length - 1];
+      if (created) {
+        await syncLayoutToIndex(created, this.store);
+      }
       await feedbackService.showHUD(`Saved "${name}"`);
     } catch (err: any) {
       await feedbackService.report({

--- a/asyar-launcher/src/built-in-features/window-management/index.ts
+++ b/asyar-launcher/src/built-in-features/window-management/index.ts
@@ -129,7 +129,6 @@ class WindowManagementExtension implements Extension {
       icon: 'icon:store',
       action: async () => {
         await applyCustomLayout(layout, this.store);
-        return { type: 'no-view' };
       },
     }));
   }

--- a/asyar-launcher/src/built-in-features/window-management/layoutLifecycle.test.ts
+++ b/asyar-launcher/src/built-in-features/window-management/layoutLifecycle.test.ts
@@ -1,0 +1,142 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockIndexItem = vi.hoisted(() => vi.fn());
+const mockDeleteItem = vi.hoisted(() => vi.fn());
+const mockRegisterCommand = vi.hoisted(() => vi.fn());
+const mockUnregisterCommand = vi.hoisted(() => vi.fn());
+const mockShortcutUnregister = vi.hoisted(() => vi.fn());
+const mockGetWindowBounds = vi.hoisted(() => vi.fn());
+const mockSetWindowBounds = vi.hoisted(() => vi.fn());
+const mockShowHUD = vi.hoisted(() => vi.fn());
+const mockReport = vi.hoisted(() => vi.fn());
+
+vi.mock('../../services/search/SearchService', () => ({
+  searchService: {
+    indexItem: mockIndexItem,
+    deleteItem: mockDeleteItem,
+  },
+}));
+
+vi.mock('../../services/extension/commandService.svelte', () => ({
+  commandService: {
+    registerCommand: mockRegisterCommand,
+    unregisterCommand: mockUnregisterCommand,
+  },
+}));
+
+vi.mock('../shortcuts/shortcutService', () => ({
+  shortcutService: {
+    unregister: mockShortcutUnregister,
+  },
+}));
+
+vi.mock('../../services/windowManagement/windowManagementService', () => ({
+  windowManagementService: {
+    getWindowBounds: mockGetWindowBounds,
+    setWindowBounds: mockSetWindowBounds,
+  },
+}));
+
+vi.mock('../../services/feedback/feedbackService.svelte', () => ({
+  feedbackService: {
+    showHUD: mockShowHUD,
+    report: mockReport,
+  },
+}));
+
+vi.mock('../../services/log/logService', () => ({
+  logService: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  applyCustomLayout,
+  syncLayoutToIndex,
+  removeLayoutFromIndex,
+  deleteLayout,
+  renameLayout,
+} from './layoutLifecycle';
+import { windowManagementState } from './state.svelte';
+import type { IStorageService } from 'asyar-sdk/contracts';
+
+function makeStore(): IStorageService {
+  return {
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => {}),
+    delete: vi.fn(async () => true),
+    getAll: vi.fn(async () => ({})),
+    clear: vi.fn(async () => 0),
+  } as unknown as IStorageService;
+}
+
+describe('layoutLifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const testLayout = {
+    id: 'test-123',
+    name: 'Work Layout',
+    bounds: { x: 50, y: 50, width: 1200, height: 800 },
+  };
+
+  it('syncLayoutToIndex indexes item and registers command', async () => {
+    await syncLayoutToIndex(testLayout);
+    expect(mockIndexItem).toHaveBeenCalledWith({
+      category: 'command',
+      id: 'cmd_window-management_layout_test-123',
+      name: 'Work Layout',
+      extension: 'window-management',
+      trigger: 'layout Work Layout',
+      type: 'command',
+      icon: 'icon:store',
+    });
+    expect(mockRegisterCommand).toHaveBeenCalledWith(
+      'cmd_window-management_layout_test-123',
+      expect.objectContaining({ execute: expect.any(Function) }),
+      'window-management',
+    );
+  });
+
+  it('applyCustomLayout sets window bounds and displays HUD', async () => {
+    mockGetWindowBounds.mockResolvedValue({ x: 0, y: 0, width: 800, height: 600 });
+    mockSetWindowBounds.mockResolvedValue(undefined);
+    mockShowHUD.mockResolvedValue(undefined);
+
+    const store = makeStore();
+    await applyCustomLayout(testLayout, store);
+
+    expect(mockSetWindowBounds).toHaveBeenCalledWith(testLayout.bounds);
+    expect(mockShowHUD).toHaveBeenCalledWith('Work Layout');
+  });
+
+  it('removeLayoutFromIndex deletes from search, command and shortcut services', async () => {
+    await removeLayoutFromIndex('test-123');
+    expect(mockDeleteItem).toHaveBeenCalledWith('cmd_window-management_layout_test-123');
+    expect(mockUnregisterCommand).toHaveBeenCalledWith('cmd_window-management_layout_test-123');
+    expect(mockShortcutUnregister).toHaveBeenCalledWith('cmd_window-management_layout_test-123');
+  });
+
+  it('deleteLayout removes from state and index', async () => {
+    const store = makeStore();
+    vi.spyToMethod?.(windowManagementState, 'deleteCustomLayout') ||
+      (windowManagementState.deleteCustomLayout = vi.fn().mockResolvedValue(undefined));
+    await deleteLayout('test-123', store);
+    expect(windowManagementState.deleteCustomLayout).toHaveBeenCalledWith('test-123', store);
+    expect(mockDeleteItem).toHaveBeenCalledWith('cmd_window-management_layout_test-123');
+  });
+
+  it('renameLayout updates state and re-indexes layout', async () => {
+    const store = makeStore();
+    windowManagementState.customLayouts = [
+      { id: 'test-123', name: 'Work Layout', bounds: { x: 0, y: 0, width: 800, height: 600 } },
+    ];
+    await renameLayout('test-123', 'New Work Layout', store);
+    expect(mockIndexItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'New Work Layout',
+        id: 'cmd_window-management_layout_test-123',
+      }),
+    );
+  });
+});

--- a/asyar-launcher/src/built-in-features/window-management/layoutLifecycle.test.ts
+++ b/asyar-launcher/src/built-in-features/window-management/layoutLifecycle.test.ts
@@ -119,8 +119,7 @@ describe('layoutLifecycle', () => {
 
   it('deleteLayout removes from state and index', async () => {
     const store = makeStore();
-    vi.spyToMethod?.(windowManagementState, 'deleteCustomLayout') ||
-      (windowManagementState.deleteCustomLayout = vi.fn().mockResolvedValue(undefined));
+    windowManagementState.deleteCustomLayout = vi.fn().mockResolvedValue(undefined);
     await deleteLayout('test-123', store);
     expect(windowManagementState.deleteCustomLayout).toHaveBeenCalledWith('test-123', store);
     expect(mockDeleteItem).toHaveBeenCalledWith('cmd_window-management_layout_test-123');

--- a/asyar-launcher/src/built-in-features/window-management/layoutLifecycle.ts
+++ b/asyar-launcher/src/built-in-features/window-management/layoutLifecycle.ts
@@ -1,0 +1,81 @@
+import { windowManagementState, type CustomLayout } from './state.svelte';
+import { windowManagementService } from '../../services/windowManagement/windowManagementService';
+import { feedbackService } from '../../services/feedback/feedbackService.svelte';
+import { searchService } from '../../services/search/SearchService';
+import { commandService } from '../../services/extension/commandService.svelte';
+import { shortcutService } from '../shortcuts/shortcutService';
+import { logService } from '../../services/log/logService';
+import type { IStorageService } from 'asyar-sdk/contracts';
+
+export async function applyCustomLayout(
+  layout: CustomLayout,
+  store?: IStorageService,
+): Promise<void> {
+  try {
+    const current = await windowManagementService.getWindowBounds();
+    if (store) {
+      await windowManagementState.savePreviousBounds(current, store);
+    }
+    await windowManagementService.setWindowBounds(layout.bounds);
+    await feedbackService.showHUD(layout.name);
+  } catch (err: any) {
+    logService.error(`[WindowManagement] applyCustomLayout failed: ${err}`);
+    await feedbackService.report({
+      source: 'frontend',
+      kind: 'manual',
+      severity: 'error',
+      retryable: false,
+      context: { message: `Could not apply layout${err.message ? ' — ' + err.message : ''}` },
+    });
+  }
+}
+
+export async function syncLayoutToIndex(
+  layout: CustomLayout,
+  store?: IStorageService,
+): Promise<void> {
+  await searchService.indexItem({
+    category: 'command',
+    id: `cmd_window-management_layout_${layout.id}`,
+    name: layout.name,
+    extension: 'window-management',
+    trigger: `layout ${layout.name}`,
+    type: 'command',
+    icon: 'icon:store',
+  });
+
+  commandService.registerCommand(
+    `cmd_window-management_layout_${layout.id}`,
+    {
+      execute: async () => {
+        await applyCustomLayout(layout, store);
+        return { type: 'no-view' };
+      },
+    },
+    'window-management',
+  );
+}
+
+export async function removeLayoutFromIndex(layoutId: string): Promise<void> {
+  const objectId = `cmd_window-management_layout_${layoutId}`;
+  await searchService.deleteItem(objectId);
+  commandService.unregisterCommand(objectId);
+  await shortcutService.unregister(objectId);
+}
+
+export async function deleteLayout(layoutId: string, store: IStorageService): Promise<void> {
+  await windowManagementState.deleteCustomLayout(layoutId, store);
+  await removeLayoutFromIndex(layoutId);
+}
+
+export async function renameLayout(
+  layoutId: string,
+  newName: string,
+  store: IStorageService,
+): Promise<void> {
+  await windowManagementState.renameCustomLayout(layoutId, newName, store);
+  const updated = windowManagementState.customLayouts.find((l) => l.id === layoutId);
+  if (updated) {
+    await syncLayoutToIndex(updated, store);
+  }
+}

--- a/asyar-launcher/src/built-in-features/window-management/layoutLifecycle.ts
+++ b/asyar-launcher/src/built-in-features/window-management/layoutLifecycle.ts
@@ -63,7 +63,7 @@ export async function removeLayoutFromIndex(layoutId: string): Promise<void> {
   await shortcutService.unregister(objectId);
 }
 
-export async function deleteLayout(layoutId: string, store: IStorageService): Promise<void> {
+export async function deleteLayout(layoutId: string, store?: IStorageService): Promise<void> {
   await windowManagementState.deleteCustomLayout(layoutId, store);
   await removeLayoutFromIndex(layoutId);
 }
@@ -71,7 +71,7 @@ export async function deleteLayout(layoutId: string, store: IStorageService): Pr
 export async function renameLayout(
   layoutId: string,
   newName: string,
-  store: IStorageService,
+  store?: IStorageService,
 ): Promise<void> {
   await windowManagementState.renameCustomLayout(layoutId, newName, store);
   const updated = windowManagementState.customLayouts.find((l) => l.id === layoutId);

--- a/asyar-launcher/src/built-in-features/window-management/manifest.json
+++ b/asyar-launcher/src/built-in-features/window-management/manifest.json
@@ -152,6 +152,14 @@
       "icon": "icon:settings",
       "mode": "view",
       "component": "ManageView"
+    },
+    {
+      "id": "save-current-layout",
+      "name": "Save Current Window as Layout",
+      "description": "Save the frontmost window position and size as a custom layout",
+      "trigger": "save window layout position custom",
+      "icon": "icon:plus",
+      "mode": "background"
     }
   ],
   "background": {

--- a/asyar-launcher/src/built-in-features/window-management/state.svelte.test.ts
+++ b/asyar-launcher/src/built-in-features/window-management/state.svelte.test.ts
@@ -111,6 +111,42 @@ describe('WindowManagementState', () => {
     });
   });
 
+  describe('renameCustomLayout', () => {
+    it('renames layout by id and persists to storage', async () => {
+      const layouts = [
+        { id: 'abc', name: 'Old Name', bounds: { x: 0, y: 0, width: 800, height: 600 } },
+        { id: 'def', name: 'Layout B', bounds: { x: 0, y: 0, width: 1200, height: 800 } },
+      ];
+      storeMock = makeStoreMock({ custom_layouts: JSON.stringify(layouts) });
+      await state.loadFromStorage(storeMock);
+      await state.renameCustomLayout('abc', 'New Name', storeMock);
+      expect(state.customLayouts).toHaveLength(2);
+      expect(state.customLayouts[0].name).toBe('New Name');
+      expect(state.customLayouts[1].name).toBe('Layout B');
+      expect(storeMock.set).toHaveBeenCalledWith(
+        'custom_layouts',
+        JSON.stringify(state.customLayouts),
+      );
+    });
+
+    it('is a no-op when name is empty or unchanged', async () => {
+      const layouts = [
+        { id: 'abc', name: 'Old Name', bounds: { x: 0, y: 0, width: 800, height: 600 } },
+      ];
+      storeMock = makeStoreMock({ custom_layouts: JSON.stringify(layouts) });
+      await state.loadFromStorage(storeMock);
+      await state.renameCustomLayout('abc', '   ', storeMock);
+      expect(state.customLayouts[0].name).toBe('Old Name');
+      expect(storeMock.set).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op for unknown id', async () => {
+      await state.loadFromStorage(storeMock);
+      await state.renameCustomLayout('nonexistent', 'Name', storeMock);
+      expect(state.customLayouts).toEqual([]);
+    });
+  });
+
   describe('savePreviousBounds', () => {
     it('stores bounds in state and persists to storage', async () => {
       const bounds: WindowBounds = { x: 50, y: 50, width: 1440, height: 900 };

--- a/asyar-launcher/src/built-in-features/window-management/state.svelte.ts
+++ b/asyar-launcher/src/built-in-features/window-management/state.svelte.ts
@@ -1,6 +1,7 @@
 import { logService } from '../../services/log/logService';
 import type { IStorageService } from 'asyar-sdk/contracts';
 import type { WindowBounds } from '../../lib/ipc/commands';
+import { useListSelection } from '../../lib/listSelection.svelte';
 
 export interface CustomLayout {
   id: string;
@@ -14,10 +15,35 @@ const STORAGE_KEY_PREV_BOUNDS = 'previous_bounds';
 export class WindowManagementState {
   customLayouts = $state<CustomLayout[]>([]);
   previousBounds = $state<WindowBounds | null>(null);
+  store = $state<IStorageService | null>(null);
 
-  async loadFromStorage(store: IStorageService): Promise<void> {
+  private selection = useListSelection({ items: () => this.customLayouts });
+
+  get selectedIndex(): number {
+    return this.selection.selectedIndex;
+  }
+
+  get selectedLayout(): CustomLayout | null {
+    return this.selection.selectedItem;
+  }
+
+  setStore(store: IStorageService): void {
+    this.store = store;
+  }
+
+  setIndex(index: number): void {
+    this.selection.setIndex(index);
+  }
+
+  moveSelection(direction: 'up' | 'down'): void {
+    this.selection.moveSelection(direction);
+  }
+
+  async loadFromStorage(store?: IStorageService): Promise<void> {
+    const targetStore = store ?? this.store;
+    if (!targetStore) return;
     try {
-      const rawLayouts = await store.get(STORAGE_KEY_LAYOUTS);
+      const rawLayouts = await targetStore.get(STORAGE_KEY_LAYOUTS);
       this.customLayouts = rawLayouts ? JSON.parse(rawLayouts) : [];
     } catch {
       logService.warn('[WindowManagement] Failed to parse custom_layouts — resetting to []');
@@ -25,41 +51,59 @@ export class WindowManagementState {
     }
 
     try {
-      const rawBounds = await store.get(STORAGE_KEY_PREV_BOUNDS);
+      const rawBounds = await targetStore.get(STORAGE_KEY_PREV_BOUNDS);
       this.previousBounds = rawBounds ? JSON.parse(rawBounds) : null;
     } catch {
       this.previousBounds = null;
     }
   }
 
-  async addCustomLayout(name: string, bounds: WindowBounds, store: IStorageService): Promise<void> {
+  async addCustomLayout(
+    name: string,
+    bounds: WindowBounds,
+    store?: IStorageService,
+  ): Promise<CustomLayout> {
+    const targetStore = store ?? this.store;
     const layout: CustomLayout = {
       id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
       name,
       bounds,
     };
     this.customLayouts = [...this.customLayouts, layout];
-    await store.set(STORAGE_KEY_LAYOUTS, JSON.stringify(this.customLayouts));
+    if (targetStore) {
+      await targetStore.set(STORAGE_KEY_LAYOUTS, JSON.stringify(this.customLayouts));
+    }
+    this.selection.setIndex(this.customLayouts.length - 1);
+    return layout;
   }
 
-  async deleteCustomLayout(id: string, store: IStorageService): Promise<void> {
+  async deleteCustomLayout(id: string, store?: IStorageService): Promise<void> {
+    const targetStore = store ?? this.store;
     this.customLayouts = this.customLayouts.filter((l) => l.id !== id);
-    await store.set(STORAGE_KEY_LAYOUTS, JSON.stringify(this.customLayouts));
+    if (targetStore) {
+      await targetStore.set(STORAGE_KEY_LAYOUTS, JSON.stringify(this.customLayouts));
+    }
   }
 
-  async renameCustomLayout(id: string, newName: string, store: IStorageService): Promise<void> {
+  async renameCustomLayout(id: string, newName: string, store?: IStorageService): Promise<void> {
+    const targetStore = store ?? this.store;
     const trimmed = newName.trim();
     if (!trimmed) return;
     const existing = this.customLayouts.find((l) => l.id === id);
     if (!existing || existing.name === trimmed) return;
 
     this.customLayouts = this.customLayouts.map((l) => (l.id === id ? { ...l, name: trimmed } : l));
-    await store.set(STORAGE_KEY_LAYOUTS, JSON.stringify(this.customLayouts));
+    if (targetStore) {
+      await targetStore.set(STORAGE_KEY_LAYOUTS, JSON.stringify(this.customLayouts));
+    }
   }
 
-  async savePreviousBounds(bounds: WindowBounds, store: IStorageService): Promise<void> {
+  async savePreviousBounds(bounds: WindowBounds, store?: IStorageService): Promise<void> {
+    const targetStore = store ?? this.store;
     this.previousBounds = bounds;
-    await store.set(STORAGE_KEY_PREV_BOUNDS, JSON.stringify(bounds));
+    if (targetStore) {
+      await targetStore.set(STORAGE_KEY_PREV_BOUNDS, JSON.stringify(bounds));
+    }
   }
 }
 

--- a/asyar-launcher/src/built-in-features/window-management/state.svelte.ts
+++ b/asyar-launcher/src/built-in-features/window-management/state.svelte.ts
@@ -47,6 +47,16 @@ export class WindowManagementState {
     await store.set(STORAGE_KEY_LAYOUTS, JSON.stringify(this.customLayouts));
   }
 
+  async renameCustomLayout(id: string, newName: string, store: IStorageService): Promise<void> {
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+    const existing = this.customLayouts.find((l) => l.id === id);
+    if (!existing || existing.name === trimmed) return;
+
+    this.customLayouts = this.customLayouts.map((l) => (l.id === id ? { ...l, name: trimmed } : l));
+    await store.set(STORAGE_KEY_LAYOUTS, JSON.stringify(this.customLayouts));
+  }
+
   async savePreviousBounds(bounds: WindowBounds, store: IStorageService): Promise<void> {
     this.previousBounds = bounds;
     await store.set(STORAGE_KEY_PREV_BOUNDS, JSON.stringify(bounds));

--- a/asyar-launcher/src/lib/keyboard/launcherKeyboard.test.ts
+++ b/asyar-launcher/src/lib/keyboard/launcherKeyboard.test.ts
@@ -1709,4 +1709,45 @@ describe('launcherKeyboard characterization tests', () => {
       expect(contextModeService.activate).not.toHaveBeenCalled();
     });
   });
+
+  describe('restoreSearchFocus', () => {
+    it('focuses and selects input when select option is true', async () => {
+      const input = {
+        focus: vi.fn(),
+        select: vi.fn(),
+        value: 'hello',
+      } as unknown as HTMLInputElement;
+      const deps = createMockDeps({
+        getSearchInput: () => input,
+      });
+      const { restoreSearchFocus } = createKeyboardHandlers(deps);
+
+      restoreSearchFocus({ select: true });
+
+      // requestAnimationFrame fires on next tick
+      await new Promise((r) => requestAnimationFrame(r));
+
+      expect(input.focus).toHaveBeenCalledWith({ preventScroll: true });
+      expect(input.select).toHaveBeenCalled();
+    });
+
+    it('focuses without select when input value is empty', async () => {
+      const input = {
+        focus: vi.fn(),
+        select: vi.fn(),
+        value: '',
+      } as unknown as HTMLInputElement;
+      const deps = createMockDeps({
+        getSearchInput: () => input,
+      });
+      const { restoreSearchFocus } = createKeyboardHandlers(deps);
+
+      restoreSearchFocus({ select: true });
+
+      await new Promise((r) => requestAnimationFrame(r));
+
+      expect(input.focus).toHaveBeenCalledWith({ preventScroll: true });
+      expect(input.select).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/asyar-launcher/src/routes/+page.svelte
+++ b/asyar-launcher/src/routes/+page.svelte
@@ -12,6 +12,7 @@
   import ToastHost from '../components/feedback/ToastHost.svelte';
   import DialogHost from '../components/feedback/DialogHost.svelte';
   import FatalErrorDialog from '../components/feedback/FatalErrorDialog.svelte';
+  import { isAnyModalOpen } from '../components/base/Modal.logic';
   import { createKeyboardHandlers } from '../lib/keyboard/launcherKeyboard';
   import { searchStores } from '../services/search/stores/search.svelte';
   import { searchService } from '../services/search/SearchService';
@@ -585,7 +586,7 @@
 
 <WorkerIframes />
 
-<style global>
+<style>
   /*
    * Non-macOS: visible styled scrollbar.
    * macOS: NO ::-webkit-scrollbar rule at all — defining one (even
@@ -594,14 +595,14 @@
    * default keeps the real macOS overlay scrollbar that fades in
    * on scroll, controlled by System Settings → "Show scroll bars".
    */
-  html:not([data-platform='macos']) ::-webkit-scrollbar {
+  :global(html:not([data-platform='macos']) ::-webkit-scrollbar) {
     width: 8px;
     height: 8px;
   }
-  html:not([data-platform='macos']) ::-webkit-scrollbar-track {
+  :global(html:not([data-platform='macos']) ::-webkit-scrollbar-track) {
     background: transparent;
   }
-  html:not([data-platform='macos']) ::-webkit-scrollbar-thumb {
+  :global(html:not([data-platform='macos']) ::-webkit-scrollbar-thumb) {
     background-color: var(--scrollbar-thumb);
     border-radius: var(--radius-md);
   }

--- a/asyar-launcher/src/routes/+page.svelte
+++ b/asyar-launcher/src/routes/+page.svelte
@@ -151,6 +151,7 @@
     // DOM blur, so without this its keydown listener keeps swallowing arrows
     // and Enter on the next launcher invocation.
     let unlistenResignKey: UnlistenFn | null = null;
+    let unlistenBecomeKey: UnlistenFn | null = null;
     listen('main_panel_did_resign_key', () => {
       if (isActionPanelOpen) {
         isActionPanelOpen = false;
@@ -162,11 +163,24 @@
       })
       .catch((e) => logService.debug(`[+page] listen resign-key failed: ${e}`));
 
+    // When the panel becomes key (e.g. after shortcut execution or window summon),
+    // restore and select search focus if no modal is open.
+    listen('main_panel_did_become_key', () => {
+      if (!isAnyModalOpen(document) && !isActionPanelOpen) {
+        keyboard.restoreSearchFocus({ select: true });
+      }
+    })
+      .then((fn) => {
+        unlistenBecomeKey = fn;
+      })
+      .catch((e) => logService.debug(`[+page] listen become-key failed: ${e}`));
+
     return () => {
       window.removeEventListener('keydown', keyboard.handleGlobalKeydown, true);
       document.removeEventListener('click', keyboard.maintainSearchFocus, true);
       window.removeEventListener('blur', handleBlur);
       unlistenResignKey?.();
+      unlistenBecomeKey?.();
     };
   });
 
@@ -229,7 +243,12 @@
   $effect(() => {
     void recordActiveDay();
     const promise = getCurrentWindow().onFocusChanged(({ payload: focused }) => {
-      if (focused) void recordActiveDay();
+      if (focused) {
+        void recordActiveDay();
+        if (!isAnyModalOpen(document) && !isActionPanelOpen) {
+          keyboard.restoreSearchFocus({ select: true });
+        }
+      }
     });
     return () => {
       void promise.then((unlisten) => unlisten()).catch(() => {});


### PR DESCRIPTION
- **Silent Preset Snapping (#653):** Window management commands (\`applyPreset\`, \`restore\`, \`save-current-layout\`) now return \`{ type: 'no-view' }\`, preventing the launcher window from popping open when preset shortcuts are fired.
- **Custom Layout Shortcuts (#653):** Custom layouts are now dynamically registered in \`searchService\` and \`commandService\` with persistent IDs (\`cmd_window-management_layout_<id>\`), making global shortcuts assigned to custom layouts work across app restarts.
### Features & UX
- **Rename Layouts:** Added layout renaming support in state and \`ManageView\` (inline rename via \`⌘R\`, double-click, or ⌘K menu).
- **Save Layout Command:** Added \`save-current-layout\` (\"Save Current Window as Layout\") directly to \`manifest.json\` to allow saving frontmost window layout directly from root search.
- **Keyboard Navigation:** Added arrow-key navigation and full ⌘K actions (Apply, Rename, Save Current, Delete) in \`ManageView\`.
Closes #653"